### PR TITLE
fix(cli): restore node-pty Darwin helper modes after install

### DIFF
--- a/packages/jinn/package.json
+++ b/packages/jinn/package.json
@@ -15,9 +15,11 @@
   "files": [
     "dist/",
     "template/",
-    "assets/"
+    "assets/",
+    "scripts/fix-node-pty-permissions.mjs"
   ],
   "scripts": {
+    "postinstall": "node scripts/fix-node-pty-permissions.mjs",
     "build": "rm -rf dist/bin dist/src && tsc -p tsconfig.build.json && mkdir -p dist/src/talk && (cp src/talk/*.md src/talk/*.py dist/src/talk/ 2>/dev/null || true)",
     "dev": "tsc && (tsc --watch &) && node --watch-path=dist dist/bin/jinn.js start",
     "typecheck": "tsc --noEmit",

--- a/packages/jinn/scripts/fix-node-pty-permissions.mjs
+++ b/packages/jinn/scripts/fix-node-pty-permissions.mjs
@@ -1,0 +1,44 @@
+import { chmod, readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+if (process.platform !== "darwin") {
+  process.exit(0);
+}
+
+const require = createRequire(import.meta.url);
+let nodePtyRoot;
+try {
+  nodePtyRoot = dirname(require.resolve("node-pty/package.json"));
+} catch (error) {
+  throw new Error("jinn-cli postinstall could not resolve node-pty/package.json", { cause: error });
+}
+
+async function fixPrebuilds(nodePtyRoot) {
+  let platforms;
+  try {
+    platforms = await readdir(join(nodePtyRoot, "prebuilds"), {
+      withFileTypes: true,
+    });
+  } catch (error) {
+    throw new Error(`jinn-cli postinstall could not read node-pty prebuilds at ${nodePtyRoot}`, { cause: error });
+  }
+
+  const darwinPrebuilds = platforms.filter(
+    (platform) => platform.isDirectory() && platform.name.startsWith("darwin-"),
+  );
+  if (darwinPrebuilds.length === 0) {
+    throw new Error(`jinn-cli postinstall found no Darwin node-pty prebuilds at ${nodePtyRoot}`);
+  }
+
+  await Promise.all(darwinPrebuilds.map(async (platform) => {
+    const helper = join(nodePtyRoot, "prebuilds", platform.name, "spawn-helper");
+    try {
+      await chmod(helper, 0o755);
+    } catch (error) {
+      throw new Error(`jinn-cli postinstall could not chmod node-pty helper ${helper}`, { cause: error });
+    }
+  }));
+}
+
+await fixPrebuilds(nodePtyRoot);


### PR DESCRIPTION
This fixes an issue where every time i restarted the gateway, my Claude engine wouldn't work. I'd have to reconnect the Claude engine. Codex was working fine after restarts for me because i am using a headless codex. this should ensure that Claude will continue working even after gateway restarts. 

Fixes macOS npm installs that leave node-pty spawn helpers non-executable. The postinstall resolves node-pty from the installed CLI context, chmods Darwin helpers, and fails explicitly on resolution/prebuild/helper errors.

Validation: typecheck + build; packed fresh hoisted install observed 0644 before, 0755 after; node-pty spawn(`/bin/echo`, [`PTY_OK`]) passed.