### PR TITLE
feat: full Telegram connector support with web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 .env
 .env.local
 .worktrees/
+.DS_Store

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -267,7 +267,12 @@ export async function startGateway(
         ignoreOldMessagesOnBoot: config.connectors.telegram.ignoreOldMessagesOnBoot,
       });
       telegram.onMessage((msg) => {
-        sessionManager.route(msg, telegram).catch((err) => {
+        const routeOpts: RouteOptions = {};
+        if (config.connectors.telegram?.employee) {
+          const emp = employeeRegistry.get(config.connectors.telegram.employee);
+          if (emp) routeOpts.employee = emp;
+        }
+        sessionManager.route(msg, telegram, routeOpts).catch((err) => {
           logger.error(`Telegram route error: ${err instanceof Error ? err.message : err}`);
         });
       });
@@ -365,6 +370,23 @@ export async function startGateway(
             });
             await whatsapp.start();
             connector = whatsapp;
+            break;
+          }
+          case "telegram": {
+            const telegramConfig = { ...typeConfig, id } as any;
+            const tg = new TelegramConnector(telegramConfig);
+            tg.onMessage((msg) => {
+              const routeOpts: RouteOptions = {};
+              if (employee) {
+                const emp = employeeRegistry.get(employee);
+                if (emp) routeOpts.employee = emp;
+              }
+              sessionManager.route(msg, tg, routeOpts).catch((err) => {
+                logger.error(`${id} route error: ${err instanceof Error ? err.message : err}`);
+              });
+            });
+            await tg.start();
+            connector = tg;
             break;
           }
           default:
@@ -473,6 +495,23 @@ export async function startGateway(
               });
               await whatsapp.start();
               connector = whatsapp;
+              break;
+            }
+            case "telegram": {
+              const telegramConfig = { ...typeConfig, id } as any;
+              const tg = new TelegramConnector(telegramConfig);
+              tg.onMessage((msg) => {
+                const routeOpts: RouteOptions = {};
+                if (employee) {
+                  const emp = employeeRegistry.get(employee);
+                  if (emp) routeOpts.employee = emp;
+                }
+                sessionManager.route(msg, tg, routeOpts).catch((err) => {
+                  logger.error(`${id} route error: ${err instanceof Error ? err.message : err}`);
+                });
+              });
+              await tg.start();
+              connector = tg;
               break;
             }
             default:

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -340,6 +340,10 @@ export interface DiscordConnectorConfig {
 }
 
 export interface TelegramConnectorConfig {
+  /** Unique instance identifier (e.g. "telegram-support") */
+  id?: string;
+  /** Employee to handle messages from this connector instance */
+  employee?: string;
   botToken: string;
   allowFrom?: number[];
   ignoreOldMessagesOnBoot?: boolean;

--- a/packages/web/src/app/settings/page.tsx
+++ b/packages/web/src/app/settings/page.tsx
@@ -62,6 +62,11 @@ interface Config {
       guildId?: string
       channelId?: string
     }
+    telegram?: {
+      botToken?: string
+      allowFrom?: number[]
+      ignoreOldMessagesOnBoot?: boolean
+    }
     whatsapp?: {
       authDir?: string
       allowFrom?: string[]
@@ -69,7 +74,7 @@ interface Config {
     web?: Record<string, never>
     instances?: Array<{
       id: string
-      type: "discord" | "slack" | "whatsapp"
+      type: "discord" | "slack" | "whatsapp" | "telegram"
       employee?: string
       botToken?: string
       allowFrom?: string | string[]
@@ -1168,6 +1173,48 @@ export default function SettingsPage() {
                       updateConfig(["connectors", "discord", "channelId"], v.trim() || undefined)
                     }
                     placeholder="Restrict to this channel (right-click → Copy Channel ID)"
+                  />
+                </FieldRow>
+
+                {/* Telegram */}
+                <div
+                  className="border-t border-[var(--separator)] mt-[var(--space-3)] pt-[var(--space-3)]"
+                />
+                <div
+                  className="text-[length:var(--text-caption1)] font-[var(--weight-semibold)] text-[var(--text-tertiary)] mb-[var(--space-2)]"
+                >
+                  Telegram
+                </div>
+                <FieldRow label="Bot Token">
+                  <SettingsInput
+                    type="password"
+                    value={config.connectors?.telegram?.botToken ?? ""}
+                    onChange={(v) =>
+                      updateConfig(["connectors", "telegram", "botToken"], v)
+                    }
+                    placeholder="123456:ABC-DEF..."
+                  />
+                </FieldRow>
+                <FieldRow label="Allow From (User IDs)">
+                  <SettingsInput
+                    value={Array.isArray(config.connectors?.telegram?.allowFrom)
+                      ? config.connectors?.telegram?.allowFrom?.join(", ")
+                      : ""}
+                    onChange={(v) =>
+                      updateConfig(
+                        ["connectors", "telegram", "allowFrom"],
+                        v.trim() ? v.split(",").map((entry) => Number(entry.trim())).filter((n) => !isNaN(n)) : undefined,
+                      )
+                    }
+                    placeholder="Telegram user IDs, comma-separated (optional)"
+                  />
+                </FieldRow>
+                <FieldRow label="Ignore Old Messages on Boot">
+                  <ToggleSwitch
+                    checked={config.connectors?.telegram?.ignoreOldMessagesOnBoot ?? true}
+                    onChange={(v) =>
+                      updateConfig(["connectors", "telegram", "ignoreOldMessagesOnBoot"], v)
+                    }
                   />
                 </FieldRow>
 


### PR DESCRIPTION
## Summary
- Add Telegram section to the web settings page (bot token, allow from user IDs, ignore old messages on boot)
- Add employee routing to the Telegram connector, matching parity with Slack, Discord, and WhatsApp
- Add Telegram case to connector instances creation and hot-reload
- Add `id` and `employee` fields to `TelegramConnectorConfig`
- Add `.DS_Store` to `.gitignore`

## Test plan
- [x] TypeScript type-check passes (jimmy + web)
- [x] All 41 Telegram connector tests pass
- [x] Manual: configure Telegram bot token via settings UI and verify bot responds
- [x] Manual: verify connector instances with `type: "telegram"` work in config.yaml