### PR TITLE
Add node-pty to pnpm.onlyBuiltDependencies (Linux build fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "onlyBuiltDependencies": [
       "@swc/core",
       "better-sqlite3",
-      "classic-level"
+      "classic-level",
+      "node-pty"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- pnpm 10 only runs install scripts for packages listed in `pnpm.onlyBuiltDependencies`. `node-pty` was added as a dependency but not to that allowlist, so its postinstall (which runs `node-gyp rebuild`) is skipped.
- On Linux this is fatal: `node-pty` ships no Linux prebuild, so `build/Release/pty.node` never gets compiled and the gateway crashes at startup with `Failed to load native module: pty.node`.
- macOS and Windows users are unaffected — `node-pty` ships prebuilds for `darwin-arm64`, `darwin-x64`, `win32-arm64`, `win32-x64`.

## Reproduction
On a fresh Linux clone with Node 24.15.0 and pnpm 10.6.4:

```
git clone https://github.com/hristo2612/jinn && cd jinn
pnpm install
node -e 'require("node-pty")'
# → Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-x64
```

After this patch, `pnpm install` runs node-pty's postinstall, `node-gyp` compiles `pty.node` into `build/Release/`, and `require("node-pty")` succeeds.

## Test plan
- [x] Reproduced on Amazon Linux 2023, Node 24.15.0, pnpm 10.6.4: fresh `pnpm install` of `main` leaves `node-pty/build/Release/` absent and `require("node-pty")` throws.
- [x] With this change applied: `pnpm install` runs the postinstall, `pty.node` is built, runtime require succeeds, `jinn start` boots cleanly.
- [ ] macOS / Windows: unchanged — prebuilds are still consumed without invoking node-gyp.