### PR TITLE
fix(claude): warn when a model's real context window is smaller than configured

### DIFF
--- a/packages/jinn/src/cli/__tests__/setup-template.test.ts
+++ b/packages/jinn/src/cli/__tests__/setup-template.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+
+/** The default config is a template string, so a YAML mistake in it is invisible
+ *  until a user runs `jinn setup` and their install is broken. Model ids
+ *  containing "[" (the 1M-context variants) are the sharp edge: "[" is a YAML
+ *  indicator, so an unquoted opus[1m] parses fine in block style and throws in
+ *  flow style — which is what the template uses. */
+const setupSrc = fs.readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "../setup.ts"),
+  "utf8",
+);
+
+/** Pull DEFAULT_CONFIG out of the source and neutralise its one interpolation. */
+function defaultConfigYaml(): string {
+  const m = /const DEFAULT_CONFIG = `([\s\S]*?)`;/.exec(setupSrc);
+  if (!m) throw new Error("DEFAULT_CONFIG template literal not found in setup.ts");
+  return m[1].replace(/\$\{getPackageVersion\(\)\}/g, "0.0.0-test");
+}
+
+describe("setup.ts DEFAULT_CONFIG", () => {
+  it("is valid YAML", () => {
+    expect(() => YAML.parse(defaultConfigYaml())).not.toThrow();
+  });
+
+  it("parses every model id as a plain string", () => {
+    const cfg = YAML.parse(defaultConfigYaml()) as {
+      models: Record<string, { models: { id: unknown; label: unknown }[] }>;
+    };
+    for (const [engine, block] of Object.entries(cfg.models ?? {})) {
+      for (const m of block.models ?? []) {
+        expect(typeof m.id, `${engine} model id ${JSON.stringify(m.id)} must be a string`).toBe("string");
+        expect(String(m.id).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("keeps bracketed ids intact — an unquoted [1m] would parse as a sequence", () => {
+    const cfg = YAML.parse(defaultConfigYaml()) as {
+      models: Record<string, { models: { id: string }[] }>;
+    };
+    const ids = cfg.models.claude.models.map((m) => m.id);
+    for (const id of ["opus[1m]", "sonnet[1m]"]) {
+      expect(ids, `${id} must survive parsing verbatim`).toContain(id);
+    }
+  });
+
+  it("every engine default names a model present in that engine's roster", () => {
+    const cfg = YAML.parse(defaultConfigYaml()) as {
+      models: Record<string, { default: string; models: { id: string }[] }>;
+    };
+    for (const [engine, block] of Object.entries(cfg.models ?? {})) {
+      if (!block?.default) continue;
+      expect(block.models.map((m) => m.id), `${engine} default must exist in its roster`).toContain(block.default);
+    }
+  });
+});

--- a/packages/jinn/src/cli/setup.ts
+++ b/packages/jinn/src/cli/setup.ts
@@ -260,9 +260,20 @@ models:
     default: opus
     effortMechanism: claude-flag
     models:
+      # Bare aliases (opus/sonnet) run Claude Code's standard context window.
+      # The "[1m]" variants request the 1M-token window and are separate model
+      # ids, not a flag — "opus" and "opus[1m]" are different models to the CLI.
+      # Pick a [1m] entry if you run large personas or long agentic sessions;
+      # a big injected system prompt against the standard window compacts early
+      # and can thrash. Leave contextWindow unset unless you have measured it:
+      # a declared window that the engine does not honour is worse than none,
+      # and the gateway warns when observed context never approaches it.
       - { id: opus, label: "Opus (Latest)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
       - { id: sonnet, label: "Sonnet (Latest)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
       - { id: fable, label: "Fable (Latest)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
+      # Quoted: "[" is a YAML indicator, so a bare opus[1m] breaks flow style.
+      - { id: "opus[1m]", label: "Opus (1M context)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
+      - { id: "sonnet[1m]", label: "Sonnet (1M context)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
   codex:
     default: gpt-5.5
     effortMechanism: codex-config

--- a/packages/jinn/src/sessions/manager.ts
+++ b/packages/jinn/src/sessions/manager.ts
@@ -38,7 +38,8 @@ import { SessionQueue } from "./queue.js";
 import { JINN_HOME } from "../shared/paths.js";
 import { logger } from "../shared/logger.js";
 import { resolveEffort } from "../shared/effort.js";
-import { effortLevelsForModel, engineAvailable, isKnownEngine, engineUnavailableMessage } from "../shared/models.js";
+import { effortLevelsForModel, engineAvailable, isKnownEngine, engineUnavailableMessage, contextWindowForModel } from "../shared/models.js";
+import { assessContextCeiling, reportContextCeiling } from "../shared/context-ceiling.js";
 import { detectRateLimit, isDeadSessionError, rateLimitEngineLabel } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, isLikelyNearClaudeUsageLimit } from "../shared/usageAwareness.js";
 import { loadJobs } from "../cron/jobs.js";
@@ -917,6 +918,25 @@ export class SessionManager {
           platformContextFingerprint,
         });
       }
+      // The highest context a model ever reaches is the ceiling it is actually
+      // being allowed. If it never approaches the window the roster declares,
+      // the model id we passed is not getting the window we think it is (e.g.
+      // Claude's bare `opus` alias caps at 200K where `opus[1m]` gives 1M) and
+      // sessions will compaction-thrash. Warns once per model; never throws.
+      reportContextCeiling(
+        engineAtTurnStart,
+        modelForTurn,
+        assessContextCeiling({
+          engine: engineAtTurnStart,
+          model: modelForTurn,
+          // `exact`: a model missing from the roster would otherwise report the
+          // engine default's window, and comparing one model's context against
+          // another's declared window is worse than not checking at all.
+          declaredWindow: contextWindowForModel(this.config, engineAtTurnStart, modelForTurn, { exact: true }),
+          currentTokens: result.contextTokens,
+          userPrompt: msg.text,
+        }),
+      );
       const updatedSession = completeSessionAttempt(session.id, attemptToken, {
         ...(typeof result.contextTokens === "number" ? { lastContextTokens: result.contextTokens } : {}),
         status: wasInterrupted ? "interrupted" : (result.error ? "error" : "idle"),

--- a/packages/jinn/src/shared/__tests__/context-ceiling.test.ts
+++ b/packages/jinn/src/shared/__tests__/context-ceiling.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  assessContextCeiling,
+  resetContextCeilingState,
+  SUSPECT_RATIO,
+  MIN_TURNS_SINCE_PEAK,
+  MIN_EVIDENCE_TOKENS,
+} from "../context-ceiling.js";
+
+/** Measured from the real incident (2026-07-24, transcript 1a6151f8): Opus
+ *  spawned via the bare `opus` alias got a 200K window while the roster
+ *  declared 1M — it peaked at 191,584 across 116 readings. Fable, on a genuine
+ *  1M window, peaked at 640,447 across 1021. Those two numbers are what the
+ *  thresholds are calibrated against. */
+const DECLARED_1M = 1_000_000;
+const BROKEN_PEAK = 191_584;
+const HEALTHY_PEAK = 640_447;
+
+/** Feed n turns at `tokens`, as manager.ts would.
+ *
+ *  Returns the last verdict, but with `warn`/`suspect` folded across the whole
+ *  run: `warn` is once-per-model, so the final verdict of a long run always
+ *  reads false even when it fired on turn 26. Asserting on the last verdict
+ *  alone silently passes — that flaw let a mutation removing MIN_EVIDENCE_TOKENS
+ *  survive. "Did it ever fire" is what these tests actually mean. */
+function feed(n: number, tokens: number, declared: number, model = "opus", userPrompt = "do the task") {
+  let last!: ReturnType<typeof assessContextCeiling>;
+  let everWarned = false;
+  let everSuspect = false;
+  for (let i = 0; i < n; i++) {
+    last = assessContextCeiling({
+      engine: "claude", model, declaredWindow: declared, currentTokens: tokens, userPrompt,
+    });
+    everWarned ||= last.warn;
+    everSuspect ||= last.suspect;
+  }
+  return { ...last, warn: everWarned, suspect: everSuspect };
+}
+
+beforeEach(() => resetContextCeilingState());
+
+describe("assessContextCeiling — detection", () => {
+  it("fires on the real incident's ceiling once there is enough evidence", () => {
+    const v = feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M);
+    expect(v.warn).toBe(true);
+    expect(v.observedCeiling).toBe(BROKEN_PEAK);
+    expect(v.ratio).toBeCloseTo(0.192, 3);
+  });
+
+  it("warns exactly once per model however long the thrash continues", () => {
+    const verdicts = Array.from({ length: 200 }, () =>
+      assessContextCeiling({
+        engine: "claude", model: "opus", declaredWindow: DECLARED_1M,
+        currentTokens: BROKEN_PEAK, userPrompt: "go",
+      }),
+    );
+    expect(verdicts.filter((v) => v.warn).length).toBe(1);
+  });
+
+  it("tracks each engine/model pair independently", () => {
+    feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M, "opus");
+    expect(feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M, "sonnet").warn).toBe(true);
+  });
+
+  it("remembers the peak — one big turn is enough to clear suspicion", () => {
+    assessContextCeiling({
+      engine: "claude", model: "opus", declaredWindow: DECLARED_1M,
+      currentTokens: HEALTHY_PEAK, userPrompt: "go",
+    });
+    expect(feed(MIN_TURNS_SINCE_PEAK * 2, 60_000, DECLARED_1M, "opus").warn).toBe(false);
+  });
+});
+
+describe("assessContextCeiling — false positives", () => {
+  it("never fires on the healthy 1M model from the same transcript", () => {
+    expect(feed(200, HEALTHY_PEAK, DECLARED_1M, "fable").warn).toBe(false);
+  });
+
+  it("stays silent before there is enough evidence", () => {
+    expect(feed(MIN_TURNS_SINCE_PEAK, BROKEN_PEAK, DECLARED_1M).suspect).toBe(false);
+  });
+
+  it("stays silent on light usage that never pushed the window", () => {
+    // Many turns, but never near MIN_EVIDENCE_TOKENS — proves nothing.
+    expect(feed(500, MIN_EVIDENCE_TOKENS - 1, DECLARED_1M, "chatty").warn).toBe(false);
+  });
+
+  it("stays silent when the roster declares the window honestly", () => {
+    // Same 191K ceiling, but the roster correctly says 200K.
+    expect(feed(200, BROKEN_PEAK, 200_000, "opus-honest").warn).toBe(false);
+  });
+
+  it("stays silent when the declared window is unknown", () => {
+    expect(feed(200, BROKEN_PEAK, undefined as unknown as number, "mystery").suspect).toBe(false);
+  });
+
+  it("excludes slash commands from evidence entirely", () => {
+    for (const cmd of ["/clear", "/compact", "  /compact  ", "/model opus"]) {
+      resetContextCeilingState();
+      expect(feed(200, BROKEN_PEAK, DECLARED_1M, "opus", cmd).suspect, `${cmd} must not count`).toBe(false);
+    }
+  });
+
+  it("does not mistake a path argument for a slash command", () => {
+    expect(feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M, "opus", "read /etc/hosts").warn).toBe(true);
+  });
+});
+
+describe("assessContextCeiling — robustness", () => {
+  it("returns a fresh verdict object each call", () => {
+    const a = assessContextCeiling({ engine: "claude", model: "m", declaredWindow: DECLARED_1M, currentTokens: null });
+    (a as { suspect: boolean }).suspect = true;
+    const b = assessContextCeiling({ engine: "claude", model: "m", declaredWindow: DECLARED_1M, currentTokens: null });
+    expect(b.suspect).toBe(false);
+  });
+
+  it("never throws on malformed or hostile input", () => {
+    const bad = [0, -5, Number.NaN, Number.POSITIVE_INFINITY, null, undefined];
+    for (const tokens of bad) {
+      for (const declared of [DECLARED_1M, 0, -1, Number.NaN, undefined]) {
+        expect(() =>
+          assessContextCeiling({
+            engine: "claude", model: "opus",
+            declaredWindow: declared as number,
+            currentTokens: tokens as number,
+          }),
+        ).not.toThrow();
+      }
+    }
+  });
+
+  it("keeps the threshold inside the gap measured on real data", () => {
+    expect(BROKEN_PEAK / DECLARED_1M).toBeLessThan(SUSPECT_RATIO);
+    expect(HEALTHY_PEAK / DECLARED_1M).toBeGreaterThan(SUSPECT_RATIO);
+  });
+});

--- a/packages/jinn/src/shared/context-ceiling.ts
+++ b/packages/jinn/src/shared/context-ceiling.ts
@@ -1,0 +1,172 @@
+/**
+ * Detects a declared context window that the engine does not actually honour.
+ *
+ * Why this exists: in July 2026 the roster declared Opus at 1M while the Claude
+ * CLI — handed the bare `opus` alias instead of `opus[1m]` — enforced 200K.
+ * Nothing compared the two, so sessions compaction-thrashed for weeks (63
+ * compaction boundaries in one transcript) before a human noticed. Correcting
+ * the number fixes that day; this makes the *next* wrong number announce itself.
+ *
+ * Mechanism: a peak that has stopped growing is a ceiling. We track the highest
+ * context a model has ever reached and how long that peak has held; once it has
+ * held across many turns without moving, and sits far below the declared
+ * window, the window we were told about is not the window being enforced.
+ *
+ * Two earlier designs were falsified by replaying the real transcript, and both
+ * failure modes are worth keeping in mind before changing the thresholds:
+ *
+ *  1. Classifying individual compaction events by the level they fired at.
+ *     Healthy Fable compacted at 280K–494K and broken Opus at 169K — these
+ *     overlap once the declared window is 1M, so it produced both a false
+ *     negative and a false positive on the very incident it was written for.
+ *  2. Comparing the running max against the declared window. Every model's max
+ *     is low early in its life, so this warned on the healthy model long before
+ *     it had climbed to its true 640K peak.
+ *
+ * What separates them is not the peak's height but its *stability*: below the
+ * 35% line the capped model held its peak for 79 turns while the healthy one
+ * never held one for more than 4 before climbing past it.
+ *
+ * Uses only what a turn already produced — no catalog, no network. That is a
+ * hard requirement: this must work on subscription auth.
+ */
+import { logger } from "./logger.js";
+
+/** A model that never exceeds this fraction of its declared window, despite
+ *  sustained use, is not being given that window. Measured: broken Opus
+ *  reached 0.19, healthy Fable 0.64. */
+export const SUSPECT_RATIO = 0.35;
+
+/** Absolute floor before any conclusion: below this, the model simply has not
+ *  been pushed hard enough to say anything about its ceiling. */
+export const MIN_EVIDENCE_TOKENS = 100_000;
+
+/** Turns the peak must hold without growing before it counts as a ceiling
+ *  rather than a still-climbing high-water mark. This is the load-bearing
+ *  threshold: a low max means nothing on its own, because every model's max is
+ *  low early on. Measured on the incident transcript — below the 35% line, the
+ *  capped model plateaued for 79 turns while the healthy one never plateaued
+ *  for more than 4 before climbing past it. */
+export const MIN_TURNS_SINCE_PEAK = 25;
+
+export interface ContextCeilingInput {
+  engine: string;
+  model?: string;
+  /** Declared window from the model roster, if any. */
+  declaredWindow?: number;
+  /** Context reading from the turn that just finished. */
+  currentTokens?: number | null;
+  /** The prompt that drove this turn. Slash commands (`/clear`, `/compact`,
+   *  `/model`) mutate context on purpose; they are excluded from evidence so a
+   *  user's own housekeeping cannot be mistaken for an enforced ceiling. */
+  userPrompt?: string;
+}
+
+export interface ContextCeilingVerdict {
+  /** Enough evidence gathered, and it points at a smaller real window. */
+  suspect: boolean;
+  /** Threshold crossed and not yet reported for this model. */
+  warn: boolean;
+  observedCeiling?: number;
+  declaredWindow?: number;
+  ratio?: number;
+  turns?: number;
+  turnsSincePeak?: number;
+}
+
+/** Returned by value, never by reference: a shared literal would let one
+ *  caller's mutation corrupt every later verdict. */
+const notSuspect = (): ContextCeilingVerdict => ({ suspect: false, warn: false });
+
+interface ModelEvidence {
+  turns: number;
+  maxObserved: number;
+  /** Turns since maxObserved last grew — how long the peak has held. */
+  turnsSincePeak: number;
+}
+
+/** Evidence per engine/model, and already-warned markers. Process-lifetime
+ *  only — a restart re-arms the warning, which is also when a config change
+ *  takes effect, so that is the behaviour we want. */
+const evidence = new Map<string, ModelEvidence>();
+const warned = new Set<string>();
+
+/** Test seam. */
+export function resetContextCeilingState(): void {
+  evidence.clear();
+  warned.clear();
+}
+
+function isPositiveFinite(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
+/** A prompt beginning with a slash command — the user deliberately mutating
+ *  context. Anchored to the start so "read /etc/hosts" is not mistaken for one. */
+function isContextMutatingCommand(prompt?: string): boolean {
+  return typeof prompt === "string" && /^\s*\//.test(prompt);
+}
+
+/**
+ * Record one turn's context reading and report whether the model's declared
+ * window now looks wrong. Total: every malformed input returns "not suspect"
+ * rather than throwing, because this runs inside the turn-completion path and
+ * must never break a turn.
+ */
+export function assessContextCeiling(input: ContextCeilingInput): ContextCeilingVerdict {
+  const { engine, model, declaredWindow, currentTokens, userPrompt } = input;
+
+  if (!isPositiveFinite(declaredWindow)) return notSuspect();
+  if (!isPositiveFinite(currentTokens)) return notSuspect();
+  // The user mutated context on purpose — not evidence about the window.
+  if (isContextMutatingCommand(userPrompt)) return notSuspect();
+
+  const key = `${engine}/${model ?? "default"}`;
+  const prior = evidence.get(key) ?? { turns: 0, maxObserved: 0, turnsSincePeak: 0 };
+  const grew = currentTokens > prior.maxObserved;
+  const next: ModelEvidence = {
+    turns: prior.turns + 1,
+    maxObserved: grew ? currentTokens : prior.maxObserved,
+    turnsSincePeak: grew ? 0 : prior.turnsSincePeak + 1,
+  };
+  evidence.set(key, next);
+
+  // A peak that is still growing is a high-water mark, not a ceiling — every
+  // model's max is low early on, so concluding here is what produced a false
+  // positive on the healthy model when this was first written.
+  if (next.turnsSincePeak < MIN_TURNS_SINCE_PEAK) return notSuspect();
+  if (next.maxObserved < MIN_EVIDENCE_TOKENS) return notSuspect();
+
+  const ratio = next.maxObserved / declaredWindow;
+  if (ratio >= SUSPECT_RATIO) return notSuspect(); // reaches a plausible fraction — healthy
+
+  const verdict: ContextCeilingVerdict = {
+    suspect: true,
+    warn: !warned.has(key),
+    observedCeiling: next.maxObserved,
+    declaredWindow,
+    ratio,
+    turns: next.turns,
+    turnsSincePeak: next.turnsSincePeak,
+  };
+  if (verdict.warn) warned.add(key);
+  return verdict;
+}
+
+/** Emit the warning for a verdict that earned one. Never throws. */
+export function reportContextCeiling(engine: string, model: string | undefined, v: ContextCeilingVerdict): void {
+  if (!v.warn) return;
+  try {
+    const pct = Math.round((v.ratio ?? 0) * 100);
+    logger.warn(
+      `Context window looks smaller than configured for ${engine}/${model ?? "default"}: ` +
+        `across ${v.turns} turns the context never exceeded ${v.observedCeiling?.toLocaleString()} tokens, ` +
+        `but the roster declares ${v.declaredWindow?.toLocaleString()} (${pct}%). ` +
+        `If the engine is enforcing a smaller window, sessions will compaction-thrash. ` +
+        `Verify the model id passed to the engine (Claude needs the [1m] suffix for a 1M window, e.g. "opus[1m]") ` +
+        `or correct contextWindow for this model in config.yaml.`,
+    );
+  } catch {
+    /* diagnostics must never break a turn */
+  }
+}

--- a/packages/jinn/src/shared/models.ts
+++ b/packages/jinn/src/shared/models.ts
@@ -306,11 +306,24 @@ export function effortLevelsForModel(config: JinnConfig, engine: string, modelId
 }
 
 /** Context window (tokens) for a session's engine+model, or undefined if unknown. */
-export function contextWindowForModel(config: JinnConfig, engine: string, modelId?: string): number | undefined {
+/** Declared context window for a model.
+ *
+ *  By default an unlisted model falls back to the engine's default model, which
+ *  is right for display but wrong for comparisons: it would report model Y's
+ *  window for model X. Pass `exact` when the answer is only meaningful if this
+ *  specific model is actually in the roster. */
+export function contextWindowForModel(
+  config: JinnConfig,
+  engine: string,
+  modelId?: string,
+  opts?: { exact?: boolean },
+): number | undefined {
   const entry = getModelRegistry(config)[engine];
   if (!entry) return undefined;
+  const exactMatch = modelId ? entry.models.find((m) => m.id === modelId) : undefined;
+  if (opts?.exact) return exactMatch?.contextWindow;
   const model =
-    (modelId ? entry.models.find((m) => m.id === modelId) : undefined) ??
+    exactMatch ??
     entry.models.find((m) => m.id === entry.defaultModel) ??
     entry.models[0];
   return model?.contextWindow;


### PR DESCRIPTION
## The problem

Claude Code treats `opus` and `opus[1m]` as **different model ids** — only the latter gets the 1M window. A roster entry that declares `contextWindow: 1000000` for the bare alias therefore runs at the standard window while Jinn believes otherwise, and nothing compares the two.

That interacts badly with Jinn specifically. Jinn injects a large fixed context every turn (persona + org roster + MCP tool definitions + skills). On the install where I found this, that floor measured **54,076 tokens** — ~5% of a 1M window, but **27% of the smaller one**. Each compaction returns to that floor, so each cycle buys little headroom, and sessions compact → work briefly → compact again until the turn dies with a missing Stop hook.

Measured from one transcript, both models in the same file, both declared at 1M:

| model as spawned | readings | peak context | peak / declared |
|---|---|---|---|
| bare alias | 116 | 191,584 | **0.19** |
| correctly-configured model | 1021 | 640,447 | 0.64 |

63 compaction boundaries, context pinned just under a hard ceiling. The elapsed time before anyone noticed was weeks — **the bug was not the wrong number, it was that a wrong number was undetectable.**

## What this adds

A detector that makes the mismatch self-reporting. **A peak that stops growing is a ceiling** — track the highest context each model reaches and how long that peak holds, then warn once per model when it has held across many turns, sits above an evidence floor, and never approaches the declared window.

It uses only what a turn already produced — no catalog lookup, no network — so it works on subscription auth. It is purely diagnostic: no behaviour change, no default change, and it stays silent when no `contextWindow` is declared (nothing to contradict).

## Two designs this replaces

Both were falsified by replaying a real transcript, and both are documented in the module so the thresholds aren't re-litigated blindly:

1. **Classifying individual compaction events by the level they fire at.** Healthy compacted at 280K–494K, broken at 169K — these overlap against a 1M declared window. It produced both a false negative and a false positive on the very incident it was written for.
2. **Comparing the running max to the declared window.** Every model's max is low early in its life, so it warned on the healthy model long before it climbed to its real peak.

What separates them is not the peak's height but its **stability**: below the 35% line the capped model held its peak for 79 turns; the healthy one never held one for more than 4 before climbing past it.

## Also in this PR

- **Setup template offers the `[1m]` variants** as selectable options. **Defaults are deliberately unchanged** — the 1M variants appear to carry different billing on some plans (the CLI labels them conditionally on account scopes), so this surfaces the choice rather than making it for people.
- **Template ids containing `[` are quoted.** Unquoted they are a YAML parse error in flow style — I hit this while writing the change, and it would have broken `jinn setup` outright. A new test parses `DEFAULT_CONFIG` and asserts every model id survives; it fails on the unquoted form.
- **`contextWindowForModel` gains an opt-in `exact` mode.** It falls back to the engine default for unlisted models, which is right for display and wrong for comparisons — reporting model Y's window for model X would produce false warnings. Existing callers are unchanged.

## Testing

- 18 tests across the detector and the template guard
- Thresholds calibrated against the measured transcript, not chosen by feel
- Mutation-tested: 8/8 seeded faults caught (threshold value, plateau gate, evidence floor, slash-command guard, once-per-model dedupe, peak tracking, ratio, regex anchoring). One mutation initially survived and exposed a bug in the *test* helper, which is fixed.
- Also replayed against the real transcript end-to-end: fires on the capped model, silent on the healthy one. That harness read a machine-specific path so it is not included here.

## Notes

- Complements #675861f2 (`re-run model discovery periodically`). Discovery can keep effort levels and windows fresh, but the `[1m]` ids exist only in the CLI's alias table and appear in no API — so those stay hand-maintained, and this is the backstop for when they drift.
- `pnpm typecheck` reports a pre-existing `node-telegram-bot-api` error on `main` unrelated to this change.
- Draft: happy to adjust thresholds, drop the setup-template portion, or split the `exact` change out if you'd prefer them separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQ5j8zHtB9hmNxbJycQQUN
