### PR TITLE
fix: skip Slack unfurl events that crash Claude engine

### DIFF
--- a/packages/jimmy/src/connectors/slack/index.ts
+++ b/packages/jimmy/src/connectors/slack/index.ts
@@ -97,6 +97,11 @@ export class SlackConnector implements Connector {
         logger.info(`[slack] Skipping bot message`);
         return;
       }
+      // Skip ghost events from URL unfurls (user=undefined, text="")
+      if (!(event as any).user) {
+        logger.debug(`[slack] Skipping event with no user (likely URL unfurl)`);
+        return;
+      }
       if (!this.handler) {
         logger.info(`[slack] No handler registered, dropping message`);
         return;


### PR DESCRIPTION
## Summary

- Skip Slack message events with no `user` field (URL unfurl ghosts) in the Slack connector
- Prevents empty prompts from reaching the Claude engine and crashing with exit code 1

## Problem

When a message contains a URL, Slack fires a secondary unfurl event ~1s later with `user=undefined` and `text=""`. This event passes all existing guards and routes an empty prompt to Claude:

```
[INFO] [slack] Received message event: user=U04RU... text="Message with https://..."
[INFO] [slack] Received message event: user=undefined text=""
[ERROR] Claude exited with code 1: Error: Input must be provided either through stdin or as a prompt argument when using --print
```

## Fix

4-line guard in `packages/jimmy/src/connectors/slack/index.ts`, right after the existing `bot_id` check:

```typescript
if (!(event as any).user) {
    logger.debug(`[slack] Skipping event with no user (likely URL unfurl)`);
    return;
}
```

Fixes #43

## Test plan

- [x] Send a Slack message with a URL → no crash, message processed normally
- [x] Send a Slack message without a URL → still works
- [x] Bot messages still filtered by existing `bot_id` guard