### PR TITLE
Honor employee session defaults

### DIFF
--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -1027,11 +1027,21 @@ export async function handleApiRequest(
       const prompt = body.prompt || body.message;
       if (!prompt) return badRequest(res, "prompt or message is required");
       const config = context.getConfig();
+      const employeeName = coercePortalEmployee(body.employee, config.portal?.portalName);
+      let employeeDefaults: { engine: string; model: string; effortLevel?: string } | undefined;
+      if (employeeName) {
+        const { scanOrg } = await import("./org.js");
+        const emp = scanOrg().get(employeeName);
+        if (emp) {
+          employeeDefaults = { engine: emp.engine, model: emp.model };
+          if (emp.effortLevel) employeeDefaults.effortLevel = emp.effortLevel;
+        }
+      }
       const selection = validateNewSessionSelection(config, {
         engine: body.engine,
         model: body.model,
         effortLevel: body.effortLevel,
-      });
+      }, employeeDefaults);
       if (!selection.ok) return badRequest(res, selection.error || "invalid engine/model/effort");
       const engineName = selection.engine || config.engines.default;
       const sessionKey = `web:${Date.now()}`;
@@ -1051,7 +1061,7 @@ export async function handleApiRequest(
         // pseudo-employee (there is no org employee by the portal's name).
         // Coerce it to null so it buckets into the direct group rather than
         // spawning a phantom group that renders with the portal's own title.
-        employee: coercePortalEmployee(body.employee, config.portal?.portalName),
+        employee: employeeName,
         parentSessionId: body.parentSessionId,
         effortLevel: selection.effortLevel,
         // Honor body.model so API clients can pin per-employee models

--- a/packages/jinn/src/sessions/__tests__/session-patch.test.ts
+++ b/packages/jinn/src/sessions/__tests__/session-patch.test.ts
@@ -53,6 +53,34 @@ describe("validateNewSessionSelection", () => {
     });
   });
 
+  it("uses employee engine/model/effort defaults when the request only names an employee", () => {
+    const r = validateNewSessionSelection(
+      cfg(),
+      {},
+      { engine: "claude", model: "claude-sonnet-4-6", effortLevel: "high" },
+    );
+    expect(r).toEqual({
+      ok: true,
+      engine: "claude",
+      model: "claude-sonnet-4-6",
+      effortLevel: "high",
+    });
+  });
+
+  it("lets explicit request values override employee defaults", () => {
+    const r = validateNewSessionSelection(
+      cfg(),
+      { model: "opus", effortLevel: "medium" },
+      { engine: "claude", model: "claude-sonnet-4-6", effortLevel: "high" },
+    );
+    expect(r).toEqual({
+      ok: true,
+      engine: "claude",
+      model: "opus",
+      effortLevel: "medium",
+    });
+  });
+
   it("rejects an unknown engine before persisting a session", () => {
     const r = validateNewSessionSelection(cfg(), { engine: "not-real", model: "opus" });
     expect(r.ok).toBe(false);

--- a/packages/jinn/src/sessions/manager.ts
+++ b/packages/jinn/src/sessions/manager.ts
@@ -159,6 +159,7 @@ export class SessionManager {
         transportMeta: msg.transportMeta,
         employee: opts.employee?.name ?? undefined,
         model: opts.model ?? opts.employee?.model ?? undefined,
+        effortLevel: opts.employee?.effortLevel ?? undefined,
         title: opts.title,
         prompt: msg.text,
         portalName: this.config.portal?.portalName,

--- a/packages/jinn/src/sessions/session-patch.ts
+++ b/packages/jinn/src/sessions/session-patch.ts
@@ -36,9 +36,10 @@ export interface SessionPatchContext {
 export function validateNewSessionSelection(
   config: JinnConfig,
   body: { engine?: unknown; model?: unknown; effortLevel?: unknown },
+  defaults: { engine?: string; model?: string; effortLevel?: string } = {},
 ): NewSessionSelectionResult {
   const registry = getModelRegistry(config);
-  let engine: string = config.engines.default;
+  let engine: string = defaults.engine?.trim() || config.engines.default;
 
   if (body.engine !== undefined) {
     if (typeof body.engine !== "string" || !body.engine.trim()) {
@@ -51,11 +52,12 @@ export function validateNewSessionSelection(
   if (!entry) return { ok: false, error: `unknown engine "${engine}"` };
 
   let model: string | undefined;
-  if (body.model !== undefined) {
-    if (typeof body.model !== "string" || !body.model.trim()) {
+  const requestedModel = body.model !== undefined ? body.model : defaults.model;
+  if (requestedModel !== undefined) {
+    if (typeof requestedModel !== "string" || !requestedModel.trim()) {
       return { ok: false, error: "model must be a non-empty string" };
     }
-    model = body.model.trim();
+    model = requestedModel.trim();
     if (!entry.models.some((m) => m.id === model)) {
       if (engine === "pi") {
         // Pi models are discovered dynamically; tolerate an id the snapshot hasn't
@@ -69,11 +71,12 @@ export function validateNewSessionSelection(
   }
 
   let effortLevel: string | undefined;
-  if (body.effortLevel !== undefined) {
-    if (typeof body.effortLevel !== "string" || !body.effortLevel.trim()) {
+  const requestedEffortLevel = body.effortLevel !== undefined ? body.effortLevel : defaults.effortLevel;
+  if (requestedEffortLevel !== undefined) {
+    if (typeof requestedEffortLevel !== "string" || !requestedEffortLevel.trim()) {
       return { ok: false, error: "effortLevel must be a non-empty string" };
     }
-    effortLevel = body.effortLevel.trim();
+    effortLevel = requestedEffortLevel.trim();
     const effectiveModel = model ?? undefined;
     const valid = effortLevelsForModel(config, engine, effectiveModel);
     if (valid.length === 0) {


### PR DESCRIPTION
## Summary
- use employee org defaults for new session engine/model/effort when the request only names an employee
- keep explicit request engine/model/effort values higher priority than employee defaults
- persist employee effortLevel for connector-routed employee sessions

## Root cause
Parent-spawned child sessions often call `POST /api/sessions` with only `employee`. The API persisted the employee name, but validated only raw request engine/model/effort fields, leaving model and effort null. Execution then fell back to engine defaults such as Claude Opus / Medium instead of the employee YAML defaults.

## Verification
- pnpm --dir packages/jinn exec vitest run src/sessions/__tests__/session-patch.test.ts -t "employee"
- pnpm --filter jinn-cli test
- pnpm --filter jinn-cli typecheck
- pnpm --filter jinn-cli build
- git diff --check
- privacy grep on diff