### PR TITLE
Fix chat final history partial cleanup

### DIFF
--- a/packages/jinn/src/gateway/__tests__/streamed-blocks.test.ts
+++ b/packages/jinn/src/gateway/__tests__/streamed-blocks.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../streamed-blocks.js";
 
 describe("streamed block persistence", () => {
-  it("preserves interleaved progress and tool blocks for durable chat history", () => {
+  it("keeps tool-bearing turns consolidated to the final assistant message", () => {
     expect(
       shouldPreserveStreamedBlocks({
         quietPreempted: false,
@@ -15,7 +15,7 @@ describe("streamed block persistence", () => {
           { content: "PROGRESS-FINAL" },
         ],
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("keeps plain text-only turns consolidated to the final assistant message", () => {

--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -2730,12 +2730,10 @@ async function runWebSession(
     const wasSuperseded = !wasInterrupted && isTurnSuperseded(currentSession.id, turnStartedAt);
     const quietPreempted = wasInterrupted || wasSuperseded;
 
-    // Turn settled. Plain text-only turns collapse to a single final assistant
-    // message. Tool-bearing turns preserve their interleaved text/tool blocks so
-    // durable chat history still shows what happened between the first and final
-    // answer. If the turn was preempted by a newer user message, drop stale
-    // partials/results so the old assistant answer cannot land after the new user
-    // bubble.
+    // Turn settled. Mid-turn rows are refresh-only, including tool rows: durable
+    // chat history collapses to the final assistant message. If the turn was
+    // preempted by a newer user message, drop stale partials/results so the old
+    // assistant answer cannot land after the new user bubble.
     const streamedBlocks = getMessages(currentSession.id).filter((m) => m.partial);
     const finalBlocksById = new Map<string, ChatBlock>();
     for (const message of streamedBlocks) {

--- a/packages/jinn/src/gateway/streamed-blocks.ts
+++ b/packages/jinn/src/gateway/streamed-blocks.ts
@@ -3,12 +3,13 @@ export interface StreamedBlockForPersistence {
   toolCall?: string;
 }
 
-export function shouldPreserveStreamedBlocks(args: {
+export function shouldPreserveStreamedBlocks(_args: {
   quietPreempted: boolean;
   streamedBlocks: StreamedBlockForPersistence[];
 }): boolean {
-  if (args.quietPreempted) return false;
-  return args.streamedBlocks.some((m) => !!m.toolCall);
+  // Partial stream rows are a refresh cache only. Durable history is the final
+  // assistant message, regardless of whether tools were used mid-turn.
+  return false;
 }
 
 export function resultAlreadyInStreamedBlocks(


### PR DESCRIPTION
## Summary

- Fixes chat history finalization so mid-turn text/tool rows stay refresh-only.
- Prevents tool-bearing turns from converting partial rows into durable SQLite history.
- Updates the regression test to assert tool-call turns collapse to the final assistant message.

## Root cause

`shouldPreserveStreamedBlocks()` returned true for any streamed tool call, which made `runWebSession` call `finalizePartialMessages()` instead of deleting partial rows at turn completion.

## Verification

- `pnpm --dir packages/jinn exec vitest run src/gateway/__tests__/streamed-blocks.test.ts src/sessions/__tests__/messages-partial.test.ts src/gateway/__tests__/block-finalize.test.ts src/sessions/__tests__/registry-search-messages.test.ts`
- `pnpm --dir packages/jinn exec vitest run`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- branch diff leak-grep clean
