### PR TITLE
fix(todos): make review rejections reachable and declared blocks durable

### DIFF
--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -167,6 +167,7 @@ import {
 import {
   appendWorkItemEvent,
   createWorkItem,
+  effectiveMaxRounds,
   getWorkItem,
   getWorkItemBySourceRef,
   getWorkItemSpend,
@@ -1002,6 +1003,11 @@ function cronJobSummary(job: Record<string, unknown>, lastRun: unknown): Record<
 const WORK_ITEM_STATUSES: readonly WorkItemStatus[] = ['backlog', 'assigned', 'executing', 'in_review', 'done', 'blocked', 'escalated', 'cancelled'];
 const WORK_ITEM_SOURCES: readonly WorkItemSource[] = ['human', 'delegation', 'cron', 'workflow', 'session', 'connector', 'goal'];
 const AGENT_WORK_ITEM_TARGETS: readonly WorkItemStatus[] = ['executing', 'in_review', 'blocked', 'escalated', 'done'];
+
+/** The three outcomes of a review pass. `fail` is the counted round; it is the
+ *  verdict the /status route structurally could not express. */
+const REVIEW_VERDICTS = ['pass', 'fail', 'blocked'] as const;
+type ReviewVerdict = (typeof REVIEW_VERDICTS)[number];
 const VERIFY_MODES = ['trust', 'verify', 'thorough'] as const;
 const VERIFY_POLICY_KEYS = new Set(['mode', 'verifier', 'maxRounds']);
 
@@ -1907,16 +1913,48 @@ function resolveTodoEditAuthority(caller: WorkItemCaller, item: WorkItem): TodoE
   };
 }
 
-function canReviewWorkItemDone(session: Session, item: WorkItem, linked: Session[]): { ok: true } | { ok: false; error: string } {
-  if (item.status !== 'in_review') {
-    return { ok: false, error: `marking a Todo done through MCP requires an authorized reviewer and an item already in_review; use the human review surface for ${item.status} → done` };
-  }
-  if (linked.some((s) => s.id === session.id)) {
-    return { ok: false, error: `session ${session.id} executed work item ${item.id} and cannot mark it done — a reviewer does (self-review ban); use the human review surface / a reviewer session to mark done` };
-  }
+type ReviewerIneligibility = 'not-in-review' | 'self-review' | 'not-reviewer';
+
+/**
+ * The reviewer predicate shared by `done` closure and review verdicts: the item
+ * is in review, the caller did NOT execute it (self-review ban), and the caller
+ * is its parent/delegator/creator. Both callers map the same reasons to their
+ * own wording — one predicate so closure and verdict authority cannot diverge.
+ */
+function reviewerEligibility(
+  session: Session,
+  item: WorkItem,
+  linked: Session[],
+): { ok: true } | { ok: false; reason: ReviewerIneligibility } {
+  if (item.status !== 'in_review') return { ok: false, reason: 'not-in-review' };
+  if (linked.some((s) => s.id === session.id)) return { ok: false, reason: 'self-review' };
   if (linked.some((s) => s.parentSessionId === session.id)) return { ok: true };
   if (item.sourceRef?.startsWith(`delegate:${session.id}:`)) return { ok: true };
   if (item.source === 'session' && item.sourceRef?.startsWith(`session:${session.id}:`)) return { ok: true };
+  return { ok: false, reason: 'not-reviewer' };
+}
+
+function canReviewWorkItemDone(session: Session, item: WorkItem, linked: Session[]): { ok: true } | { ok: false; error: string } {
+  const eligible = reviewerEligibility(session, item, linked);
+  if (eligible.ok) return { ok: true };
+  if (eligible.reason === 'not-in-review') {
+    return { ok: false, error: `marking a Todo done through MCP requires an authorized reviewer and an item already in_review; use the human review surface for ${item.status} → done` };
+  }
+  if (eligible.reason === 'self-review') {
+    return { ok: false, error: `session ${session.id} executed work item ${item.id} and cannot mark it done — a reviewer does (self-review ban); use the human review surface / a reviewer session to mark done` };
+  }
+  return { ok: false, error: `session ${session.id} is not an authorized reviewer for Todo ${item.id}; use the human review surface or the parent reviewer session` };
+}
+
+function canRenderReviewVerdict(session: Session, item: WorkItem, linked: Session[]): { ok: true } | { ok: false; error: string } {
+  const eligible = reviewerEligibility(session, item, linked);
+  if (eligible.ok) return { ok: true };
+  if (eligible.reason === 'not-in-review') {
+    return { ok: false, error: `a review verdict applies to a Todo already in_review; ${item.id} is ${item.status}` };
+  }
+  if (eligible.reason === 'self-review') {
+    return { ok: false, error: `session ${session.id} executed work item ${item.id} and cannot render a verdict on its own work (self-review ban) — its reviewer does` };
+  }
   return { ok: false, error: `session ${session.id} is not an authorized reviewer for Todo ${item.id}; use the human review surface or the parent reviewer session` };
 }
 
@@ -3607,6 +3645,18 @@ export async function handleApiRequest(
       }
       const item = getWorkItem(params.id);
       if (!item) return notFound(res);
+      // A rejection FROM review is a review verdict, not a status write. Routed
+      // here it would skip the round counter entirely (`bounce` is only reachable
+      // through /review, because this route sets `manual` and a manual move into
+      // `executing` is legal only from backlog/assigned), so the loop that
+      // `effectiveMaxRounds` exists to bound becomes unbounded and never
+      // escalates. Producers hitting a genuine external wall still block from
+      // `executing` exactly as before.
+      if (target === "blocked" && item.status === "in_review" && caller.kind !== "operator") {
+        return json(res, {
+          error: `Todo ${item.id} is in_review — a reviewer rejection is a verdict, not a status write. Use review_verdict with verdict "fail" (returns it to the producer as a counted round) or "blocked" (an external need with an exact unblock condition).`,
+        }, 403);
+      }
       const authorized = authorizeAgentWorkItemStatus(caller, item, target as WorkItemStatus);
       if (!authorized.ok) return json(res, { error: authorized.error }, authorized.status);
       // The banner's asked-for-after reason (design-doc §5): a same-status
@@ -3639,7 +3689,12 @@ export async function handleApiRequest(
               manual: true,
               human: isOperatorPut || undefined,
               callerSessionId: caller.kind === "session" ? caller.callerId : undefined,
-              detail: note ? { note } : undefined,
+              // A block written by a caller (not derived by the reconciler) is a
+              // governance declaration: it must survive session-transport churn
+              // until someone resolves it. `declared` is what reconcile.ts reads.
+              detail: target === "blocked"
+                ? { ...(note ? { note } : {}), declared: true }
+                : (note ? { note } : undefined),
             });
         const activityReceiptId = persistTodoMutationActivity(
           req,
@@ -3657,6 +3712,91 @@ export async function handleApiRequest(
             : `${err.message} — use the human surface for this transition if it is intentional`;
           const statusCode = err.code === "illegal-edge" ? 400 : 403;
           return json(res, { error: human }, statusCode);
+        }
+        throw err;
+      }
+    }
+
+    // POST /api/work-items/:id/review — the review VERDICT surface.
+    //
+    // A verdict is a governance act with a consequence, not a status write, and
+    // this is the only route that reaches the consequences:
+    //   pass    → done                     (closure IS the verdict; no separate step)
+    //   fail    → executing {bounce}       (rounds++, auto-escalates at maxRounds)
+    //   blocked → blocked {declared}       (survives reconciler derivation)
+    // The /status route cannot express `fail`: it sets `manual`, and a manual
+    // move into `executing` is legal only from backlog/assigned, so the bounce
+    // edge — and with it the entire round budget — was unreachable there.
+    params = matchRoute("/api/work-items/:id/review", pathname);
+    if (method === "POST" && params) {
+      const caller = resolveWorkItemCaller(req, res, context);
+      if (!caller) return;
+      if (!requireTodoRouteId(res, params.id)) return;
+      const parsed = await readJsonBody(req, res);
+      if (!parsed.ok) return;
+      if (!parsed.body || typeof parsed.body !== "object" || Array.isArray(parsed.body)) {
+        return badRequest(res, "request body must be a JSON object");
+      }
+      const body = parsed.body as Record<string, unknown>;
+      const approvalKeys = findApprovalKeysDeep(body);
+      if (approvalKeys.length > 0) {
+        return badRequest(res, `approval fields (${approvalKeys.join(", ")}) cannot be attached through a review verdict — approvals are requested/decided through the approval authority surface`);
+      }
+      const verdict = typeof body.verdict === "string" ? body.verdict.trim() : "";
+      if (!(REVIEW_VERDICTS as readonly string[]).includes(verdict)) {
+        return badRequest(res, `verdict must be one of ${REVIEW_VERDICTS.join(", ")}`);
+      }
+      const note = typeof body.note === "string" ? body.note.trim() : "";
+      // Findings are batched by construction: a FAIL carries the COMPLETE list
+      // from one exhaustive pass. Returning the first defect found turns one
+      // round into N, and each round is a fresh session paying full context cost.
+      const findings = Array.isArray(body.findings)
+        ? body.findings.filter((f): f is string => typeof f === "string" && f.trim().length > 0).map((f) => f.trim())
+        : [];
+      if (verdict === "fail" && findings.length === 0) {
+        return badRequest(res, "a fail verdict requires findings: the complete ranked list of defects from this pass, not the first one found");
+      }
+      const unblockCondition = typeof body.unblockCondition === "string" ? body.unblockCondition.trim() : "";
+      if (verdict === "blocked" && !unblockCondition) {
+        return badRequest(res, "a blocked verdict requires unblockCondition: the exact external need, stated so someone can satisfy it without asking you");
+      }
+      const item = getWorkItem(params.id);
+      if (!item) return notFound(res);
+      if (caller.kind !== "operator") {
+        const eligible = canRenderReviewVerdict(caller.session, item, listSessionsByWorkItem(item.id));
+        if (!eligible.ok) return json(res, { error: eligible.error }, 403);
+      }
+      const target: WorkItemStatus = verdict === "pass" ? "done" : verdict === "fail" ? "executing" : "blocked";
+      try {
+        const result = transition(params.id, target, workItemActor(caller), {
+          callerSessionId: caller.kind === "session" ? caller.callerId : undefined,
+          bounce: verdict === "fail",
+          detail: {
+            verdict,
+            ...(note ? { note } : {}),
+            ...(findings.length > 0 ? { findings } : {}),
+            ...(verdict === "blocked" ? { declared: true, unblockCondition } : {}),
+          },
+        });
+        const activityReceiptId = persistTodoMutationActivity(
+          req,
+          context,
+          result.item,
+          "status-transitioned",
+          result.item.version !== item.version,
+        );
+        return json(res, withActivityReceipt({
+          workItem: result.item,
+          escalated: result.escalated,
+          verdict,
+          rounds: result.item.rounds,
+          maxRounds: effectiveMaxRounds(result.item),
+        }, activityReceiptId));
+      } catch (err) {
+        if (err instanceof TransitionError) {
+          if (err.code === "not-found") return notFound(res);
+          const statusCode = err.code === "illegal-edge" ? 400 : 403;
+          return json(res, { error: err.message }, statusCode);
         }
         throw err;
       }

--- a/packages/jinn/src/mcp/__tests__/cost-cron-tools.test.ts
+++ b/packages/jinn/src/mcp/__tests__/cost-cron-tools.test.ts
@@ -77,7 +77,7 @@ describe("cost + cron tools — schemas and belt registration", () => {
     expect(names).toContain("get_cron_run_history");
     expect(names).toContain("cancel_workflow_run");
     expect(names.filter((name) => name === "list_work_items")).toHaveLength(1);
-    expect(names).toHaveLength(62);
+    expect(names).toHaveLength(63);
   });
 });
 

