### PR TITLE
Separate adjacent Codex text blocks

### DIFF
--- a/packages/jinn/src/engines/__tests__/codex.test.ts
+++ b/packages/jinn/src/engines/__tests__/codex.test.ts
@@ -223,6 +223,18 @@ describe("CodexEngine — final result assembly (last agent_message wins, NOT co
     expect(result.result).not.toContain("intermediate");
   });
 
+  it("separates adjacent live agent_message blocks without changing the final result", async () => {
+    const { result, deltas } = await runWith({}, [
+      threadStarted("t1"),
+      agentMessage("First block."),
+      agentMessage("Second block."),
+    ]);
+
+    const liveText = deltas.filter((d) => d.type === "text").map((d) => d.content).join("");
+    expect(liveText).toBe("First block.\n\nSecond block.");
+    expect(result.result).toBe("Second block.");
+  });
+
   it("flushes a trailing agent_message that arrives without a newline (close-time lineBuf)", async () => {
     const { result } = await runWith(
       {},

--- a/packages/jinn/src/engines/codex.ts
+++ b/packages/jinn/src/engines/codex.ts
@@ -187,11 +187,22 @@ export class CodexEngine implements InterruptibleEngine {
       let hardTimeout: NodeJS.Timeout | undefined;
       let terminalSettleTimer: NodeJS.Timeout | undefined;
       const onStream = opts.onStream || null;
+      let lastStreamedTextBlock: string | null = null;
       const STDERR_MAX = 10 * 1024; // 10KB rolling window for error reporting
 
       const clearTimers = () => {
         if (hardTimeout) { clearTimeout(hardTimeout); hardTimeout = undefined; }
         if (terminalSettleTimer) { clearTimeout(terminalSettleTimer); terminalSettleTimer = undefined; }
+      };
+      const resetTextBlockRun = () => { lastStreamedTextBlock = null; };
+      const streamTextBlock = (delta: StreamDelta) => {
+        if (!onStream) return;
+        const needsBoundary =
+          lastStreamedTextBlock !== null &&
+          !lastStreamedTextBlock.endsWith("\n") &&
+          !delta.content.startsWith("\n");
+        onStream(needsBoundary ? { ...delta, content: `\n\n${delta.content}` } : delta);
+        lastStreamedTextBlock = delta.content;
       };
 
       // Settle the turn on codex's parsed terminal event (`turn.completed` →
@@ -266,29 +277,35 @@ export class CodexEngine implements InterruptibleEngine {
               logger.info(`Codex session got thread ID: ${threadId}`);
               break;
             case "tool_start":
+              resetTextBlockRun();
               if (onStream) onStream(parsed.delta);
               break;
             case "tool_end":
+              resetTextBlockRun();
               if (onStream) onStream(parsed.delta);
               break;
             case "text":
               // Each agent_message item is a COMPLETE assistant message; codex emits
               // several per turn (preamble + final). The result must be the FINAL
               // message, not all of them concatenated — so replace, don't append.
-              // Live streaming of each block is unaffected (onStream below).
+              // Adjacent live blocks need a paragraph boundary because the web UI
+              // appends text deltas like chunks.
               resultText = parsed.delta.content;
-              if (onStream) onStream(parsed.delta);
+              streamTextBlock(parsed.delta);
               break;
             case "error":
+              resetTextBlockRun();
               turnError = parsed.message;
               if (onStream) onStream({ type: "error", content: parsed.message });
               break;
             case "usage":
+              resetTextBlockRun();
               numTurns++;
               if (parsed.contextTokens) lastContextTokens = parsed.contextTokens;
               scheduleTerminalSettle(); // turn.completed = end of turn
               break;
             case "turn_failed":
+              resetTextBlockRun();
               turnError = parsed.message;
               if (onStream) onStream({ type: "error", content: parsed.message });
               scheduleTerminalSettle(); // turn.failed = end of turn


### PR DESCRIPTION
## Summary
- add a Codex regression test for adjacent `agent_message` text blocks
- insert a live-stream paragraph boundary only between adjacent Codex text blocks
- keep final result assembly unchanged: the final Codex `agent_message` still wins

## Root cause
Codex headless emits each `agent_message` as a complete assistant text block, while the chat UI appends `text` deltas as chunks. When Codex emitted two adjacent text blocks with no tool event between them, the live UI rendered them as `sentence1.sentence2`.

## Verification
- pnpm --dir packages/jinn exec vitest run src/engines/__tests__/codex.test.ts -t "separates adjacent live agent_message blocks"
- pnpm --dir packages/jinn exec vitest run src/engines/__tests__/codex.test.ts
- pnpm --filter jinn-cli test
- pnpm --filter jinn-cli typecheck
- pnpm --filter jinn-cli build
- git diff --check
- privacy grep on diff