### PR TITLE
Fix chat mode streaming and selector regressions

### DIFF
--- a/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
+++ b/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 
 // claude-interactive.ts imports node-pty at the top level. node-pty loads its
 // native module at import time and that fails on Linux CI runners (looks for
@@ -7,8 +7,29 @@ import { describe, it, expect, vi } from "vitest";
 // focused and CI-portable.
 vi.mock("node-pty", () => ({ spawn: vi.fn() }));
 
-import { TurnResolver, buildInteractiveArgs } from "../claude-interactive.js";
+import { TurnResolver, buildInteractiveArgs, claudeHookToDeltas, pasteAndSubmit } from "../claude-interactive.js";
 import { MAIN_AGENT_SENTINEL } from "../sse-pty-proxy.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("claudeHookToDeltas", () => {
+  it("does not emit a duplicate tool_use for PreToolUse", () => {
+    expect(claudeHookToDeltas({
+      hook_event_name: "PreToolUse",
+      tool_name: "Bash",
+      tool_input: { command: "printf ok" },
+    })).toEqual([]);
+  });
+
+  it("emits a tool_result for PostToolUse", () => {
+    expect(claudeHookToDeltas({
+      hook_event_name: "PostToolUse",
+      tool_name: "Bash",
+    })).toEqual([{ type: "tool_result", content: "Bash", toolName: "Bash" }]);
+  });
+});
 
 describe("TurnResolver", () => {
   it("resolves only after BOTH SessionStart and Stop", async () => {
@@ -50,6 +71,18 @@ describe("TurnResolver", () => {
     expect(v.numTurns).toBe(1);
   });
 
+  it("strips leaked thinking blocks from Stop hook assistant text", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "warm-sid", assumeStarted: true });
+    r.onHook({
+      hook_event_name: "Stop",
+      last_assistant_message: "<thinking>private reasoning</thinking>\n\nVisible answer.",
+    });
+    const v = await r.promise;
+    expect(v.result).toBe("Visible answer.");
+    expect(v.result).not.toContain("private reasoning");
+    expect(v.sessionId).toBe("warm-sid");
+  });
+
   it("settles immediately on StopFailure (does not wait for SessionStart) and exposes it", async () => {
     const r = new TurnResolver({ fallbackSessionId: "old" });
     r.onHook({ hook_event_name: "StopFailure", error: "rate_limit", error_details: "resets 3pm" });
@@ -67,6 +100,15 @@ describe("TurnResolver", () => {
     expect(v.result).toBe("transcript final");
     expect(v.sessionId).toBe("c1");
     expect(v.numTurns).toBe(1);
+  });
+
+  it("strips leaked thinking blocks from recovered transcript text", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "old" });
+    r.onHook({ hook_event_name: "SessionStart", session_id: "c1" });
+    r.completeRecovered("<thinking>private transcript reasoning</thinking>\n\nVisible transcript answer.", "c1");
+    const v = await r.promise;
+    expect(v.result).toBe("Visible transcript answer.");
+    expect(v.result).not.toContain("private transcript reasoning");
   });
 });
 
@@ -94,5 +136,24 @@ describe("buildInteractiveArgs — system prompt + sentinel via CLI flag", () =>
   it("omits the flag when no appendSystemPrompt is given", () => {
     const args = buildInteractiveArgs({ prompt: "hi", settingsPath: "/tmp/s.json" });
     expect(args).not.toContain("--append-system-prompt");
+  });
+});
+
+describe("pasteAndSubmit", () => {
+  it("waits for multiline bracketed paste to settle before submitting", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const proc = { write: (data: string) => { writes.push(data); } };
+
+    pasteAndSubmit(proc as any, "Describe this image\n\nAttached files:\n- /tmp/image.png");
+
+    expect(writes).toEqual(["\x1b[200~Describe this image\n\nAttached files:\n- /tmp/image.png\x1b[201~"]);
+    vi.advanceTimersByTime(149);
+    expect(writes).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(writes).toEqual([
+      "\x1b[200~Describe this image\n\nAttached files:\n- /tmp/image.png\x1b[201~",
+      "\r",
+    ]);
   });
 });

--- a/packages/jinn/src/engines/__tests__/grok.test.ts
+++ b/packages/jinn/src/engines/__tests__/grok.test.ts
@@ -187,6 +187,33 @@ describe("parseGrokJsonLine", () => {
       .toEqual([{ type: "text", content: "G" }]);
   });
 
+  it("drops reasoning-like event names even when they carry generic text fields", () => {
+    const parsed = parseGrokJsonLine(JSON.stringify({
+      type: "reasoning_delta",
+      content: "private chain-of-thought",
+    }));
+
+    expect(parsed?.deltas).toEqual([]);
+    expect(JSON.stringify(parsed)).not.toContain("private chain-of-thought");
+  });
+
+  it("omits thinking blocks from mixed assistant content snapshots", () => {
+    const parsed = parseGrokJsonLine(JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content: [
+        { type: "thinking", text: "hidden reasoning" },
+        { type: "text", text: "visible answer" },
+      ],
+      session_id: "grok-1",
+    }));
+
+    expect(parsed?.sessionId).toBe("grok-1");
+    expect(parsed?.doneText).toBe("visible answer");
+    expect(parsed?.deltas).toContainEqual({ type: "text_snapshot", content: "visible answer" });
+    expect(JSON.stringify(parsed)).not.toContain("hidden reasoning");
+  });
+
   it("skips Grok transcript user/system entries", () => {
     expect(parseGrokJsonLine(JSON.stringify({ type: "user", content: "<system-reminder>startup</system-reminder>" }))?.deltas)
       .toEqual([]);
@@ -322,6 +349,19 @@ describe("parseGrokJsonLine", () => {
 
     expect(parseGrokJsonLine(JSON.stringify({ type: "error", message: "bad auth" }))?.deltas)
       .toEqual([{ type: "error", content: "bad auth" }]);
+  });
+
+  it("drops nested reasoning wrappers from Grok content blocks", () => {
+    const parsed = parseGrokJsonLine(JSON.stringify({
+      type: "message",
+      content: [
+        { type: "content", content: { type: "thinking", text: "private nested reasoning" } },
+        { type: "content", content: { type: "text", text: "visible answer" } },
+      ],
+    }));
+
+    expect(parsed?.deltas).toEqual([{ type: "text_snapshot", content: "visible answer" }]);
+    expect(parsed?.deltas.some((d) => String(d.content).includes("private nested reasoning"))).toBe(false);
   });
 });
 

