### PR TITLE
fix(web): polyfill crypto.randomUUID for non-secure contexts

### DIFF
--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -17,6 +17,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Polyfill crypto.randomUUID for non-secure contexts (plain HTTP over LAN/Tailscale) */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if(typeof crypto!=='undefined'&&!crypto.randomUUID){crypto.randomUUID=function(){return'10000000-1000-4000-8000-100000000000'.replace(/[018]/g,function(c){var r=crypto.getRandomValues(new Uint8Array(1))[0];return(c^(r&(15>>(c/4)))).toString(16)})}}`,
+          }}
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var t=localStorage.getItem('jinn-theme')||'dark';if(t==='system'){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}document.documentElement.setAttribute('data-theme',t)}catch(e){}})()`,


### PR DESCRIPTION
## Summary
- Adds an inline `crypto.randomUUID` polyfill in the root layout, before any app code runs
- Uses `crypto.getRandomValues()` as the entropy source (available in all contexts)

## Problem
`crypto.randomUUID()` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) (HTTPS or `localhost`). When accessing the web UI over plain HTTP on a LAN IP or Tailscale hostname (e.g. `http://my-server.tail12345.ts.net:7777`), the chat page crashes with:

```
TypeError: crypto.randomUUID is not a function
```

The error boundary catches it as `[ChatErrorBoundary] crypto.randomUUID is not a function`, resulting in a blank/crashed chat page.

## Test plan
- [ ] Access `/chat` via `http://localhost:7777` — should work (already did)
- [ ] Access `/chat` via `http://<lan-ip>:7777` — should now work instead of crashing
- [ ] Access `/chat` via `http://<tailscale-hostname>:7777` — should now work
- [ ] Access `/chat` via HTTPS — polyfill is a no-op, native `randomUUID` used