### PR TITLE
fix(gateway): honor body.model in POST /api/sessions and /stub (fixes #38)

### DIFF
--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -655,11 +655,14 @@ export async function handleApiRequest(
         sessionKey,
         replyContext: { source: "web" },
         employee: body.employee,
+        // Honor body.model so API clients can pin per-employee models.
+        // See POST /api/sessions handler below for the full rationale. Fixes #38.
+        model: body.model,
         title: body.title,
         portalName: config.portal?.portalName,
       });
       insertMessage(session.id, "assistant", greeting);
-      logger.info(`Stub session created: ${session.id}`);
+      logger.info(`Stub session created: ${session.id} (model=${body.model || "default"})`);
       return json(res, serializeSession(session, context), 201);
     }
 
@@ -684,10 +687,16 @@ export async function handleApiRequest(
         employee: body.employee,
         parentSessionId: body.parentSessionId,
         effortLevel: body.effortLevel,
+        // Honor body.model so API clients can pin per-employee models
+        // (e.g. MCP servers that look up org/<employee>.yaml and pass the
+        // employee's configured model). Without this, runWebSession falls
+        // back to config.engines.claude.model, breaking per-employee routing.
+        // Fixes #38.
+        model: body.model,
         prompt,
         portalName: config.portal?.portalName,
       });
-      logger.info(`Web session created: ${session.id}`);
+      logger.info(`Web session created: ${session.id} (model=${body.model || "default"})`);
       insertMessage(session.id, "user", prompt);
 
       // Run engine asynchronously — respond immediately, push result via WebSocket


### PR DESCRIPTION
## Summary

`POST /api/sessions` and `POST /api/sessions/stub` currently drop `body.model` silently and fall back to `config.engines.claude.model`. This breaks per-employee model routing for any client that looks up the employee's configured model and sends it in the request body (e.g. MCP servers reading `org/*.yaml`).

**Fixes #38**

## Root cause

The handler at `packages/jimmy/src/gateway/api.ts` (L666-720 on current `main`) calls `createSession({..., employee, parentSessionId, effortLevel, prompt, portalName})` without propagating `body.model`. The downstream infrastructure already supports the override:

- `createSession(opts)` in `sessions/registry.ts` accepts `opts.model` and persists it to the `sessions.model` column.
- `runWebSession` in `gateway/api.ts` (around L1189) already uses `currentSession.model ?? engineConfig.model`.

Only the handler → `createSession` plumbing was missing. The `POST /api/sessions/stub` handler (L641-664) has the same issue.

## Reproduction (before this PR)

```bash
curl -s http://127.0.0.1:7777/api/sessions \
  -H 'content-type: application/json' \
  -d '{"prompt":"ping","engine":"claude","model":"glm-4.7","employee":"glm-reasoner"}'
```

Gateway log observed:

```
Web session created: 0b19ddd4-...
running engine "claude" (model: default)
Claude engine (one-shot) starting: ... --model deepseek-code (resume: none)
```

The client sent `model: "glm-4.7"`, the handler silently dropped it, `runWebSession` fell back to `config.engines.claude.model` (default `deepseek-code`), and the engine-router spawned the wrong wrapper (`deepseek-wrapper.mjs` instead of `glm-wrapper.mjs`).

## Gateway log after this PR

```
Web session created: a9d10f3c-... (model=glm-4.7)
running engine "claude" (model: glm-4.7)
Claude engine (one-shot) starting: ... --model glm-4.7 (resume: none)
```

## Changes

`packages/jimmy/src/gateway/api.ts`:

1. **`POST /api/sessions`** handler: pass `model: body.model` to `createSession()`.
2. **`POST /api/sessions/stub`** handler: same treatment for consistency.
3. Both `logger.info(...)` lines enriched with `(model=${body.model || "default"})` so the routing decision is observable in the logs.

The patch is 11 additions, 2 deletions. No new dependencies, no schema changes, no breaking changes — existing clients that don't send `body.model` continue to fall back to `config.engines.claude.model` exactly as before.

## Relation to @dancryer's suggestion in #38

The issue proposes having the API look up the employee in `createSession()` itself so the web UI also benefits. That's a more general fix and remains a valid follow-up — it would let callers that only pass `employee` (without `model`) still get the right wrapper.

The cleanest final precedence IMO would be:

```
currentSession.model ?? employeeConfig.model ?? engineConfig.model
```

This PR is the minimal half of that: it unblocks any client that already knows the employee's model. Happy to extend it with the employee lookup in a follow-up (or in this PR if you prefer — just say which).

## Test plan

Manual reproduction on `jinn-cli@0.5.3` with the [jinn-team MCP](https://github.com/hackos0911/jinn-team-mcp) as the client, 3 employees covering 3 different wrappers:

- [x] `glm-reasoner` (`glm-4.7`) → spawns `glm-wrapper.mjs` (was `deepseek-wrapper.mjs`)
- [x] `tech-watch` (`gemini-2.5-flash`) → spawns `gemini-wrapper.mjs` (was `deepseek-wrapper.mjs`)
- [x] `deadpool` (`deepseek-code`) → spawns `deepseek-wrapper.mjs` (unchanged, confirms no regression on default path)
- [x] Gateway log now shows `(model=...)` instead of `(model: default)` for all three
- [x] `runWebSession` resolves `currentSession.model` correctly in all three cases

I haven't added a unit test in this PR because I didn't want to touch the test harness without knowing the project's conventions. Happy to add one if you point me at an existing session/routing test to mirror.