--- a/packages/jinn/src/engines/__tests__/sse-event-to-deltas.test.ts
+++ b/packages/jinn/src/engines/__tests__/sse-event-to-deltas.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from "vitest";
 // unit test stays CI-portable (no native binding needed).
 vi.mock("node-pty", () => ({ spawn: vi.fn() }));
 
-import { sseEventToDeltas, truncatedToolInput } from "../claude-interactive.js";
+import { sseEventToDeltas } from "../claude-interactive.js";
 
 describe("sseEventToDeltas (Item D — SSE → StreamDelta mapping)", () => {
   it("maps message_start.usage to a context delta (input + cache_read + cache_creation)", () => {
@@ -50,46 +50,5 @@ describe("sseEventToDeltas (Item D — SSE → StreamDelta mapping)", () => {
     for (const type of ["ping", "content_block_stop", "message_delta", "message_stop"]) {
       expect(sseEventToDeltas({ type })).toEqual([]);
     }
-  });
-});
-
-// ---------------------------------------------------------------------------
-// truncatedToolInput — used by the PreToolUse hook handler to carry a short
-// input snippet on the second tool_use delta so Talk whispers can differentiate.
-//
-// NOTE: the PreToolUse hook fires inside run() which spawns a PTY; that path is
-// not unit-testable in isolation (requires a live PTY + engine session). The
-// helper is extracted and tested here; the plumbing relies on the type guarantee
-// (StreamDelta.input) and frontend integration tests (talk-whisper.test.ts).
-// ---------------------------------------------------------------------------
-describe("truncatedToolInput", () => {
-  it("stringifies a JSON object and returns first 200 chars", () => {
-    const input = { command: "curl -X POST http://localhost:7777/api/talk/delegate -d '{}'" };
-    const result = truncatedToolInput(input);
-    expect(result).toBe(JSON.stringify(input).slice(0, 200));
-    expect(result.length).toBeLessThanOrEqual(200);
-  });
-
-  it("passes a string through untouched (up to 200 chars)", () => {
-    expect(truncatedToolInput("hello world")).toBe("hello world");
-  });
-
-  it("truncates long inputs to exactly maxChars", () => {
-    const long = "x".repeat(500);
-    expect(truncatedToolInput(long)).toHaveLength(200);
-    expect(truncatedToolInput(long, 50)).toHaveLength(50);
-  });
-
-  it("returns empty string for null/undefined/number/boolean", () => {
-    expect(truncatedToolInput(null)).toBe("");
-    expect(truncatedToolInput(undefined)).toBe("");
-    expect(truncatedToolInput(42)).toBe("");
-    expect(truncatedToolInput(true)).toBe("");
-  });
-
-  it("preserves /api/talk/* paths inside object inputs (needed for whisper matching)", () => {
-    const obj = { url: "http://host/api/talk/delegate", body: "{}" };
-    const result = truncatedToolInput(obj);
-    expect(result.toLowerCase()).toContain("/api/talk/delegate");
   });
 });

--- a/packages/jinn/src/engines/__tests__/turn-resolver-grace.test.ts
+++ b/packages/jinn/src/engines/__tests__/turn-resolver-grace.test.ts
@@ -67,6 +67,36 @@ describe("TurnResolver — StopFailure grace window", () => {
     expect(r.isSettled).toBe(false);
   });
 
+  it("non-hard permission/safety failures are graced because Claude may continue", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "sid", assumeStarted: true, stopFailureGraceMs: 1000 });
+    const get = probe(r);
+    r.onHook({ hook_event_name: "StopFailure", error: "permission_error", session_id: "sid" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(r.isSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(get()?.error).toBe("Interactive turn failed: permission_error");
+  });
+
+  it("does not expire a graced StopFailure while upstream sub-agent work is still active", async () => {
+    let activeUpstream = true;
+    const r = new TurnResolver({
+      fallbackSessionId: "sid",
+      assumeStarted: true,
+      stopFailureGraceMs: 1000,
+      shouldDeferStopFailure: () => activeUpstream,
+    });
+    const get = probe(r);
+
+    r.onHook({ hook_event_name: "StopFailure", error: "invalid_request", session_id: "sid" });
+    await vi.advanceTimersByTimeAsync(2500);
+    expect(r.isSettled).toBe(false);
+    expect(get()).toBeUndefined();
+
+    activeUpstream = false;
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(get()?.error).toBe("Interactive turn failed: invalid_request");
+  });
+
   it("noteActivity() outside a grace window is a no-op", () => {
     const r = new TurnResolver({ fallbackSessionId: "sid", assumeStarted: true });
     r.noteActivity();

--- a/packages/jinn/src/engines/claude-interactive.ts
+++ b/packages/jinn/src/engines/claude-interactive.ts
@@ -251,12 +251,10 @@ export function sseEventToDeltas(e: SseDataEvent): StreamDelta[] {
 }
 
 const STOP_FAILURE_GRACE_MS = 20_000;
-/** StopFailure error types the interactive CLI routinely survives and retries
- *  (the PTY keeps working) — eligible for the grace window. rate_limit /
- *  billing_error / authentication_failed / max_output_tokens settle
- *  immediately: the CLI genuinely stops on those, and manager.ts's wait/retry/
- *  fallback machinery keys off the prompt settle. */
-const GRACE_ELIGIBLE_ERRORS = new Set(["invalid_request", "server_error", "unknown"]);
+/** StopFailure errors that must settle immediately. Rate-limit/billing/auth
+ *  need the manager fallback machinery right away; everything else gets a grace
+ *  window because Claude Code can keep working after a sub-agent/API failure. */
+const IMMEDIATE_STOP_FAILURE_ERRORS = new Set(["rate_limit", "billing_error", "authentication_failed", "max_output_tokens"]);
 
 export interface TurnResolverOpts {
   fallbackSessionId: string | undefined;
@@ -266,6 +264,8 @@ export interface TurnResolverOpts {
   assumeStarted?: boolean;
   /** Test override for the StopFailure grace window (default 20s). */
   stopFailureGraceMs?: number;
+  /** While true, a graced StopFailure keeps waiting instead of settling. */
+  shouldDeferStopFailure?: () => boolean;
   /** This turn is a Claude-native local command (see isNativeClaudeCommand). Such
    *  commands produce no new assistant message, so a Stop hook's
    *  last_assistant_message is the PREVIOUS turn's stale text — maybeComplete must
@@ -314,7 +314,7 @@ export class TurnResolver {
       // numTurns:1 keeps isDeadSessionError from false-positiving.
       this.stopFailurePayload = h;
       if (typeof h.session_id === "string" && !this.claudeSessionId) this.claudeSessionId = h.session_id;
-      if (GRACE_ELIGIBLE_ERRORS.has(String(h.error ?? "unknown"))) {
+      if (!IMMEDIATE_STOP_FAILURE_ERRORS.has(String(h.error ?? "unknown"))) {
         this.armGrace();
       } else {
         this.settleWithFailure();
@@ -380,7 +380,13 @@ export class TurnResolver {
   private armGrace(): void {
     this.clearGrace();
     const ms = this.opts.stopFailureGraceMs ?? STOP_FAILURE_GRACE_MS;
-    this.graceTimer = setTimeout(() => this.settleWithFailure(), ms);
+    this.graceTimer = setTimeout(() => {
+      if (this.opts.shouldDeferStopFailure?.()) {
+        this.armGrace();
+        return;
+      }
+      this.settleWithFailure();
+    }, ms);
     this.graceTimer.unref?.();
   }
 
@@ -648,6 +654,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       fallbackSessionId: opts.resumeSessionId,
       assumeStarted: !!warm, // warm PTY = SessionStart already fired (turn 1 or idle spawn)
       native: nativeCommand,
+      shouldDeferStopFailure: () => this.hasActiveUpstream(jinnSessionId),
     });
     const entry: { resolver: TurnResolver; onStream?: (d: StreamDelta) => void; boundProc?: pty.IPty; activeTools: number } = {
       resolver,

--- a/packages/jinn/src/engines/claude-interactive.ts
+++ b/packages/jinn/src/engines/claude-interactive.ts
@@ -148,6 +148,13 @@ export function lastAssistantTextFromTranscript(transcriptPath: string, afterMs?
   return last;
 }
 
+export function stripReasoningBlocks(text: string): string {
+  return text
+    .replace(/<\s*(thinking|reasoning|thought)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, "")
+    .replace(/```(?:thinking|reasoning|thought)\b[\s\S]*?```/gi, "")
+    .trim();
+}
+
 function computeInteractiveCost(transcriptPath: string, model?: string): { cost: number; turns: number } | null {
   let content: string;
   try { content = fs.readFileSync(transcriptPath, "utf-8"); } catch { return null; }
@@ -194,19 +201,14 @@ export function buildInteractiveArgs(o: InteractiveArgsOpts): string[] {
   return args;
 }
 
-/**
- * Stringify a tool_input value from a hook payload into a truncated string
- * suitable for the `input` field on a StreamDelta (first `maxChars` chars).
- * Exported for unit testing; not part of the public engine API.
- */
-export function truncatedToolInput(toolInput: unknown, maxChars = 200): string {
-  const raw =
-    typeof toolInput === "object" && toolInput !== null
-      ? JSON.stringify(toolInput)
-      : typeof toolInput === "string"
-      ? toolInput
-      : "";
-  return raw.slice(0, maxChars);
+export function claudeHookToDeltas(h: Record<string, unknown>): StreamDelta[] {
+  if (h.hook_event_name !== "PostToolUse") return [];
+  const toolName = typeof h.tool_name === "string" ? h.tool_name : undefined;
+  return [{
+    type: "tool_result",
+    content: String(h.tool_name ?? ""),
+    toolName,
+  }];
 }
 
 /**
@@ -344,7 +346,7 @@ export class TurnResolver {
     // Native local commands (/usage, /limits, …) produce no new assistant
     // message; the Stop hook's last_assistant_message is the prior turn's stale
     // text. Settling with it would persist a duplicate chat echo — settle empty.
-    const text = this.opts.native ? "" : String(this.stopPayload.last_assistant_message ?? "");
+    const text = this.opts.native ? "" : stripReasoningBlocks(String(this.stopPayload.last_assistant_message ?? ""));
     this.settle({ sessionId: sid, result: text, error: undefined, numTurns: 1 });
   }
 
@@ -366,7 +368,7 @@ export class TurnResolver {
 
   completeRecovered(text: string, sessionId?: string): void {
     if (sessionId && !this.claudeSessionId) this.claudeSessionId = sessionId;
-    this.settle({ sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "", result: text, numTurns: 1 });
+    this.settle({ sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "", result: stripReasoningBlocks(text), numTurns: 1 });
   }
 
   /** Proof of life (SSE delta / tool hook) while a StopFailure is pending —
@@ -443,17 +445,17 @@ export function isNativeClaudeCommand(prompt: string): boolean {
   return first !== undefined && NATIVE_CLAUDE_COMMANDS.has(first);
 }
 
-/** Bracketed-paste `text` into a PTY then submit with CR after a 50ms beat.
+/** Bracketed-paste `text` into a PTY then submit with CR after a 150ms beat.
  *  Phase 0 finding: bracketed-paste does NOT neutralize a leading /, @, or ! —
  *  they still trigger the slash-command / mention / bash-mode handlers and the
  *  turn is never submitted. neutralizeForPaste() prepends a space for mentions,
  *  bash-mode, and jinn-skill slash commands, while letting engine-native commands
  *  (/compact, /clear, /model, …) pass through raw so the TUI actually runs them.
  *  Shared by injectPrompt() (warm-PTY first turn) and writeStdin() (raw WS input). */
-function pasteAndSubmit(proc: pty.IPty, text: string): void {
+export function pasteAndSubmit(proc: Pick<pty.IPty, "write">, text: string): void {
   const payload = neutralizeForPaste(text);
   proc.write(`\x1b[200~${payload}\x1b[201~`);
-  setTimeout(() => proc.write("\r"), 50);
+  setTimeout(() => proc.write("\r"), 150);
 }
 
 export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngine {
@@ -663,33 +665,15 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       // Register BEFORE spawning so a fast SessionStart is buffered+drained, not lost.
       this.hookRegistry.register(jinnSessionId, (h) => {
         resolver.onHook(h);
-        // tool_use markers + intermediate text now stream from the per-PTY SSE proxy
-        // (content_block_start / content_block_delta) in true order. The hook only
-        // supplies tool_result — the assistant SSE stream has no tool_result event
-        // (tools execute locally between assistant messages).
-        // PreToolUse fires just before the tool runs; the full input is assembled by
-        // then. Emit a second tool_use delta carrying a truncated input so the Talk
-        // whisper can distinguish delegate/search/card calls from generic Bash work.
+        // tool_use markers + intermediate text stream from the per-PTY SSE proxy
+        // in true order. The hook only supplies tool_result; SSE has no local tool
+        // completion event because tools execute between assistant messages.
         if (h.hook_event_name === "PreToolUse") {
           entry.activeTools += 1;
-          if (opts.onStream) {
-            opts.onStream({
-              type: "tool_use",
-              content: String(h.tool_name ?? ""),
-              toolName: typeof h.tool_name === "string" ? h.tool_name : undefined,
-              input: truncatedToolInput(h.tool_input),
-            });
-          }
         }
         if (h.hook_event_name === "PostToolUse") {
           entry.activeTools = Math.max(0, entry.activeTools - 1);
-          if (opts.onStream) {
-            opts.onStream({
-              type: "tool_result",
-              content: String(h.tool_name ?? ""),
-              toolName: typeof h.tool_name === "string" ? h.tool_name : undefined,
-            });
-          }
+          for (const delta of claudeHookToDeltas(h as Record<string, unknown>)) opts.onStream?.(delta);
         }
       });
 
@@ -808,7 +792,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       const recovered = recoveryPath ? lastAssistantTextFromTranscript(recoveryPath, turnStartedAt) : undefined;
       if (recovered) {
         logger.info(`Recovered ${recovered.length} chars of lost turn text for session ${jinnSessionId} from transcript (Stop hook missing)`);
-        result.result = recovered;
+        result.result = stripReasoningBlocks(recovered);
       }
     }
     // Map a StopFailure rate-limit into result.rateLimit so manager.ts's
@@ -1128,9 +1112,10 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       const text = String(h.last_assistant_message ?? "");
       const sid = typeof h.session_id === "string" ? h.session_id : "";
       this.cancelLateRecovery(jinnSessionId);
-      if (text.trim()) {
+      const safeText = stripReasoningBlocks(text);
+      if (safeText.trim()) {
         logger.info(`InteractiveClaudeEngine: late Stop superseded failed turn for ${jinnSessionId}`);
-        opts.onLateRecovery?.({ result: text, sessionId: sid });
+        opts.onLateRecovery?.({ result: safeText, sessionId: sid });
       } else {
         logger.info(`InteractiveClaudeEngine: late Stop with no text for ${jinnSessionId} — recovery abandoned`);
       }

--- a/packages/jinn/src/engines/grok.ts
+++ b/packages/jinn/src/engines/grok.ts
@@ -118,6 +118,11 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function isReasoningType(value: unknown): boolean {
+  const type = String(value ?? "").toLowerCase();
+  return type.includes("thought") || type.includes("thinking") || type.includes("reasoning") || type.includes("chain_of_thought");
+}
+
 function stringField(obj: Record<string, unknown>, keys: string[]): string | undefined {
   for (const key of keys) {
     const value = obj[key];
@@ -126,29 +131,41 @@ function stringField(obj: Record<string, unknown>, keys: string[]): string | und
   return undefined;
 }
 
+function stripReasoningMarkup(text: string): string {
+  return text
+    .replace(/<\s*(thinking|reasoning|thought)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, "");
+}
+
 function textFromContent(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") return stripReasoningMarkup(value);
   if (!Array.isArray(value)) return "";
   return value
     .map((block) => {
-      if (typeof block === "string") return block;
+      if (typeof block === "string") return stripReasoningMarkup(block);
       const b = asRecord(block);
       if (!b) return "";
-      const direct = stringField(b, ["text", "content", "value", "output"]);
-      if (direct) return direct;
+      if (isReasoningType(b.type) || isReasoningType(b.kind) || isReasoningType(b.role)) return "";
       const nested = asRecord(b.content);
-      if (nested) return stringField(nested, ["text", "content", "value", "output"]) ?? textFromContent(nested.content);
+      if (nested) {
+        if (isReasoningType(nested.type) || isReasoningType(nested.kind) || isReasoningType(nested.role)) return "";
+        const nestedDirect = stringField(nested, ["text", "content", "value", "output"]);
+        return nestedDirect ? stripReasoningMarkup(nestedDirect) : textFromContent(nested.content);
+      }
+      const direct = stringField(b, ["text", "content", "value", "output"]);
+      if (direct) return stripReasoningMarkup(direct);
       return Array.isArray(b.content) ? textFromContent(b.content) : "";
     })
     .join("");
 }
 
 function textFromUnknown(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (typeof value === "string") return stripReasoningMarkup(value);
   if (Array.isArray(value)) return textFromContent(value);
   const obj = asRecord(value);
   if (!obj) return "";
-  return stringField(obj, ["text", "content", "value", "output", "message"]) ?? textFromContent(obj.content);
+  if (isReasoningType(obj.type) || isReasoningType(obj.kind) || isReasoningType(obj.role)) return "";
+  const direct = stringField(obj, ["text", "content", "value", "output", "message"]);
+  return direct ? stripReasoningMarkup(direct) : textFromContent(obj.content);
 }
 
 function compactText(text: string, max = 500): string {
@@ -291,7 +308,7 @@ export function parseGrokJsonLine(line: string): GrokParsedLine | null {
         contextTokens,
       };
     }
-    if (updateType === "agent_thought_chunk") {
+    if (isReasoningType(updateType)) {
       // Raw model reasoning ("thought") must NEVER reach the UI — the payload can
       // contain chain-of-thought, <thinking> blocks, even draft answers. Drop it
       // entirely (no placeholder line): the pre-token spinner covers the reasoning
@@ -380,7 +397,7 @@ export function parseGrokJsonLine(line: string): GrokParsedLine | null {
     return { deltas: [{ type: "error", content: error }, ...deltas], sessionId, error, terminal: true };
   }
 
-  if (eventType === "thought") {
+  if (isReasoningType(eventType)) {
     // Raw reasoning chunk — never displayed (same contract as agent_thought_chunk).
     // Dropped entirely; no placeholder status line.
     return { deltas, sessionId, terminal, contextTokens };

--- a/packages/jinn/src/gateway/__tests__/streamed-blocks.test.ts
+++ b/packages/jinn/src/gateway/__tests__/streamed-blocks.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  resultAlreadyInStreamedBlocks,
+  shouldPreserveStreamedBlocks,
+} from "../streamed-blocks.js";
+
+describe("streamed block persistence", () => {
+  it("preserves interleaved progress and tool blocks for durable chat history", () => {
+    expect(
+      shouldPreserveStreamedBlocks({
+        quietPreempted: false,
+        streamedBlocks: [
+          { content: "PROGRESS-FIRST" },
+          { content: "Used Bash", toolCall: "Bash" },
+          { content: "PROGRESS-FINAL" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps plain text-only turns consolidated to the final assistant message", () => {
+    expect(
+      shouldPreserveStreamedBlocks({
+        quietPreempted: false,
+        streamedBlocks: [{ content: "just streaming text" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("drops streamed blocks from interrupted or superseded turns", () => {
+    expect(
+      shouldPreserveStreamedBlocks({
+        quietPreempted: true,
+        streamedBlocks: [
+          { content: "old progress" },
+          { content: "Using Bash", toolCall: "Bash" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes when the final result is already one streamed text block", () => {
+    expect(
+      resultAlreadyInStreamedBlocks("PROGRESS-FINAL", [
+        { content: "PROGRESS-FIRST" },
+        { content: "Used Bash", toolCall: "Bash" },
+        { content: "PROGRESS-FINAL" },
+      ]),
+    ).toBe(true);
+
+    expect(
+      resultAlreadyInStreamedBlocks("PROGRESS-FINAL", [
+        { content: "PROGRESS-FIRST" },
+        { content: "Used Bash", toolCall: "Bash" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("does not treat an earlier repeated progress block as the final answer", () => {
+    expect(
+      resultAlreadyInStreamedBlocks("same", [
+        { content: "same" },
+        { content: "Used Bash", toolCall: "Bash" },
+        { content: "different final" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("recognizes whole-turn results already represented by multiple streamed text blocks", () => {
+    expect(
+      resultAlreadyInStreamedBlocks("first final", [
+        { content: "first" },
+        { content: "Used Bash", toolCall: "Bash" },
+        { content: "final" },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -68,6 +68,7 @@ import { WhatsAppConnector } from "../connectors/whatsapp/index.js";
 import { handleFilesRequest, handleSessionAttachment, fileIdsToMedia, rehomeAttachmentsToSession, ensureFilesDir } from "./files.js";
 import { readJsonBody, readBodyRaw } from "./http-helpers.js";
 import { readJsonlTail } from "./jsonl-tail.js";
+import { resultAlreadyInStreamedBlocks, shouldPreserveStreamedBlocks } from "./streamed-blocks.js";
 import { notifyParentSession, notifyRateLimited, notifyRateLimitResumed, notifyDiscordChannel, notifyAttachedTalkSessions } from "../sessions/callbacks.js";
 import { loadInstances } from "../cli/instances.js";
 import { handleHookPost, isLoopback } from "./hook-endpoint.js";
@@ -2534,18 +2535,15 @@ async function runWebSession(
     const wasSuperseded = !wasInterrupted && isTurnSuperseded(currentSession.id, turnStartedAt);
     const quietPreempted = wasInterrupted || wasSuperseded;
 
-    // Turn settled. Most engines replace live partials with a single final
-    // assistant message. Antigravity's transcript is already interleaved text +
-    // tool rows, so preserve those blocks when tool cards were streamed. If the
-    // turn was preempted by a newer user message, drop stale partials/results so
-    // the old assistant answer cannot land after the new user bubble.
+    // Turn settled. Plain text-only turns collapse to a single final assistant
+    // message. Tool-bearing turns preserve their interleaved text/tool blocks so
+    // durable chat history still shows what happened between the first and final
+    // answer. If the turn was preempted by a newer user message, drop stale
+    // partials/results so the old assistant answer cannot land after the new user
+    // bubble.
     const streamedBlocks = getMessages(currentSession.id).filter((m) => m.partial);
-    const preserveStreamedBlocks =
-      !quietPreempted && currentSession.engine === "antigravity" && streamedBlocks.some((m) => !!m.toolCall);
-    const resultAlreadyPersisted =
-      preserveStreamedBlocks &&
-      !!result.result?.trim() &&
-      streamedBlocks.some((m) => !m.toolCall && m.content.trim() === result.result.trim());
+    const preserveStreamedBlocks = shouldPreserveStreamedBlocks({ quietPreempted, streamedBlocks });
+    const resultAlreadyPersisted = preserveStreamedBlocks && resultAlreadyInStreamedBlocks(result.result, streamedBlocks);
     if (preserveStreamedBlocks) finalizePartialMessages(currentSession.id);
     else deletePartialMessages(currentSession.id);
 

--- a/packages/jinn/src/gateway/streamed-blocks.ts
+++ b/packages/jinn/src/gateway/streamed-blocks.ts
@@ -1,0 +1,27 @@
+export interface StreamedBlockForPersistence {
+  content: string;
+  toolCall?: string;
+}
+
+export function shouldPreserveStreamedBlocks(args: {
+  quietPreempted: boolean;
+  streamedBlocks: StreamedBlockForPersistence[];
+}): boolean {
+  if (args.quietPreempted) return false;
+  return args.streamedBlocks.some((m) => !!m.toolCall);
+}
+
+export function resultAlreadyInStreamedBlocks(
+  result: string | null | undefined,
+  streamedBlocks: StreamedBlockForPersistence[],
+): boolean {
+  const normalize = (text: string) => text.replace(/\s+/g, " ").trim();
+  const resultKey = result ? normalize(result) : "";
+  if (!resultKey) return false;
+  const textBlocks = streamedBlocks
+    .filter((m) => !m.toolCall)
+    .map((m) => normalize(m.content))
+    .filter(Boolean);
+  if (textBlocks.at(-1) === resultKey) return true;
+  return normalize(textBlocks.join("\n\n")) === resultKey;
+}

--- a/packages/web/src/components/chat/__tests__/new-chat-employee-flow.test.ts
+++ b/packages/web/src/components/chat/__tests__/new-chat-employee-flow.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest'
  * Tests the logic for building session creation params based on employee selection.
  * This is the pure function extracted from ChatPane's handleSend.
  */
-import { buildNewSessionParams } from '../new-chat-helpers'
+import { buildNewSessionParams, resolveNewSessionSelector, shouldPersistNewSessionSelector } from '../new-chat-helpers'
 
 describe('buildNewSessionParams', () => {
   it('creates session without employee field when COO is selected (null)', () => {
@@ -94,5 +94,67 @@ describe('buildNewSessionParams', () => {
       selectedEmployee: 'content-lead',
     })
     expect(afterSwitch.employee).toBe('content-lead')
+  })
+})
+
+describe('resolveNewSessionSelector', () => {
+  it('uses selected employee engine, model, and effort defaults when the selector has not been manually changed', () => {
+    const selector = resolveNewSessionSelector({
+      selectedEmployee: {
+        name: 'research-lead',
+        engine: 'grok',
+        model: 'grok-build',
+        effortLevel: 'xhigh',
+      },
+      storedSelector: { engine: 'claude', model: 'opus', effortLevel: 'medium' },
+      currentSelector: { engine: 'claude', model: 'opus', effortLevel: 'medium' },
+      manuallyChanged: false,
+    })
+
+    expect(selector).toEqual({
+      engine: 'grok',
+      model: 'grok-build',
+      effortLevel: 'xhigh',
+    })
+  })
+
+  it('preserves the operator-selected engine, model, and effort after choosing an employee', () => {
+    const selector = resolveNewSessionSelector({
+      selectedEmployee: {
+        name: 'writer',
+        engine: 'claude',
+        model: 'opus',
+        effortLevel: 'high',
+      },
+      storedSelector: { engine: 'claude', model: 'opus', effortLevel: 'medium' },
+      currentSelector: { engine: 'codex', model: 'gpt-5.5', effortLevel: 'xhigh' },
+      manuallyChanged: true,
+    })
+
+    expect(selector).toEqual({
+      engine: 'codex',
+      model: 'gpt-5.5',
+      effortLevel: 'xhigh',
+    })
+  })
+
+  it('falls back to the stored selector for a direct COO chat', () => {
+    expect(resolveNewSessionSelector({
+      selectedEmployee: null,
+      storedSelector: { engine: 'codex', model: 'gpt-5.5', effortLevel: 'high' },
+      currentSelector: { engine: 'claude', model: 'opus' },
+      manuallyChanged: false,
+    })).toEqual({ engine: 'codex', model: 'gpt-5.5', effortLevel: 'high' })
+  })
+})
+
+describe('shouldPersistNewSessionSelector', () => {
+  it('persists direct-chat selectors and manual operator selections', () => {
+    expect(shouldPersistNewSessionSelector({ selectedEmployee: null, manuallyChanged: false })).toBe(true)
+    expect(shouldPersistNewSessionSelector({ selectedEmployee: 'writer', manuallyChanged: true })).toBe(true)
+  })
+
+  it('does not persist employee defaults as the next direct-chat selector', () => {
+    expect(shouldPersistNewSessionSelector({ selectedEmployee: 'writer', manuallyChanged: false })).toBe(false)
   })
 })

--- a/packages/web/src/components/chat/chat-pane.tsx
+++ b/packages/web/src/components/chat/chat-pane.tsx
@@ -13,7 +13,7 @@ import { useLiveSession } from '@/hooks/use-live-session'
 
 const CliTerminal = lazy(() => import('@/components/cli-terminal').then(m => ({ default: m.CliTerminal })))
 import type { CliTerminalHandle } from '@/components/cli-terminal'
-import { buildNewSessionParams } from '@/components/chat/new-chat-helpers'
+import { buildNewSessionParams, resolveNewSessionSelector, shouldPersistNewSessionSelector } from '@/components/chat/new-chat-helpers'
 import type { Employee } from '@/lib/api'
 import type { Message, MediaAttachment } from '@/lib/conversations'
 
@@ -185,6 +185,9 @@ export function ChatPane({
         displayName: emp.displayName,
         department: emp.department,
         rank: emp.rank,
+        engine: emp.engine,
+        model: emp.model,
+        effortLevel: emp.effortLevel,
       }))
     : []
   // Reset the employee picker when there is no session (the live read pipeline
@@ -195,6 +198,16 @@ export function ChatPane({
   // Engine/Model/Effort selector state (composer). Engine is editable on a new
   // chat only; model + effort are editable in existing chats too.
   const [selector, setSelector] = useState<SelectorValue>(() => readNewSessionSelector())
+  const selectorRef = useRef(selector)
+  const newSessionSelectorDirtyRef = useRef(false)
+  const previousSessionIdForSelectorRef = useRef(sessionId)
+  useEffect(() => { selectorRef.current = selector }, [selector])
+  useEffect(() => {
+    if (previousSessionIdForSelectorRef.current && !sessionId) {
+      newSessionSelectorDirtyRef.current = false
+    }
+    previousSessionIdForSelectorRef.current = sessionId
+  }, [sessionId])
   const [effortPendingNote, setEffortPendingNote] = useState(false)
   const [selectorError, setSelectorError] = useState<string | null>(null)
   const cliTerminalRef = useRef<CliTerminalHandle | null>(null)
@@ -206,7 +219,12 @@ export function ChatPane({
     const emp = selectedEmployee && Array.isArray(orgData?.employees)
       ? orgData.employees.find((e) => e.name === selectedEmployee)
       : undefined
-    setSelector(emp ? { engine: emp.engine, model: emp.model } : readNewSessionSelector())
+    setSelector(resolveNewSessionSelector({
+      selectedEmployee: emp ?? null,
+      storedSelector: readNewSessionSelector(),
+      currentSelector: selectorRef.current,
+      manuallyChanged: newSessionSelectorDirtyRef.current,
+    }))
     setEffortPendingNote(false)
     setSelectorError(null)
   }, [selectedEmployee, sessionId, orgData])
@@ -257,6 +275,7 @@ export function ChatPane({
           setSelectorError(err instanceof Error ? err.message : 'Model/effort update failed')
         })
     } else {
+      newSessionSelectorDirtyRef.current = true
       setSelector(next)
       setSelectorError(null)
       writeNewSessionSelector(next)
@@ -311,7 +330,9 @@ export function ChatPane({
           })
           if (viewMode === 'cli' && supportsCliPreference(selector.engine)) (params as Record<string, unknown>).mode = 'interactive'
           const session = (await api.createSession(params)) as Record<string, unknown>
-          writeNewSessionSelector(selector)
+          if (shouldPersistNewSessionSelector({ selectedEmployee, manuallyChanged: newSessionSelectorDirtyRef.current })) {
+            writeNewSessionSelector(selector)
+          }
           sid = String(session.id)
           onSessionCreated?.(sid, userMsg)
           onRefresh?.()

--- a/packages/web/src/components/chat/new-chat-helpers.ts
+++ b/packages/web/src/components/chat/new-chat-helpers.ts
@@ -1,3 +1,59 @@
+export interface NewSessionSelectorValue {
+  engine?: string
+  model?: string
+  effortLevel?: string
+}
+
+export interface NewSessionEmployeeDefaults {
+  name: string
+  engine?: string | null
+  model?: string | null
+  effortLevel?: string | null
+}
+
+function cleanSelector(value: NewSessionSelectorValue | undefined): NewSessionSelectorValue {
+  const clean = (v: string | null | undefined) => {
+    const t = typeof v === 'string' ? v.trim() : ''
+    return t ? t : undefined
+  }
+  return {
+    engine: clean(value?.engine),
+    model: clean(value?.model),
+    effortLevel: clean(value?.effortLevel),
+  }
+}
+
+/**
+ * Resolve the selector shown/sent for a new chat.
+ *
+ * Employee config is the default only while the operator has not manually picked
+ * a model/effort in the current composer. Once they do, that explicit choice
+ * wins even if they later choose a non-COO employee.
+ */
+export function resolveNewSessionSelector(opts: {
+  selectedEmployee?: NewSessionEmployeeDefaults | null
+  storedSelector?: NewSessionSelectorValue
+  currentSelector?: NewSessionSelectorValue
+  manuallyChanged: boolean
+}): NewSessionSelectorValue {
+  if (opts.manuallyChanged) return cleanSelector(opts.currentSelector)
+  if (opts.selectedEmployee) {
+    return cleanSelector({
+      engine: opts.selectedEmployee.engine ?? undefined,
+      model: opts.selectedEmployee.model ?? undefined,
+      effortLevel: opts.selectedEmployee.effortLevel ?? undefined,
+    })
+  }
+  return cleanSelector(opts.storedSelector)
+}
+
+export function shouldPersistNewSessionSelector(opts: {
+  selectedEmployee?: string | null
+  manuallyChanged: boolean
+}): boolean {
+  return !opts.selectedEmployee || opts.manuallyChanged
+}
+
 /**
  * Build the params object for creating a new session via POST /api/sessions.
  * When an employee is selected, include the employee field.

--- a/packages/web/src/hooks/__tests__/use-live-session.test.ts
+++ b/packages/web/src/hooks/__tests__/use-live-session.test.ts
@@ -99,6 +99,34 @@ describe("useLiveSession (read-only)", () => {
     expect(result.current.messages.filter((m) => m.toolCall === "read")).toHaveLength(1)
   })
 
+  it("keeps visible progress around a tool call instead of collapsing to only the final answer", async () => {
+    getSession.mockResolvedValue({ status: "running", messages: [] })
+    const { subscribe, emit } = makeBus()
+    const { result } = renderHook(() =>
+      useLiveSession("s1", { subscribe, readOnly: true }),
+    )
+    await act(async () => { await Promise.resolve() })
+
+    act(() => {
+      emit("session:delta", { sessionId: "s1", type: "text", content: "PROGRESS-FIRST" })
+      emit("session:delta", { sessionId: "s1", type: "tool_use", content: "Using Bash", toolName: "Bash" })
+      emit("session:delta", { sessionId: "s1", type: "tool_result", content: "TOOL-CALL-OK", toolName: "Bash" })
+      emit("session:delta", { sessionId: "s1", type: "text", content: "PROGRESS-FINAL" })
+    })
+
+    await act(async () => {
+      emit("session:completed", { sessionId: "s1", result: "PROGRESS-FINAL" })
+      await Promise.resolve()
+    })
+
+    expect(result.current.messages.map((m) => m.content)).toEqual([
+      "PROGRESS-FIRST",
+      "Used Bash",
+      "PROGRESS-FINAL",
+    ])
+    expect(result.current.messages[1]?.toolCall).toBe("Bash")
+  })
+
   it("shows transient status deltas and clears them when real output arrives", async () => {
     getSession.mockResolvedValue({ status: "running", messages: [] })
     const { subscribe, emit } = makeBus()
@@ -240,6 +268,40 @@ describe("useLiveSession (editable write path)", () => {
     expect(result.current.loading).toBe(false)
     expect(result.current.streamingText).toBe("")
     expect(result.current.messages.map((m) => m.content)).toEqual(["do it", "Done."])
+  })
+
+  it("does not remove an older identical assistant answer when a later turn completes", async () => {
+    getSession.mockResolvedValue({
+      status: "idle",
+      messages: [
+        { id: "u-old", role: "user", content: "old question", timestamp: 1 },
+        { id: "a-old", role: "assistant", content: "Done.", timestamp: 2 },
+      ],
+    })
+    const { subscribe, emit } = makeBus()
+    const { result } = renderHook(() => useLiveSession("s1", { subscribe }))
+    await act(async () => { await Promise.resolve() })
+
+    act(() => {
+      result.current.beginSend({
+        id: "u-new",
+        role: "user",
+        content: "new question",
+        timestamp: 3,
+      })
+    })
+
+    await act(async () => {
+      emit("session:completed", { sessionId: "s1", result: "Done." })
+      await Promise.resolve()
+    })
+
+    expect(result.current.messages.map((m) => m.content)).toEqual([
+      "old question",
+      "Done.",
+      "new question",
+      "Done.",
+    ])
   })
 
   it("seeds backgroundActivity from the session fetch and clears it on session switch", async () => {

--- a/packages/web/src/hooks/use-live-session.ts
+++ b/packages/web/src/hooks/use-live-session.ts
@@ -321,6 +321,7 @@ export function useLiveSession(
 
       if (event === 'session:completed') {
         clearStatusMessage()
+        const intermediateStart = intermediateStartRef.current
         streamingTextRef.current = ''
         setStreamingText('')
         setLoading(false)
@@ -338,14 +339,15 @@ export function useLiveSession(
           const resultKey = resultStr.trim()
           setMessages((prev) => {
             const cleaned = [...prev]
+            const turnStart = intermediateStart >= 0 ? Math.min(intermediateStart, cleaned.length) : cleaned.length
             // Reconcile the canonical result with any text already on screen, by
             // identity — Grok streams its answer text live, and a transcript
             // `tool_use` that lands AFTER the streamed answer freezes that text into
             // a permanent assistant bubble (via the tool_use handler above). Without
-            // this dedupe the same answer would render twice. Scan from the tail and
-            // drop an identical non-tool assistant bubble before appending the result.
+            // this dedupe the same answer would render twice. Only scan the current
+            // turn's live/intermediate range so older identical answers survive.
             if (resultKey) {
-              for (let i = cleaned.length - 1; i >= 0; i--) {
+              for (let i = cleaned.length - 1; i >= turnStart; i--) {
                 const m = cleaned[i]
                 if (
                   m.role === 'assistant' &&
@@ -362,7 +364,13 @@ export function useLiveSession(
             // Pop a trailing optimistic streaming-text bubble so the canonical result
             // replaces it, but NEVER pop an attachment (media) message — it's already
             // persisted and would otherwise vanish until reload.
-            if (last && last.role === 'assistant' && !last.toolCall && !(last.media && last.media.length > 0)) {
+            if (
+              cleaned.length - 1 >= turnStart &&
+              last &&
+              last.role === 'assistant' &&
+              !last.toolCall &&
+              !(last.media && last.media.length > 0)
+            ) {
               cleaned.pop()
             }
             return [


### PR DESCRIPTION
## Summary

Fixes a set of Chat Mode regressions around Claude/Grok streaming, attachment submission, employee selector defaults, and false error state from Claude sub-agent failures.

## What Changed

- Preserve durable interleaved progress/tool/final blocks for tool-bearing turns instead of collapsing them into only the final message.
- Narrow final-result dedupe so it only removes current-turn duplicates and does not delete older identical assistant messages.
- Strip Claude and Grok reasoning/thinking markup from final/recovered output and nested Grok content wrappers.
- Avoid duplicate Claude tool cards by letting SSE own `tool_use` and hooks own `tool_result`.
- Make image/multiline prompt submission less racy in interactive Claude by delaying submit after bracketed paste.
- Respect operator-selected engine/model/effort when picking an employee, while still using employee defaults when the selector has not been manually changed.
- Defer non-hard Claude `StopFailure` handling while upstream sub-agent work is still active, so one sub-agent API/safety failure does not mark the whole Chat Mode session errored while Claude continues.

## Root Cause

Chat Mode was treating some live/intermediate engine state as final session state:

- Text/tool streams were not preserved generally enough for non-Antigravity engines.
- Final dedupe scanned too broadly in the frontend and could touch prior turns.
- Claude hook/SSE paths duplicated tool markers.
- Claude `StopFailure` could settle a web session as failed even though the interactive CLI still had active sub-agent upstream work and could later complete normally.

## Verification

- `pnpm --filter jinn-cli test` passed: 947 passed, 1 skipped.
- `pnpm --filter jinn-cli typecheck` passed.
- `pnpm --filter @jinn/web typecheck` passed.
- Targeted web tests passed: 574 tests.
- `pnpm build` passed.
- `git diff --check` passed.
- Privacy scan on changed files returned no matches.
- Sandbox manual/API check confirmed first progress text, exactly one Bash tool row, final progress text, and no hidden reasoning markers in assistant rows.