### PR TITLE
fix(claude): seed global onboarding flags to stop interactive PTY hangs

### DIFF
--- a/packages/jinn/src/shared/__tests__/claude-settings.test.ts
+++ b/packages/jinn/src/shared/__tests__/claude-settings.test.ts
@@ -32,6 +32,8 @@ describe("claude-settings", () => {
     const d = JSON.parse(fs.readFileSync(claudeJson, "utf-8"));
     expect(d.projects[projectDir].hasTrustDialogAccepted).toBe(true);
     expect(d.projects[projectDir].hasCompletedProjectOnboarding).toBe(true);
+    expect(d.hasCompletedOnboarding).toBe(true);
+    expect(d.hasCompletedClaudeInChromeOnboarding).toBe(true);
   });
 
   it("seedTrust writes a one-time backup of a pre-existing ~/.claude.json before first modification", () => {

--- a/packages/jinn/src/shared/claude-settings.ts
+++ b/packages/jinn/src/shared/claude-settings.ts
@@ -55,20 +55,45 @@ export function cleanupSessionSettings(dir: string, sessionId: string): void {
   try { fs.unlinkSync(sessionSettingsPath(dir, sessionId)); } catch { /* best effort */ }
 }
 
-/** Idempotently mark a project directory trusted in the real ~/.claude.json. */
+/**
+ * Idempotently mark a project directory trusted AND complete the global first-run
+ * onboarding in the real ~/.claude.json, so the interactive (PTY) `claude` never
+ * blocks on a one-time consent dialog.
+ *
+ * Recent Claude Code versions gate the interactive TUI behind blocking first-run
+ * prompts: the "Bypass Permissions mode" consent (triggered by
+ * --dangerously-skip-permissions) and the "Claude in Chrome (beta)" intro
+ * (triggered by --chrome). The InteractiveClaudeEngine launches `claude`
+ * interactively with both flags and never sends a keystroke to dismiss the
+ * dialogs, so on any install where onboarding is not already complete (fresh,
+ * headless/CI, or after a Claude Code upgrade resets onboarding for a new
+ * version) every work turn hangs forever before reaching the API. Pre-seeding
+ * these flags at gateway boot answers the dialogs up front. See hristo2612/jinn#66.
+ */
 export function seedTrust(claudeJsonPath: string, projectDir: string): void {
   const realDir = fs.realpathSync(projectDir);
   let data: any = {};
   try { data = JSON.parse(fs.readFileSync(claudeJsonPath, "utf-8")); } catch { /* new file */ }
   data.projects ??= {};
   const proj = (data.projects[realDir] ??= {});
-  if (proj.hasTrustDialogAccepted === true && proj.hasCompletedProjectOnboarding === true) return;
+  const alreadySeeded =
+    data.hasCompletedOnboarding === true &&
+    data.hasCompletedClaudeInChromeOnboarding === true &&
+    proj.hasTrustDialogAccepted === true &&
+    proj.hasCompletedProjectOnboarding === true;
+  if (alreadySeeded) return;
   // About to modify the user's real ~/.claude.json — keep a one-time backup of the
   // pre-Jinn original (no timestamped proliferation; first write wins).
   const backupPath = `${claudeJsonPath}.jinn-backup`;
   if (fs.existsSync(claudeJsonPath) && !fs.existsSync(backupPath)) {
     try { fs.copyFileSync(claudeJsonPath, backupPath, fs.constants.COPYFILE_EXCL); } catch { /* best effort */ }
   }
+  // Global onboarding: dismisses the Bypass Permissions consent
+  // (hasCompletedOnboarding) and the Claude in Chrome (beta) intro
+  // (hasCompletedClaudeInChromeOnboarding) that otherwise block the interactive PTY.
+  data.hasCompletedOnboarding = true;
+  data.hasCompletedClaudeInChromeOnboarding = true;
+  // Per-project trust: dismisses the folder-trust dialog.
   proj.hasTrustDialogAccepted = true;
   proj.hasCompletedProjectOnboarding = true;
   proj.allowedTools ??= [];


### PR DESCRIPTION
Fixes #66.

## Problem

The `InteractiveClaudeEngine` (the PTY path, default since v0.18.0) launches `claude` **interactively** with `--dangerously-skip-permissions` and `--chrome`. Recent Claude Code versions (reproduced on 2.1.170) gate the interactive TUI behind one-time first-run dialogs:

- **Bypass Permissions mode** consent — triggered by `--dangerously-skip-permissions`
- **Claude in Chrome (beta)** intro — triggered by `--chrome`

jinn never sends a keystroke to dismiss them, so on any install where onboarding isn't already complete — a fresh box, a headless/CI deploy, or **after a Claude Code upgrade resets onboarding for a new version** — every work turn hangs forever in `epoll_wait` *before reaching the API*. The gateway eventually falls back to transcript recovery (`Recovered N chars of lost turn text … (Stop hook missing)`, `completed in 0ms`) and the user gets no reply. Full diagnosis in #66.

## Fix

`seedTrust()` is already invoked at gateway boot to mark the project directory trusted in the real `~/.claude.json`. This extends it to also write the two **global** onboarding flags:

- `hasCompletedOnboarding` — pre-answers the Bypass Permissions consent
- `hasCompletedClaudeInChromeOnboarding` — pre-answers the Claude in Chrome intro

It stays idempotent (the early-return guard now covers the new flags) and rides the existing atomic write + one-time backup. On a real headless server this is exactly the change that took work turns from hang-forever back to a clean ~3-4s `Stop`-hook completion.

## Test

- Extends the existing `seedTrust is idempotent` test to assert both global flags.
- `vitest run src/shared/__tests__/claude-settings.test.ts` -> 5 passed.
- `tsc --noEmit` -> clean.

## Out of scope (other suggestions from #66)

Left out to keep this minimal and behavior-preserving - happy to add if you'd prefer:

1. **Make `--chrome` opt-in** (e.g. `engines.claude.chrome: false` on headless hosts). It's hardcoded in `buildInteractiveArgs()` and `ensureIdleSpawn()` and is unusable without a display. Seeding the onboarding flag above already removes the *hang*; this would also drop the `setup issue: chrome` warning noise.
2. **Fail loud instead of hanging silently** - if an interactive turn produces no PTY output within N seconds, surface an explicit "claude appears to be waiting at an interactive prompt" error rather than blocking until the transcript-recovery fallback masks it.
