### PR TITLE
feat(telegram): wire voice/audio messages through bundled STT module

### DIFF
--- a/packages/jimmy/src/connectors/telegram/index.ts
+++ b/packages/jimmy/src/connectors/telegram/index.ts
@@ -40,6 +40,7 @@ export class TelegramConnector implements Connector {
 
   private readonly sttConfig?: TelegramConnectorConfig["stt"];
   private sttChain: Promise<unknown> = Promise.resolve();
+  private sttPending = 0;
 
   constructor(config: TelegramConnectorConfig) {
     this.bot = new TelegramBot(config.botToken, { polling: false });
@@ -139,6 +140,20 @@ export class TelegramConnector implements Connector {
         const language = langs.length === 1 ? langs[0] : "auto";
 
         // Serialize transcriptions: parallel whisper-cli runs OOM on small hosts.
+        // If another transcription is already in flight, send a one-line ack so
+        // the user doesn't sit through ~duration × queue position in silence.
+        this.sttPending++;
+        if (this.sttPending > 1) {
+          try {
+            await this.bot.sendMessage(
+              telegramMsg.chat.id,
+              "⏳ Transcribing a previous voice message — yours is queued.",
+            );
+          } catch {
+            /* non-fatal */
+          }
+        }
+
         const myTurn = this.sttChain.then(async () => {
           try {
             await this.bot.sendChatAction(telegramMsg.chat.id, "typing");
@@ -163,7 +178,11 @@ export class TelegramConnector implements Connector {
             }
           }
         });
-        this.sttChain = myTurn.catch(() => undefined);
+        this.sttChain = myTurn
+          .catch(() => undefined)
+          .finally(() => {
+            this.sttPending = Math.max(0, this.sttPending - 1);
+          });
 
         let transcript: string | undefined;
         try {

--- a/packages/jimmy/src/connectors/telegram/index.ts
+++ b/packages/jimmy/src/connectors/telegram/index.ts
@@ -40,7 +40,6 @@ export class TelegramConnector implements Connector {
 
   private readonly sttConfig?: TelegramConnectorConfig["stt"];
   private sttChain: Promise<unknown> = Promise.resolve();
-  private sttQueueDepth = 0;
 
   constructor(config: TelegramConnectorConfig) {
     this.bot = new TelegramBot(config.botToken, { polling: false });
@@ -105,91 +104,101 @@ export class TelegramConnector implements Connector {
       let messageText: string =
         (telegramMsg as any).text || (telegramMsg as any).caption || "";
 
-      // Voice / audio / video_note → transcribe via STT module
+      // Voice / audio / video_note → transcribe via STT module.
+      // If STT can't run for any reason, drop the message with a user-facing
+      // explanation rather than forwarding empty text downstream (which would
+      // crash session resume — see #54).
       const voiceLike =
         (telegramMsg as any).voice ||
         (telegramMsg as any).audio ||
         (telegramMsg as any).video_note;
 
-      if (voiceLike && this.sttConfig?.enabled) {
-        const model = this.sttConfig.model || "small";
-        if (!getModelPath(model)) {
-          logger.warn(
-            `[telegram] STT model '${model}' not downloaded — skipping transcription`,
-          );
-        } else {
-          const langs = resolveLanguages(this.sttConfig);
-          const language = langs.length === 1 ? langs[0] : "auto";
+      if (voiceLike) {
+        const model = this.sttConfig?.model || "small";
+        let unavailable: string | null = null;
+        if (!this.sttConfig?.enabled) {
+          unavailable = "voice transcription is not enabled on this gateway";
+        } else if (!getModelPath(model)) {
+          unavailable = `STT model '${model}' is not downloaded`;
+        }
 
-          // Serialize transcriptions: parallel whisper-cli runs OOM on small boxes.
-          this.sttQueueDepth = (this.sttQueueDepth || 0) + 1;
-          const myPosition = this.sttQueueDepth;
-          if (myPosition > 1) {
-            logger.info(
-              `[telegram] Voice message queued (position ${myPosition}, ${myPosition - 1} ahead)`,
-            );
-            try {
-              await this.bot.sendMessage(
-                telegramMsg.chat.id,
-                `⏳ Queued — ${myPosition - 1} voice message${myPosition - 1 === 1 ? "" : "s"} ahead. I'll transcribe yours when its turn comes up.`,
-              );
-            } catch {
-              /* non-fatal */
-            }
-          }
-
-          const myTurn = this.sttChain.then(async () => {
-            try {
-              await this.bot.sendChatAction(telegramMsg.chat.id, "typing");
-            } catch {
-              /* non-fatal */
-            }
-            logger.info(
-              `[telegram] Transcribing voice message (${voiceLike.duration}s, lang=${language})`,
-            );
-            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-stt-"));
-            try {
-              const localPath = await (this.bot as any).downloadFile(
-                voiceLike.file_id,
-                tmpDir,
-              );
-              return await sttTranscribe(localPath, model, language);
-            } finally {
-              try {
-                fs.rmSync(tmpDir, { recursive: true, force: true });
-              } catch {
-                /* non-fatal */
-              }
-            }
-          });
-          this.sttChain = myTurn
-            .catch(() => undefined)
-            .finally(() => {
-              this.sttQueueDepth = Math.max(0, (this.sttQueueDepth || 1) - 1);
-            });
-
+        if (unavailable) {
+          logger.warn(`[telegram] Dropping voice message: ${unavailable}`);
           try {
-            const text = await myTurn;
-            if (text) {
-              messageText = messageText ? `${messageText}\n\n${text}` : text;
-              logger.info(`[telegram] Transcribed ${text.length} chars`);
-            } else {
-              logger.warn("[telegram] Transcription returned empty text");
-            }
-          } catch (err) {
-            logger.error(
-              `[telegram] STT failed: ${err instanceof Error ? err.message : err}`,
+            await this.bot.sendMessage(
+              telegramMsg.chat.id,
+              `⚠️ Couldn't transcribe your voice message — ${unavailable}. Please type instead.`,
             );
+          } catch {
+            /* non-fatal */
+          }
+          return;
+        }
+
+        const langs = resolveLanguages(this.sttConfig);
+        const language = langs.length === 1 ? langs[0] : "auto";
+
+        // Serialize transcriptions: parallel whisper-cli runs OOM on small hosts.
+        const myTurn = this.sttChain.then(async () => {
+          try {
+            await this.bot.sendChatAction(telegramMsg.chat.id, "typing");
+          } catch {
+            /* non-fatal */
+          }
+          logger.info(
+            `[telegram] Transcribing voice message (${voiceLike.duration}s, lang=${language})`,
+          );
+          const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-stt-"));
+          try {
+            const localPath = await (this.bot as any).downloadFile(
+              voiceLike.file_id,
+              tmpDir,
+            );
+            return await sttTranscribe(localPath, model, language);
+          } finally {
             try {
-              await this.bot.sendMessage(
-                telegramMsg.chat.id,
-                "⚠️ Couldn't transcribe your voice message. Please try again or type instead.",
-              );
+              fs.rmSync(tmpDir, { recursive: true, force: true });
             } catch {
               /* non-fatal */
             }
-            return;
           }
+        });
+        this.sttChain = myTurn.catch(() => undefined);
+
+        let transcript: string | undefined;
+        try {
+          transcript = await myTurn;
+        } catch (err) {
+          logger.error(
+            `[telegram] STT failed: ${err instanceof Error ? err.message : err}`,
+          );
+          try {
+            await this.bot.sendMessage(
+              telegramMsg.chat.id,
+              "⚠️ Couldn't transcribe your voice message. Please try again or type instead.",
+            );
+          } catch {
+            /* non-fatal */
+          }
+          return;
+        }
+
+        if (transcript) {
+          messageText = messageText
+            ? `${messageText}\n\n${transcript}`
+            : transcript;
+          logger.info(`[telegram] Transcribed ${transcript.length} chars`);
+        } else {
+          logger.warn("[telegram] Transcription returned empty text");
+          try {
+            await this.bot.sendMessage(
+              telegramMsg.chat.id,
+              "⚠️ Couldn't make out anything in your voice message. Please try again or type instead.",
+            );
+          } catch {
+            /* non-fatal */
+          }
+          return;
         }
       }
 

--- a/packages/jimmy/src/connectors/telegram/index.ts
+++ b/packages/jimmy/src/connectors/telegram/index.ts
@@ -1,4 +1,7 @@
 import TelegramBot from "node-telegram-bot-api";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type {
   Connector,
   ConnectorCapabilities,
@@ -11,6 +14,11 @@ import type {
 import { deriveSessionKey, buildReplyContext, isOldTelegramMessage } from "./threads.js";
 import { formatResponse } from "./format.js";
 import { logger } from "../../shared/logger.js";
+import {
+  transcribe as sttTranscribe,
+  resolveLanguages,
+  getModelPath,
+} from "../../stt/stt.js";
 
 export class TelegramConnector implements Connector {
   name = "telegram";
@@ -30,6 +38,10 @@ export class TelegramConnector implements Connector {
     attachments: true,
   };
 
+  private readonly sttConfig?: TelegramConnectorConfig["stt"];
+  private sttChain: Promise<unknown> = Promise.resolve();
+  private sttQueueDepth = 0;
+
   constructor(config: TelegramConnectorConfig) {
     this.bot = new TelegramBot(config.botToken, { polling: false });
     this.ignoreOldMessagesOnBoot = config.ignoreOldMessagesOnBoot !== false;
@@ -37,6 +49,7 @@ export class TelegramConnector implements Connector {
       config.allowFrom && config.allowFrom.length > 0
         ? new Set(config.allowFrom)
         : null;
+    this.sttConfig = config.stt;
   }
 
   async start(): Promise<void> {
@@ -89,6 +102,97 @@ export class TelegramConnector implements Connector {
       const username =
         telegramMsg.from?.username || telegramMsg.from?.first_name || "unknown";
 
+      let messageText: string =
+        (telegramMsg as any).text || (telegramMsg as any).caption || "";
+
+      // Voice / audio / video_note → transcribe via STT module
+      const voiceLike =
+        (telegramMsg as any).voice ||
+        (telegramMsg as any).audio ||
+        (telegramMsg as any).video_note;
+
+      if (voiceLike && this.sttConfig?.enabled) {
+        const model = this.sttConfig.model || "small";
+        if (!getModelPath(model)) {
+          logger.warn(
+            `[telegram] STT model '${model}' not downloaded — skipping transcription`,
+          );
+        } else {
+          const langs = resolveLanguages(this.sttConfig);
+          const language = langs.length === 1 ? langs[0] : "auto";
+
+          // Serialize transcriptions: parallel whisper-cli runs OOM on small boxes.
+          this.sttQueueDepth = (this.sttQueueDepth || 0) + 1;
+          const myPosition = this.sttQueueDepth;
+          if (myPosition > 1) {
+            logger.info(
+              `[telegram] Voice message queued (position ${myPosition}, ${myPosition - 1} ahead)`,
+            );
+            try {
+              await this.bot.sendMessage(
+                telegramMsg.chat.id,
+                `⏳ Queued — ${myPosition - 1} voice message${myPosition - 1 === 1 ? "" : "s"} ahead. I'll transcribe yours when its turn comes up.`,
+              );
+            } catch {
+              /* non-fatal */
+            }
+          }
+
+          const myTurn = this.sttChain.then(async () => {
+            try {
+              await this.bot.sendChatAction(telegramMsg.chat.id, "typing");
+            } catch {
+              /* non-fatal */
+            }
+            logger.info(
+              `[telegram] Transcribing voice message (${voiceLike.duration}s, lang=${language})`,
+            );
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-stt-"));
+            try {
+              const localPath = await (this.bot as any).downloadFile(
+                voiceLike.file_id,
+                tmpDir,
+              );
+              return await sttTranscribe(localPath, model, language);
+            } finally {
+              try {
+                fs.rmSync(tmpDir, { recursive: true, force: true });
+              } catch {
+                /* non-fatal */
+              }
+            }
+          });
+          this.sttChain = myTurn
+            .catch(() => undefined)
+            .finally(() => {
+              this.sttQueueDepth = Math.max(0, (this.sttQueueDepth || 1) - 1);
+            });
+
+          try {
+            const text = await myTurn;
+            if (text) {
+              messageText = messageText ? `${messageText}\n\n${text}` : text;
+              logger.info(`[telegram] Transcribed ${text.length} chars`);
+            } else {
+              logger.warn("[telegram] Transcription returned empty text");
+            }
+          } catch (err) {
+            logger.error(
+              `[telegram] STT failed: ${err instanceof Error ? err.message : err}`,
+            );
+            try {
+              await this.bot.sendMessage(
+                telegramMsg.chat.id,
+                "⚠️ Couldn't transcribe your voice message. Please try again or type instead.",
+              );
+            } catch {
+              /* non-fatal */
+            }
+            return;
+          }
+        }
+      }
+
       const msg: IncomingMessage = {
         connector: this.name,
         source: "telegram",
@@ -98,7 +202,7 @@ export class TelegramConnector implements Connector {
         channel: String(telegramMsg.chat.id),
         user: username,
         userId: String(userId ?? "unknown"),
-        text: telegramMsg.text || "",
+        text: messageText,
         attachments: [],
         raw: telegramMsg,
         transportMeta: {

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -364,6 +364,7 @@ export async function startGateway(
         botToken: config.connectors.telegram.botToken,
         allowFrom: config.connectors.telegram.allowFrom,
         ignoreOldMessagesOnBoot: config.connectors.telegram.ignoreOldMessagesOnBoot,
+        stt: config.stt,
       });
       telegram.onMessage((msg) => {
         const routeOpts: RouteOptions = {};
@@ -480,7 +481,7 @@ export async function startGateway(
             break;
           }
           case "telegram": {
-            const telegramConfig = { ...typeConfig, id } as any;
+            const telegramConfig = { ...typeConfig, id, stt: config.stt } as any;
             const tg = new TelegramConnector(telegramConfig);
             tg.onMessage((msg) => {
               const routeOpts: RouteOptions = {};
@@ -605,7 +606,7 @@ export async function startGateway(
               break;
             }
             case "telegram": {
-              const telegramConfig = { ...typeConfig, id } as any;
+              const telegramConfig = { ...typeConfig, id, stt: config.stt } as any;
               const tg = new TelegramConnector(telegramConfig);
               tg.onMessage((msg) => {
                 const routeOpts: RouteOptions = {};

--- a/packages/jimmy/src/shared/types.ts
+++ b/packages/jimmy/src/shared/types.ts
@@ -330,6 +330,13 @@ export interface TelegramConnectorConfig {
   botToken: string;
   allowFrom?: number[];
   ignoreOldMessagesOnBoot?: boolean;
+  /** Speech-to-text settings forwarded from top-level `config.stt` */
+  stt?: {
+    enabled?: boolean;
+    model?: string;
+    language?: string;
+    languages?: string[];
+  };
 }
 
 export interface WhatsAppConnectorConfig {


### PR DESCRIPTION
Closes #54.

## Problem

The portal's "Download Whisper" feature downloads the model, but the Telegram connector never invokes STT. Voice messages arrive at the engine with `text: ""`, which crashes Claude session resume with the "No deferred tool marker" error.

## Change

Wires `voice`, `audio`, and `video_note` Telegram messages through the existing `stt/stt.ts` module before they reach the engine.

- Pass `stt` config from gateway through to `TelegramConnector` (3 sites in `gateway/server.ts`)
- In `connectors/telegram/index.ts`: detect voice/audio/video_note, send typing action when this message's turn comes, `bot.downloadFile()` into a per-message tempdir, call `sttTranscribe()`, prepend the transcript to `text`
- Multi-language config → `auto`; single-language → use it directly
- Tempdir is cleaned up in `finally` on both success and failure paths

### Empty-text fall-through (the actual #54 bug)

A voice message must never reach the handler with `text: ""`. Four paths now drop with a user-facing Telegram explanation and `return`:

| Condition | User-facing message |
|---|---|
| `stt.enabled` is false | "voice transcription is not enabled on this gateway" |
| Configured model not downloaded | "STT model 'X' is not downloaded" |
| `sttTranscribe()` throws | "Couldn't transcribe your voice message. Please try again…" |
| `sttTranscribe()` returns empty string | "Couldn't make out anything in your voice message…" |

### Serialization

`sttChain` (a single Promise the next transcription chains off) prevents parallel `whisper-cli` runs from OOM-ing on memory-constrained hosts. Synchronous `this.sttChain = myTurn.catch(...)` reassignment chains arrivals in order with no race, and a failed transcription doesn't poison the next job.

A single "⏳ Transcribing a previous voice message — yours is queued" ack is sent when another transcription is already in flight, so the user isn't left silent for the duration × queue position. No count is surfaced — `sttPending` is checked as a boolean internally and decremented in the chain's `finally`.

## Verification

- `tsc --noEmit` clean on `packages/jimmy`
- Tested in production on a 1.9 GB Amazon Linux box with whisper.cpp v1.8.4 and ggml-small model — transcribes PT-BR and English voice notes, serializes concurrent voice messages without OOM, drops voice messages with the right user-facing message when STT is unavailable