### PR TITLE
fix(web): messages disappear from chat after turns in long sessions (stale turn-start index)

### DIFF
--- a/packages/web/src/hooks/use-live-session.ts
+++ b/packages/web/src/hooks/use-live-session.ts
@@ -1054,15 +1054,25 @@ export function useLiveSession(
         // The server now persists mid-turn partial blocks, so the backend snapshot
         // already carries in-progress output — no localStorage replay needed. This is
         // what makes a mid-turn refresh restore the streamed blocks on any device.
-        intermediateStartRef.current = firstPartialIndex >= 0 ? firstPartialIndex : backendMessages.length
+        // The turn-start marker must be an index into the array actually rendered,
+        // not the (possibly ≤150-row) server snapshot — anchor it by message id and
+        // remap it inside the updater against whichever array we return. Otherwise a
+        // snapshot-space index truncates already-rendered history at turn completion.
+        const turnStartAnchorId = firstPartialIndex >= 0 ? backendMessages[firstPartialIndex].id : null
         setMessages((current) => {
           // If the tail snapshot is stale and misses newer live rows, keep current.
           // Older already-loaded rows are still preserved by mergePagedSnapshot.
           if (backendMessages.length < current.length && hasUnmergedLocalTail(current, backendMessages)) {
+            const anchorIdx = turnStartAnchorId ? current.findIndex((m) => m.id === turnStartAnchorId) : -1
+            if (anchorIdx >= 0) intermediateStartRef.current = anchorIdx
+            else if (intermediateStartRef.current < 0) intermediateStartRef.current = current.length
             return current
           }
           const next = backendMessages.length > 0 ? backendMessages : current
-          return mergePagedSnapshot(current, next, isPagedHistory)
+          const merged = mergePagedSnapshot(current, next, isPagedHistory)
+          const anchorIdx = turnStartAnchorId ? merged.findIndex((m) => m.id === turnStartAnchorId) : -1
+          intermediateStartRef.current = anchorIdx >= 0 ? anchorIdx : merged.length
+          return merged
         })
         // Loading state is owned by handleSend (sets true) + WS session:completed/stopped (sets false).
         // loadSession must NEVER set loading=true — a stale GET arriving after completion would


### PR DESCRIPTION
## Symptom

In sessions longer than the paged snapshot window (150 messages), previously rendered messages — both user and assistant, including media — disappear from the chat pane when a turn completes. The newest message often reappears on the next snapshot; older rows stay hidden until scroll-up paging. Nothing is lost in the DB; it is purely a client render bug.

## Root cause

`use-live-session.ts` tracks the current turn's start via `intermediateStartRef`. A reload effect fires `loadSession` shortly into every turn, and its running branch set:

```ts
intermediateStartRef.current = firstPartialIndex >= 0 ? firstPartialIndex : backendMessages.length
```

`firstPartialIndex`/`backendMessages.length` are indices into the **newest-150 snapshot**, but the ref is later applied to the **full rendered list** (which `mergePagedSnapshot` deliberately grows past 150 by keeping older rows). On `session:completed`, the handler does `list.slice(0, turnStart)` + re-appends media/tail — with the stale snapshot-space index this deletes the newest ~N rendered messages every turn completion (media rows survive the slice but get re-ordered to the bottom, which is why images appear to move).

Repro conditions: any session with >150 messages + streaming turns. Engine restarts amplify it (more rows slide the window faster) but are not the trigger.

## Fix

Anchor the turn start by **message id** instead of snapshot index: capture `backendMessages[firstPartialIndex].id` and remap it inside the `setMessages` updater via `findIndex` against whichever array is actually returned (merged or kept-current), falling back to `merged.length`. One file, +12/−2.

Verified on a 350-message live session: turn completions no longer truncate the rendered list; media rows stay in place. `tsc --noEmit` clean on the touched file (the 5 pre-existing repo errors are unrelated missing `@testing-library/user-event` types in tests).