--- a/packages/jinn/src/mcp/__tests__/knowledge-tools.test.ts
+++ b/packages/jinn/src/mcp/__tests__/knowledge-tools.test.ts
@@ -87,12 +87,12 @@ describe("knowledge tools — registry + schemas", () => {
     }
   });
 
-  it("the belt registers the knowledge group — 52 tools total", () => {
+  it("the belt registers the knowledge group — 53 tools total", () => {
     const names = buildTools().map((t) => t.name);
     expect(names).toContain("search_knowledge");
     expect(names).toContain("read_knowledge");
     expect(names).toContain("cancel_workflow_run");
-    expect(names).toHaveLength(62);
+    expect(names).toHaveLength(63);
   });
 
   it("domain teaching lives on search_knowledge; read names the instance scope", () => {

--- a/packages/jinn/src/mcp/__tests__/note-tools.test.ts
+++ b/packages/jinn/src/mcp/__tests__/note-tools.test.ts
@@ -85,14 +85,14 @@ describe("note tool contracts", () => {
       "create_note",
       "update_note",
     ]);
-    expect(names).toHaveLength(62);
+    expect(names).toHaveLength(63);
   });
 
   it("omits Notes verbs from the full belt when the feature is disabled", () => {
     const names = buildTools({ notesEnabled: false }).map((candidate) => candidate.name);
 
     expect(names.filter((name) => name.endsWith("_note") || name.endsWith("_notes"))).toEqual([]);
-    expect(names).toHaveLength(58);
+    expect(names).toHaveLength(59);
   });
 
   it("teaches read-before-update in the list result hint", async () => {

--- a/packages/jinn/src/mcp/__tests__/search-tools.test.ts
+++ b/packages/jinn/src/mcp/__tests__/search-tools.test.ts
@@ -95,13 +95,13 @@ describe("search tools — registry + schemas", () => {
     }
   });
 
-  it("the belt registers the search group — 52 tools total", () => {
+  it("the belt registers the search group — 53 tools total", () => {
     const names = buildTools().map((t) => t.name);
     expect(names).toContain("search_messages");
     expect(names).toContain("search_sessions");
     expect(names).toContain("get_message_context");
     expect(names).toContain("cancel_workflow_run");
-    expect(names).toHaveLength(62);
+    expect(names).toHaveLength(63);
   });
 
   it("domain teaching lives on search_messages; the others stay short", () => {

--- a/packages/jinn/src/mcp/__tests__/server.test.ts
+++ b/packages/jinn/src/mcp/__tests__/server.test.ts
@@ -137,6 +137,7 @@ describe("buildTools", () => {
       "rerun_workflow_run",
       "retire_workflow",
       "retry_workflow_node",
+      "review_verdict",
       "search_knowledge",
       "search_messages",
       "search_sessions",
@@ -248,7 +249,7 @@ describe("handleMcpRequest — tools/call", () => {
 
   it("compiles every advertised registry schema or supplies its shared runtime schema", () => {
     const tools = buildTools();
-    expect(tools).toHaveLength(62);
+    expect(tools).toHaveLength(63);
     for (const tool of tools) {
       expect(() => tool.runtimeSchema ?? z.fromJSONSchema({ ...tool.inputSchema, additionalProperties: false } as Parameters<typeof z.fromJSONSchema>[0]), tool.name).not.toThrow();
     }

--- a/packages/jinn/src/mcp/__tests__/tool-manifest-budget.test.ts
+++ b/packages/jinn/src/mcp/__tests__/tool-manifest-budget.test.ts
@@ -7,13 +7,21 @@ import { projectPiToolManifest } from "../../engines/pi-mcp.js";
 // list_work_item_attachments, list_departments) with the same ~zero headroom
 // discipline as before: new tool prose must stay concise rather than growing
 // into this ceiling.
-const MAX_MANIFEST_TOKENS = 4911;
+//
+// 4911 → 5125 (review_verdict). The review-verdict surface is the only route
+// that reaches `bounce`, and therefore the only route that makes a review
+// rejection a COUNTED round. Without it `/status` sets `manual`, a manual move
+// into `executing` is legal only from backlog/assigned, so the bounce edge —
+// and with it the whole `effectiveMaxRounds` budget — is unreachable and review
+// loops never terminate. Cost after trimming its prose: 181 tokens for the
+// tool, 214 for the manifest delta. Ceiling is the new pi projection + 2.
+const MAX_MANIFEST_TOKENS = 5125;
 // Exact gate: js-tiktoken 1.0.21 with its local o200k_base ranks. The provider
 // projection is the OpenAI Responses API function-tool request shape pinned on 2026-07-12.
 const ATTESTED = {
-  rpc: { tokens: 4482, sha256: "e8c6fb5862a71902b66641a0e3e515d1199602c07bf22bb1ad0d85370571e449" },
-  pi: { tokens: 4909, sha256: "da38177f89d2ddc01c7b3454bd659b5da157d3326bf324e86ad5c7ab58f2371b" },
-  openai: { tokens: 4654, sha256: "c9d8605abc1e8567e4742138a1988f770c80110f33a8e96ca0e05d329d6de135" },
+  rpc: { tokens: 4689, sha256: "724546fc5b59276aab0f2d37ac4450c828e8fe5352692b8aa339d47866b0f437" },
+  pi: { tokens: 5123, sha256: "4a57c8528d2028d43dd3080f4fd0612f5936f6ba51ee155c013b4eef347ce6f3" },
+  openai: { tokens: 4864, sha256: "688995cc898f98ed4678daa770ff51d6c1025ca47aaa9863eeb4b13523811af5" },
 } as const;
 
 type TokenizerLoader = () => Promise<[{ Tiktoken: typeof import("js-tiktoken/lite").Tiktoken }, { default: typeof import("js-tiktoken/ranks/o200k_base").default }]>;
@@ -81,6 +89,7 @@ const EXPECTED_TOOL_NAMES = [
   "read_session",
   "request_work_item_approval",
   "retire_workflow",
+  "review_verdict",
   "rerun_workflow_run",
   "retry_workflow_node",
   "search_knowledge",
@@ -146,6 +155,7 @@ const EXPECTED_REQUIRED = {
   read_session: ["sessionId"],
   request_work_item_approval: ["id", "request"],
   retire_workflow: ["workflowId", "expectedRevision"],
+  review_verdict: ["id", "verdict"],
   rerun_workflow_run: ["workflowId", "runId", "definition", "idempotencyKey"],
   retry_workflow_node: ["workflowId", "runId", "nodeId", "idempotencyKey"],
   search_knowledge: ["query"],
@@ -183,6 +193,7 @@ const EXPECTED_ENUMS = {
     ["properties.source", ["human", "delegation", "cron", "workflow", "session", "connector", "goal"]],
   ],
   unlink_work_items: [["properties.kind", ["blocks", "relates", "duplicates"]]],
+  review_verdict: [["properties.verdict", ["pass", "fail", "blocked"]]],
   update_work_item: [["properties.status", ["executing", "in_review", "blocked", "escalated", "done"]]],
 } as const;
 
@@ -233,7 +244,7 @@ describe("tool manifest budget", () => {
   it("keeps tool names, required arrays, and enum arrays stable", () => {
     const tools = buildTools();
     expect(tools.map((t) => t.name).sort()).toEqual([...EXPECTED_TOOL_NAMES].sort());
-    expect(tools).toHaveLength(62);
+    expect(tools).toHaveLength(63);
 
     const required = Object.fromEntries(tools.map((t) => [t.name, t.inputSchema.required ?? []]));
     expect(required).toEqual(EXPECTED_REQUIRED);

--- a/packages/jinn/src/mcp/__tests__/work-item-tools.test.ts
+++ b/packages/jinn/src/mcp/__tests__/work-item-tools.test.ts
@@ -65,6 +65,7 @@ describe("work-item tools — registry + schemas", () => {
       "create_work_item",
       "update_work_item",
       "edit_work_item",
+      "review_verdict",
       "assign_work_item",
       "archive_work_item",
       "comment_work_item",
@@ -87,7 +88,7 @@ describe("work-item tools — registry + schemas", () => {
     expect(names).toContain("fire_workflow_event");
     expect(names).toContain("cancel_workflow_run");
     expect(names.some((n) => /cancel/i.test(n) && /work_item/.test(n))).toBe(false);
-    expect(names).toHaveLength(62);
+    expect(names).toHaveLength(63);
   });
 
   it("positions list as recent/filter summaries and search as text/filter hits", () => {
@@ -1148,5 +1149,156 @@ describe("work-item attachment + department tools (Todos v2 slice 5)", () => {
     const platform = departments.departments.find((d) => d.slug === "platform");
     expect(platform).toBeDefined();
     expect(platform!.todoCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+/**
+ * review_verdict — the surface that makes a rejection a COUNTED round.
+ *
+ * Before this tool the only agent route was POST /work-items/:id/status, which
+ * sets `manual`; a manual move into `executing` is legal only from
+ * backlog/assigned, so `in_review → executing` (the bounce edge) was
+ * unreachable and reviewers wrote `in_review → blocked` instead. That edge does
+ * not touch `rounds`, so the round budget never applied and review loops never
+ * terminated.
+ */
+describe("review_verdict — counted rejections and closure-on-PASS", () => {
+  /** A reviewer session, an executor child linked to the item, and the item in review. */
+  function reviewScenario(tag: string, verifyPolicy?: { mode: "trust" | "verify" | "thorough"; maxRounds?: number }) {
+    const reviewer = registry.createSession({ engine: "codex", source: "web", sourceRef: `rv-reviewer-${tag}`, title: `reviewer ${tag}` });
+    const executor = registry.createSession({
+      engine: "codex",
+      source: "web",
+      sourceRef: `rv-executor-${tag}`,
+      title: `executor ${tag}`,
+      parentSessionId: reviewer.id,
+    });
+    const item = store.createWorkItem({
+      title: `review verdict ${tag}`,
+      status: "in_review",
+      source: "delegation",
+      sourceRef: `delegate:${reviewer.id}:${tag}`,
+      ...(verifyPolicy ? { verifyPolicy } : {}),
+    });
+    store.linkSession(item.id, executor.id);
+    return { reviewer, executor, item };
+  }
+
+  it("refuses a fail with no findings — one exhaustive pass, not the first defect", async () => {
+    const { reviewer, item } = reviewScenario("nofindings");
+    await expect(tool("review_verdict").handler({ id: item.id, verdict: "fail" }, ctxFor(reviewer.id)))
+      .rejects.toThrow(/requires findings/i);
+    expect(store.getWorkItem(item.id)?.status).toBe("in_review");
+    expect(store.getWorkItem(item.id)?.rounds).toBe(0);
+  });
+
+  it("refuses a blocked with no unblockCondition", async () => {
+    const { reviewer, item } = reviewScenario("nocondition");
+    await expect(tool("review_verdict").handler({ id: item.id, verdict: "blocked" }, ctxFor(reviewer.id)))
+      .rejects.toThrow(/requires unblockCondition/i);
+    expect(store.getWorkItem(item.id)?.status).toBe("in_review");
+  });
+
+  it("refuses an unknown verdict", async () => {
+    const { reviewer, item } = reviewScenario("badverdict");
+    await expect(tool("review_verdict").handler({ id: item.id, verdict: "maybe" }, ctxFor(reviewer.id)))
+      .rejects.toThrow(/verdict must be one of/i);
+  });
+
+  it("refuses a verdict from the session that executed the work (self-review ban)", async () => {
+    const { executor, item } = reviewScenario("selfreview");
+    await expect(tool("review_verdict").handler(
+      { id: item.id, verdict: "pass" },
+      ctxFor(executor.id),
+    )).rejects.toThrow(/self-review ban/i);
+    expect(store.getWorkItem(item.id)?.status).toBe("in_review");
+  });
+
+  it("fail returns the item to its producer and CONSUMES a round", async () => {
+    const { reviewer, item } = reviewScenario("counted", { mode: "thorough", maxRounds: 4 });
+    const res = (await tool("review_verdict").handler(
+      { id: item.id, verdict: "fail", findings: ["lazy cache validation", "smoke does not bind hashes"] },
+      ctxFor(reviewer.id),
+    )) as { workItem: { status: string; rounds: number }; rounds: number; maxRounds: number };
+
+    expect(res.workItem.status).toBe("executing");
+    expect(res.workItem.rounds).toBe(1);
+    expect(res.maxRounds).toBe(4);
+    const events = store.listWorkItemEvents(item.id);
+    expect(events.at(-1)?.detail).toMatchObject({ bounce: true, verdict: "fail" });
+  });
+
+  it("escalates to the operator when the round budget is exhausted, instead of looping", async () => {
+    const maxRounds = 2;
+    const { reviewer, item } = reviewScenario("exhaust", { mode: "thorough", maxRounds });
+
+    const first = (await tool("review_verdict").handler(
+      { id: item.id, verdict: "fail", findings: ["defect one"] },
+      ctxFor(reviewer.id),
+    )) as { workItem: { status: string } };
+    expect(first.workItem.status).toBe("executing");
+
+    // Producer resubmits, reviewer rejects again — this exhausts the budget.
+    const { transition } = await import("../../work-items/transitions.js");
+    transition(item.id, "in_review", "producer", {});
+
+    const second = (await tool("review_verdict").handler(
+      { id: item.id, verdict: "fail", findings: ["defect two"] },
+      ctxFor(reviewer.id),
+    )) as { workItem: { status: string }; escalated: boolean };
+
+    expect(second.escalated).toBe(true);
+    expect(second.workItem.status).toBe("escalated");
+    expect(store.getWorkItem(item.id)?.status).toBe("escalated");
+  });
+
+  it("pass CLOSES the item — the verdict is the close, not a note for later", async () => {
+    const { reviewer, item } = reviewScenario("passcloses");
+    const res = (await tool("review_verdict").handler(
+      { id: item.id, verdict: "pass", note: "independent PASS" },
+      ctxFor(reviewer.id),
+    )) as { workItem: { status: string; closedAt: string | null } };
+
+    expect(res.workItem.status).toBe("done");
+    expect(res.workItem.closedAt).toBeTruthy();
+  });
+
+  it("blocked records a DECLARED block carrying its exact unblock condition", async () => {
+    const { reviewer, item } = reviewScenario("declared");
+    const res = (await tool("review_verdict").handler(
+      { id: item.id, verdict: "blocked", unblockCondition: "operator must authorize one Vercel production mutation" },
+      ctxFor(reviewer.id),
+    )) as { workItem: { status: string } };
+
+    expect(res.workItem.status).toBe("blocked");
+    expect(store.listWorkItemEvents(item.id).at(-1)?.detail).toMatchObject({
+      declared: true,
+      unblockCondition: "operator must authorize one Vercel production mutation",
+    });
+  });
+
+  it("closes the bypass: update_work_item cannot write `blocked` from in_review", async () => {
+    const { reviewer, item } = reviewScenario("bypass");
+    await expect(tool("update_work_item").handler(
+      { id: item.id, status: "blocked", note: "reviewer rejection smuggled as a status write" },
+      ctxFor(reviewer.id),
+    )).rejects.toThrow(/review_verdict/);
+    expect(store.getWorkItem(item.id)?.status).toBe("in_review");
+    expect(store.getWorkItem(item.id)?.rounds).toBe(0);
+  });
+
+  it("still lets a PRODUCER block from executing — the legitimate external wall", async () => {
+    const owner = registry.createSession({ engine: "codex", source: "web", sourceRef: "rv-wall-owner", title: "wall owner", employee: "platform-dev" });
+    const item = store.createWorkItem({ title: "producer hits a wall", status: "executing", source: "delegation", assignee: "platform-dev" });
+    store.linkSession(item.id, owner.id);
+
+    const res = (await tool("update_work_item").handler(
+      { id: item.id, status: "blocked", note: "source videos absent on the authoritative volume" },
+      ctxFor(owner.id),
+    )) as { workItem: { status: string } };
+
+    expect(res.workItem.status).toBe("blocked");
+    // Producer blocks are declared too — they must survive reconciler derivation.
+    expect(store.listWorkItemEvents(item.id).at(-1)?.detail).toMatchObject({ declared: true });
   });
 });

--- a/packages/jinn/src/mcp/work-item-tools.ts
+++ b/packages/jinn/src/mcp/work-item-tools.ts
@@ -12,6 +12,9 @@ const WORK_ITEM_NOTE_CHAR_CAP = 8_000;
 const STATUSES = ["backlog", "assigned", "executing", "in_review", "done", "blocked", "escalated", "cancelled"] as const;
 const SOURCES = ["human", "delegation", "cron", "workflow", "session", "connector", "goal"] as const;
 const AGENT_UPDATE_STATUSES = ["executing", "in_review", "blocked", "escalated", "done"] as const;
+/** Review outcomes. Mirrors REVIEW_VERDICTS in gateway/api.ts — the gateway is
+ *  the authority; this copy is the tool-schema enum. */
+const REVIEW_VERDICTS = ["pass", "fail", "blocked"] as const;
 const VERIFY_MODES = ["trust", "verify", "thorough"] as const;
 const ACTIVITY_RECEIPT_HINT = "Preview or Open the persisted activity receipt in this chat.";
 const TODO_ID_SCHEMA = { type: "string", pattern: "^[A-Z]{3}-[1-9][0-9]*$" } as const;
@@ -79,6 +82,22 @@ function optionalString(args: Record<string, unknown>, name: string, max = FILTE
   const s = v.trim();
   assertLength(name, s, max);
   return s;
+}
+
+function optionalStringArray(args: Record<string, unknown>, name: string, max = FILTER_CHAR_CAP): string[] | undefined {
+  const v = args[name];
+  if (v === undefined || v === null) return undefined;
+  if (!Array.isArray(v)) throw new JinnMcpToolError(`${name} must be an array of strings when provided`);
+  const out: string[] = [];
+  for (const entry of v) {
+    if (typeof entry !== "string" || !entry.trim()) {
+      throw new JinnMcpToolError(`${name} entries must be non-empty strings`);
+    }
+    const s = entry.trim();
+    assertLength(`${name} entry`, s, max);
+    out.push(s);
+  }
+  return out;
 }
 
 function optionalEnum<T extends readonly string[]>(args: Record<string, unknown>, name: string, values: T): T[number] | undefined {
@@ -361,7 +380,7 @@ export function buildWorkItemTools(): JinnMcpTool[] {
 
   const update: JinnMcpTool = {
     name: "update_work_item",
-    description: "Update Todo status.",
+    description: "Update status on your OWN Todo. Judging someone else's work is review_verdict; a rejection written here is uncounted and never terminates.",
     inputSchema: {
       type: "object",
       properties: {
@@ -474,6 +493,62 @@ export function buildWorkItemTools(): JinnMcpTool[] {
         return mutationResult(body, "Todo metadata edited.");
       }
       throw conflict!;
+    },
+  };
+
+  const reviewVerdict: JinnMcpTool = {
+    name: "review_verdict",
+    description:
+      "Verdict on a Todo you reviewed but did not execute. pass closes it. fail returns it to the producer as a counted round, escalating to the operator at the round cap. blocked is an external need.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: TODO_ID_SCHEMA,
+        verdict: { type: "string", enum: [...REVIEW_VERDICTS] },
+        note: { type: "string" },
+        findings: {
+          type: "array",
+          items: { type: "string" },
+          description: "Required for fail: every defect from this pass, worst first. All of them costs one round; the first one costs N.",
+        },
+        unblockCondition: { type: "string", description: "Required for blocked: the exact external need." },
+      },
+      required: ["id", "verdict"],
+    },
+    handler: async (args, ctx) => {
+      assertIdentity(ctx);
+      rejectApprovalFields(args, "review_verdict");
+      const id = requireTodoId(args);
+      const verdict = requireString(args, "verdict");
+      if (!(REVIEW_VERDICTS as readonly string[]).includes(verdict)) {
+        throw new JinnMcpToolError(`verdict must be one of ${REVIEW_VERDICTS.join(", ")}`);
+      }
+      const payload: Record<string, unknown> = { verdict };
+      const note = optionalString(args, "note", 4000);
+      if (note !== undefined) payload.note = note;
+      const findings = optionalStringArray(args, "findings", 4000);
+      if (findings !== undefined) payload.findings = findings;
+      if (verdict === "fail" && (findings === undefined || findings.length === 0)) {
+        throw new JinnMcpToolError(
+          "a fail verdict requires findings: the complete ranked list of defects from this pass. One exhaustive pass returning everything costs one round; returning the first defect found costs N rounds and N fresh sessions.",
+        );
+      }
+      const unblockCondition = optionalString(args, "unblockCondition", 4000);
+      if (unblockCondition !== undefined) payload.unblockCondition = unblockCondition;
+      if (verdict === "blocked" && unblockCondition === undefined) {
+        throw new JinnMcpToolError("a blocked verdict requires unblockCondition: the exact external need.");
+      }
+      const { status, body } = await gatewayRequest(ctx, "POST", `/api/work-items/${encodeURIComponent(id)}/review`, payload);
+      if (status >= 400) throw gatewayFailure(`recording review verdict on "${id}"`, status, body);
+      const rec = (body ?? {}) as { escalated?: boolean; rounds?: number; maxRounds?: number };
+      const hint = verdict === "pass"
+        ? "Todo closed on your PASS."
+        : rec.escalated === true
+          ? "Round budget exhausted — Todo escalated to the operator instead of looping."
+          : verdict === "fail"
+            ? `Returned to the producer. Round ${rec.rounds ?? "?"} of ${rec.maxRounds ?? "?"}; at the cap it escalates to the operator.`
+            : "Todo blocked on an external need; it stays blocked until the condition is satisfied.";
+      return mutationResult(body, hint);
     },
   };
 
@@ -751,5 +826,5 @@ export function buildWorkItemTools(): JinnMcpTool[] {
     },
   };
 
-  return [list, get, tree, search, create, update, edit, assign, archive, comment, listComments, attach, listAttachments, link, unlink, label, labelsList, departments];
+  return [list, get, tree, search, create, update, edit, reviewVerdict, assign, archive, comment, listComments, attach, listAttachments, link, unlink, label, labelsList, departments];
 }

--- a/packages/jinn/src/work-items/__tests__/reconcile.test.ts
+++ b/packages/jinn/src/work-items/__tests__/reconcile.test.ts
@@ -33,10 +33,17 @@ function linkedSession(id: string, workItemId: string, status: SessionStatus, at
   ).run(id, `cron:${id}`, status, outcome, workItemId, at, at);
 }
 
+let transitionsModule: typeof import("../transitions.js");
+/** The guarded transition module, loaded after JINN_HOME is redirected. */
+function transitionsFor(): typeof import("../transitions.js") {
+  return transitionsModule;
+}
+
 beforeAll(async () => {
   store = await import("../store.js");
   reconcile = await import("../reconcile.js");
   reg = await import("../../sessions/registry.js");
+  transitionsModule = await import("../transitions.js");
   db = reg.initDb();
 });
 
@@ -357,5 +364,84 @@ describe("ICI-570 — live todo events from the reconciler", () => {
     } finally {
       live.setTodoLiveEmitter(null);
     }
+  });
+});
+
+describe("declared blocks survive derivation", () => {
+  it("pure: a DECLARED block stays blocked even with an in-flight session", () => {
+    expect(
+      reconcile.deriveWorkItemStatus("blocked", [evidence("running")], undefined, { blockDeclared: true }),
+    ).toBe("blocked");
+  });
+
+  it("pure: a DERIVED block still re-derives to executing (unchanged behaviour)", () => {
+    expect(
+      reconcile.deriveWorkItemStatus("blocked", [evidence("running")], undefined, { blockDeclared: false }),
+    ).toBe("executing");
+    // Absent options behaves exactly as before this change.
+    expect(reconcile.deriveWorkItemStatus("blocked", [evidence("running")])).toBe("executing");
+  });
+
+  it("pure: a declared block does not block the STICKY terminals or review", () => {
+    expect(reconcile.deriveWorkItemStatus("done", [evidence("running")], undefined, { blockDeclared: true })).toBe("done");
+    expect(reconcile.deriveWorkItemStatus("in_review", [evidence("running")], undefined, { blockDeclared: true })).toBe("in_review");
+  });
+
+  it("integration: an agent-declared block survives a sweep and writes NO event", () => {
+    const wi = store.createWorkItem({ title: "declared block holds", status: "executing", source: "delegation" });
+    linkedSession("s-declared-hold", wi.id, "running", "2026-07-02T00:00:00.000Z");
+    transitionsFor().transition(wi.id, "blocked", "engineering-verifier", {
+      detail: { declared: true, unblockCondition: "operator must authorize the production env write" },
+    });
+    const before = store.listWorkItemEvents(wi.id);
+
+    expect(reconcile.reconcileWorkItem(wi.id)).toMatchObject({ changed: false, item: { status: "blocked" } });
+    expect(store.getWorkItem(wi.id)?.status).toBe("blocked");
+    expect(store.listWorkItemEvents(wi.id)).toEqual(before);
+  });
+
+  it("integration: a reconciler-DERIVED block still clears when work resumes", () => {
+    const wi = store.createWorkItem({ title: "derived block clears", status: "executing", source: "delegation" });
+    linkedSession("s-derived-fail", wi.id, "interrupted", "2026-07-02T01:00:00.000Z");
+
+    // Transport failure derives the block...
+    expect(reconcile.reconcileWorkItem(wi.id)).toMatchObject({ changed: true, item: { status: "blocked" } });
+    expect(store.listWorkItemEvents(wi.id).at(-1)?.actor).toBe("reconciler");
+
+    // ...and a fresh in-flight attempt clears it, exactly as before.
+    linkedSession("s-derived-retry", wi.id, "running", "2026-07-02T02:00:00.000Z");
+    expect(reconcile.reconcileWorkItem(wi.id)).toMatchObject({ changed: true, item: { status: "executing" } });
+  });
+
+  it("integration: a pre-`declared` historical block falls back to actor provenance", () => {
+    const wi = store.createWorkItem({ title: "legacy block provenance", status: "executing", source: "delegation" });
+    linkedSession("s-legacy-block", wi.id, "running", "2026-07-02T03:00:00.000Z");
+    // A caller-written block with NO `declared` marker — the shape of every one
+    // of the 46 blocks already in the live ledger.
+    transitionsFor().transition(wi.id, "blocked", "session:abc123", { detail: { note: "external need" } });
+
+    expect(store.isBlockDeclared(wi.id)).toBe(true);
+    expect(reconcile.reconcileWorkItem(wi.id)).toMatchObject({ changed: false, item: { status: "blocked" } });
+  });
+
+  it("regression: repeated declare→sweep yields ONE block, not a flap per sweep", async () => {
+    const wi = store.createWorkItem({ title: "declared block under an active sweep", status: "executing", source: "delegation" });
+    linkedSession("s-jin44", wi.id, "running", "2026-07-02T04:00:00.000Z");
+
+    transitionsFor().transition(wi.id, "blocked", "session:abc123", {
+      detail: { declared: true, unblockCondition: "fresh production env authority" },
+    });
+
+    // Before this change the sweep flipped a declared block straight back,
+    // so the block never survived long enough to be seen.
+    const stop = reconcile.startWorkItemReconciler(10);
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    stop();
+
+    const blockEvents = store.listWorkItemEvents(wi.id).filter((e) => e.toStatus === "blocked");
+    const reconcilerWrites = store.listWorkItemEvents(wi.id).filter((e) => e.actor === "reconciler");
+    expect(blockEvents).toHaveLength(1);
+    expect(reconcilerWrites).toHaveLength(0);
+    expect(store.getWorkItem(wi.id)?.status).toBe("blocked");
   });
 });

--- a/packages/jinn/src/work-items/__tests__/transitions-bounce.test.ts
+++ b/packages/jinn/src/work-items/__tests__/transitions-bounce.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+
+// Throwaway registry DB, resolved from JINN_HOME at module load (see reconcile.test.ts).
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-wi-bounce-"));
+process.env.JINN_HOME = tmp;
+
+type Store = typeof import("../store.js");
+type Transitions = typeof import("../transitions.js");
+type Reg = typeof import("../../sessions/registry.js");
+
+let store: Store;
+let transitions: Transitions;
+let db: import("better-sqlite3").Database;
+
+beforeAll(async () => {
+  store = await import("../store.js");
+  transitions = await import("../transitions.js");
+  const reg: Reg = await import("../../sessions/registry.js");
+  db = reg.initDb();
+});
+
+/** Insert a session row and link it to the item as an execution attempt. */
+function linkedSession(id: string, workItemId: string): void {
+  db.prepare(
+    `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+     VALUES (?, 'claude', 'cron', ?, 'idle', ?, '2026-07-01T00:00:00.000Z', '2026-07-01T00:00:00.000Z')`,
+  ).run(id, `cron:${id}`, workItemId);
+  store.linkSession(workItemId, id);
+}
+
+/**
+ * The review BOUNCE and its round budget (design §1.3).
+ *
+ * These paths existed and were correct but had never once executed in
+ * production: the only agent-reachable route (`POST /work-items/:id/status`)
+ * sets `manual`, and `transition()` refuses a manual move into `executing` from
+ * anything but backlog/assigned. So `in_review → executing` was unreachable,
+ * `rounds` never incremented, `effectiveMaxRounds` never fired, and reviewers
+ * expressed rejection as `in_review → blocked` instead — an uncounted edge that
+ * lets a review loop run forever: `rounds` stays 0 for the item's whole life,
+ * so `effectiveMaxRounds` never fires and a review can bounce indefinitely
+ * without ever reaching the operator.
+ *
+ * The bar these tests hold: a rejection is COUNTED, and a bounded loop ENDS in
+ * front of the operator rather than spinning.
+ */
+describe("review bounce — the round budget that had never fired", () => {
+  it("increments rounds and records bounce provenance on the audit event", () => {
+    const wi = store.createWorkItem({
+      title: "bounce increments rounds",
+      status: "in_review",
+      source: "delegation",
+      verifyPolicy: { mode: "thorough", maxRounds: 4 },
+    });
+
+    const result = transitions.transition(wi.id, "executing", "engineering-verifier", {
+      bounce: true,
+      detail: { verdict: "fail", findings: ["cache validation is lazy"] },
+    });
+
+    expect(result.item.status).toBe("executing");
+    expect(result.item.rounds).toBe(1);
+    expect(result.escalated).toBe(false);
+    expect(result.event?.detail).toMatchObject({ bounce: true, rounds: 1, verdict: "fail" });
+  });
+
+  it("is refused as `manual` — the exact reason the bounce edge was unreachable", () => {
+    const wi = store.createWorkItem({
+      title: "manual cannot bounce",
+      status: "in_review",
+      source: "delegation",
+    });
+
+    // This is what POST /work-items/:id/status did with target `executing`.
+    expect(() => transitions.transition(wi.id, "executing", "engineering-verifier", { manual: true }))
+      .toThrow(/illegal transition|illegal manual transition/);
+    expect(store.getWorkItem(wi.id)?.status).toBe("in_review");
+    expect(store.getWorkItem(wi.id)?.rounds).toBe(0);
+  });
+
+  it("ESCALATES to the operator instead of looping once the budget is exhausted", () => {
+    const maxRounds = 3;
+    const wi = store.createWorkItem({
+      title: "bounded loop ends at the operator",
+      status: "in_review",
+      source: "delegation",
+      verifyPolicy: { mode: "thorough", maxRounds },
+    });
+
+    // Rounds 1..maxRounds-1 return the item to its producer.
+    for (let round = 1; round < maxRounds; round += 1) {
+      const back = transitions.transition(wi.id, "executing", "engineering-verifier", {
+        bounce: true,
+        detail: { verdict: "fail", findings: [`round ${round} defect`] },
+      });
+      expect(back.item.status).toBe("executing");
+      expect(back.item.rounds).toBe(round);
+      expect(back.escalated).toBe(false);
+      transitions.transition(wi.id, "in_review", "pipeline-reliability-engineer", {});
+    }
+
+    // The exhausting rejection does NOT return to executing — it lands on the
+    // operator's queue. This is the loop terminator that never ran.
+    const final = transitions.transition(wi.id, "executing", "engineering-verifier", {
+      bounce: true,
+      detail: { verdict: "fail", findings: ["still not fixed"] },
+    });
+
+    expect(final.escalated).toBe(true);
+    expect(final.item.status).toBe("escalated");
+    expect(final.item.rounds).toBe(maxRounds);
+    expect(final.event?.kind).toBe("escalated");
+    expect(final.event?.detail).toMatchObject({ reason: "max-rounds-exhausted", maxRounds });
+  });
+
+  it("uses the verify-mode default budget when the item declares no maxRounds", () => {
+    const wi = store.createWorkItem({
+      title: "default budget applies",
+      status: "in_review",
+      source: "delegation",
+      verifyPolicy: { mode: "verify" },
+    });
+    const budget = store.effectiveMaxRounds(store.getWorkItem(wi.id)!);
+    expect(budget).toBeGreaterThan(0);
+
+    let escalated = false;
+    for (let round = 0; round < budget + 2 && !escalated; round += 1) {
+      const r = transitions.transition(wi.id, "executing", "engineering-verifier", {
+        bounce: true,
+        detail: { verdict: "fail", findings: ["defect"] },
+      });
+      escalated = r.escalated;
+      if (!escalated) transitions.transition(wi.id, "in_review", "producer", {});
+    }
+    expect(escalated).toBe(true);
+    expect(store.getWorkItem(wi.id)?.status).toBe("escalated");
+  });
+
+  it("a non-bounce in_review → executing does NOT consume the budget", () => {
+    const wi = store.createWorkItem({
+      title: "plain reopen is free",
+      status: "in_review",
+      source: "delegation",
+      verifyPolicy: { mode: "thorough", maxRounds: 2 },
+    });
+
+    transitions.transition(wi.id, "executing", "operator", {});
+    expect(store.getWorkItem(wi.id)?.rounds).toBe(0);
+    expect(store.getWorkItem(wi.id)?.status).toBe("executing");
+  });
+
+  it("keeps the self-review ban on the closure path", () => {
+    const wi = store.createWorkItem({
+      title: "producer cannot close its own work",
+      status: "in_review",
+      source: "delegation",
+    });
+    const linked = "sess-executor-1";
+    linkedSession(linked, wi.id);
+
+    expect(() => transitions.transition(wi.id, "done", "engineering-verifier", { callerSessionId: linked }))
+      .toThrow(/self-review/i);
+    expect(store.getWorkItem(wi.id)?.status).toBe("in_review");
+  });
+
+  it("closes on a reviewer PASS and stamps closed_at — closure IS the verdict", () => {
+    const wi = store.createWorkItem({
+      title: "pass closes immediately",
+      status: "in_review",
+      source: "delegation",
+    });
+    linkedSession("sess-executor-2", wi.id);
+
+    const closed = transitions.transition(wi.id, "done", "engineering-verifier", {
+      callerSessionId: "sess-reviewer-2",
+      detail: { verdict: "pass" },
+    });
+
+    expect(closed.item.status).toBe("done");
+    expect(closed.item.closedAt).toBeTruthy();
+    expect(closed.event?.detail).toMatchObject({ verdict: "pass" });
+  });
+});

--- a/packages/jinn/src/work-items/reconcile.ts
+++ b/packages/jinn/src/work-items/reconcile.ts
@@ -1,7 +1,9 @@
 import {
   effectiveVerifyMode,
   getWorkItem,
+  isBlockDeclared,
   listWorkItems,
+  RECONCILER_ACTOR,
   STICKY_STATUSES,
   type WorkItem,
   type WorkItemSource,
@@ -49,6 +51,17 @@ export interface WorkItemAttemptEvidence {
 /** A session is "in flight" (work is actively happening) in these states. */
 const IN_FLIGHT: ReadonlySet<SessionStatus> = new Set<SessionStatus>(['running', 'waiting']);
 
+/** Extra derivation context that cannot be read from session receipts alone. */
+export interface DeriveWorkItemOptions {
+  /**
+   * True when the item's current `blocked` was DECLARED by a caller (an agent or
+   * the operator saying "this needs a decision") rather than DERIVED from a
+   * failed/interrupted receipt. Computed by `reconcileWorkItem` from the latest
+   * block event so this function stays pure.
+   */
+  blockDeclared?: boolean;
+}
+
 /**
  * Pure derivation: given an item's current status, its provenance, and the
  * terminal receipts of its linked sessions **ordered newest-first** (as
@@ -60,6 +73,7 @@ export function deriveWorkItemStatus(
   current: WorkItemStatus,
   attempts: readonly WorkItemAttemptEvidence[],
   source?: WorkItemSource,
+  opts?: DeriveWorkItemOptions,
 ): WorkItemStatus {
   if (STICKY_STATUSES.has(current)) return current;
   if (attempts.length === 0) return current;
@@ -67,6 +81,14 @@ export function deriveWorkItemStatus(
   // Parent callbacks and review conversations may run on linked sessions after
   // submission; only an explicit review bounce may reopen execution.
   if (current === 'in_review') return current;
+  // A DECLARED block is governance too — the same argument as `in_review`. An
+  // agent saying "I need an operator decision" must not be erased because some
+  // linked session is still live: a follow-up investigation, a watchdog, or the
+  // manager's own probe all count as in-flight and would silently derive the
+  // item back to `executing`, dropping the blocker off the operator's queue
+  // before it was ever seen. A block DERIVED from a failed receipt stays
+  // transport state and keeps re-deriving as before.
+  if (current === 'blocked' && opts?.blockDeclared) return current;
   if (attempts.some((attempt) => IN_FLIGHT.has(attempt.status))) return 'executing';
   // Nothing in flight — the most recent attempt (index 0, newest-first) is the
   // authority (an old clean settle must not mask a newer failure, and a newer
@@ -100,14 +122,17 @@ export function reconcileWorkItem(id: string): ReconcileResult | undefined {
     status: s.status as SessionStatus,
     outcome: s.attemptOutcome ?? null,
   }));
-  const derived = deriveWorkItemStatus(item.status, attempts, item.source);
+  // Only pay for the block-provenance lookup when the item is actually blocked.
+  const derived = deriveWorkItemStatus(item.status, attempts, item.source, {
+    blockDeclared: item.status === 'blocked' ? isBlockDeclared(id) : false,
+  });
 
   let current = item;
   let changed = false;
   if (derived !== item.status) {
     // transitionDerived returns undefined on a sticky/concurrent race — report
     // the fresh truth as unchanged rather than clobbering a deliberate decision.
-    const updated = transitionDerived(id, derived, 'reconciler');
+    const updated = transitionDerived(id, derived, RECONCILER_ACTOR, { declared: false });
     if (updated) {
       current = updated;
       changed = true;

--- a/packages/jinn/src/work-items/store.ts
+++ b/packages/jinn/src/work-items/store.ts
@@ -51,6 +51,10 @@ const CLOSED_STATUSES: ReadonlySet<WorkItemStatus> = new Set<WorkItemStatus>(['d
  *  to the operator that session churn must not silently undo. */
 export const STICKY_STATUSES: ReadonlySet<WorkItemStatus> = new Set<WorkItemStatus>(['done', 'cancelled', 'escalated']);
 
+/** Actor recorded on the reconciler's own derived writes. Blocks bearing it are
+ *  transport-derived; anything else was declared by a caller. */
+export const RECONCILER_ACTOR = 'reconciler';
+
 export interface VerifyPolicy {
   mode: VerifyMode;
   verifier?: { employee?: string; engine?: string; model?: string };
@@ -376,6 +380,43 @@ export function appendWorkItemEvent(input: AppendWorkItemEventInput): WorkItemEv
 }
 
 /** List an item's audit trail, oldest-first (the story reads top-down). */
+/**
+ * Was this item's current `blocked` DECLARED by a caller, or DERIVED by the
+ * reconciler from a failed/interrupted receipt?
+ *
+ * A declared block is a governance statement ("this needs a decision") and must
+ * survive session-transport churn; a derived one is transport state and keeps
+ * re-deriving. Reads only the newest block event via `idx_wi_events_item`, so
+ * the reconcile sweep stays one bounded row per candidate rather than loading
+ * and JSON-parsing an item's whole event history.
+ *
+ * Blocks written before `declared` existed have no marker; those fall back to
+ * actor provenance — anything the reconciler did not write was written by a
+ * caller. That keeps historical ledgers behaving exactly as they did.
+ */
+export function isBlockDeclared(workItemId: string): boolean {
+  const db = initDb();
+  const id = parseTodoId(workItemId);
+  const row = db
+    .prepare(
+      `SELECT actor, detail FROM work_item_events
+       WHERE work_item_id = ? AND to_status = 'blocked'
+       ORDER BY created_at DESC, rowid DESC LIMIT 1`,
+    )
+    .get(id) as { actor: string | null; detail: string | null } | undefined;
+  if (!row) return false;
+  if (typeof row.detail === 'string' && row.detail) {
+    try {
+      const parsed = JSON.parse(row.detail) as Record<string, unknown>;
+      if (parsed.declared === true) return true;
+      if (parsed.declared === false) return false;
+    } catch {
+      // Unparseable payload falls through to actor provenance.
+    }
+  }
+  return row.actor !== null && row.actor !== RECONCILER_ACTOR;
+}
+
 export function listWorkItemEvents(workItemId: string): WorkItemEvent[] {
   const db = initDb();
   const id = parseTodoId(workItemId);


### PR DESCRIPTION
A reviewer has no way to say "rejected" — the only thing they can write is a status, and no status counts as a rejection, so nothing tracks how many times a piece of work has come back and a review can bounce between reviewer and producer indefinitely without ever reaching the operator. This adds a proper verdict surface (pass / fail / blocked) wired into the round-counting path that already exists, so a stuck review escalates to the operator at the cap instead of looping — and it stops the reconciler from erasing a blocker before anyone has seen it.

---

Two things in the Todos state machine that are built but unreachable.

**The review bounce can't be expressed.** `transition()` supports `in_review → executing` with `rounds++`, escalating to the operator at `effectiveMaxRounds`. But the only agent route, `POST /work-items/:id/status`, passes `manual: true`, and `transitions.ts` refuses a manual move into `executing` from anything but `backlog`/`assigned`. So that edge never fires: `rounds` stays `0` for an item's whole life, the round cap never applies, and reviewers reject by writing `in_review → blocked` instead — an uncounted edge, so a review loop never terminates.

Adds `POST /work-items/:id/review` and a `review_verdict` tool. Three verdicts, all routed to existing `transition()` options:

- `pass` → `done`
- `fail` → `executing` `{bounce}`
- `blocked` → `blocked` `{declared}`

`fail` requires the full findings list, so one pass costs one round instead of N. Agent `in_review → blocked` is refused with a pointer to the new route; producers still block from `executing`. The reviewer check is extracted so verdict authority and done-closure authority stay in sync.

**Declared blocks get erased.** `blocked` means two things: an agent saying "this needs a decision", and the reconciler saying "the last attempt failed". Derivation won, so a declared block vanished as soon as any linked session was in flight — a watchdog, a follow-up probe — and never reached the operator's queue.

`deriveWorkItemStatus` now honours a `blockDeclared` flag, the same guard already applied to `in_review`. Provenance comes from the newest block event via one indexed row. Existing blocks carry no marker and fall back to actor provenance, so old data behaves exactly as before.

No new statuses. Manifest budget `4911 → 5125` for the new tool.

