### PR TITLE
fix: resolve MCP servers for web sessions

### DIFF
--- a/packages/jimmy/src/gateway/api.ts
+++ b/packages/jimmy/src/gateway/api.ts
@@ -43,6 +43,7 @@ import { getSttStatus, downloadModel, transcribe as sttTranscribe, resolveLangua
 import { JINN_HOME } from "../shared/paths.js";
 import { resolveEffort } from "../shared/effort.js";
 import { computeNextRetryDelayMs, computeRateLimitDeadlineMs, detectRateLimit } from "../shared/rateLimit.js";
+import { resolveMcpServers, writeMcpConfigFile, cleanupMcpConfigFile } from "../mcp/resolver.js";
 import { getClaudeExpectedResetAt, recordClaudeRateLimit } from "../shared/usageAwareness.js";
 import { loadJobs, saveJobs } from "../cron/jobs.js";
 import { reloadScheduler } from "../cron/scheduler.js";
@@ -2052,6 +2053,7 @@ async function runWebSession(
   const { resolveOrgHierarchy } = await import("./org-hierarchy.js");
   const orgHierarchy = resolveOrgHierarchy(scanOrgForHierarchy());
 
+  let mcpConfigPath: string | undefined;
   try {
 
     const systemPrompt = buildContext({
@@ -2071,6 +2073,17 @@ async function runWebSession(
         ? config.engines.gemini ?? config.engines.claude
         : config.engines.claude;
     const effortLevel = resolveEffort(engineConfig, currentSession, employee);
+
+    if (currentSession.engine === "claude") {
+      try {
+        const mcpConfig = resolveMcpServers(config.mcp, employee);
+        if (Object.keys(mcpConfig.mcpServers).length > 0) {
+          mcpConfigPath = writeMcpConfigFile(mcpConfig, currentSession.id);
+        }
+      } catch (err) {
+        logger.warn(`Failed to resolve MCP config for web session ${currentSession.id}: ${err instanceof Error ? err.message : err}`);
+      }
+    }
 
     let lastHeartbeatAt = 0;
     const runHeartbeat = setInterval(() => {
@@ -2102,6 +2115,7 @@ async function runWebSession(
       model: currentSession.model ?? engineConfig.model,
       effortLevel,
       cliFlags: employee?.cliFlags,
+      mcpConfigPath,
       attachments: attachments?.length ? attachments : undefined,
       sessionId: currentSession.id,
       onStream: (delta) => {
@@ -2479,5 +2493,7 @@ async function runWebSession(
       error: errMsg,
     });
     logger.error(`Web session ${currentSession.id} error: ${errMsg}`);
+  } finally {
+    if (mcpConfigPath) cleanupMcpConfigFile(currentSession.id);
   }
 }


### PR DESCRIPTION
Web sessions created via the gateway UI/API were running the Claude engine without --mcp-config, so any configured MCP servers (config.mcp.custom, gateway, browser, search, fetch) were unavailable in-session. Channel connector sessions (Slack/Telegram) went through sessions/manager.ts which already wired this up; the web-session path in gateway/api.ts did not.

Mirror the same resolveMcpServers + writeMcpConfigFile flow here and pass mcpConfigPath into engine.run, plus a finally block to clean up the temp config file after the session completes.