### PR TITLE
feat(sessions): detect an unhonoured context window, and hand off before filling it

### DIFF
--- a/packages/jinn/src/cli/__tests__/setup-template.test.ts
+++ b/packages/jinn/src/cli/__tests__/setup-template.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+
+/** The default config is a template string, so a YAML mistake in it is invisible
+ *  until a user runs `jinn setup` and their install is broken. Model ids
+ *  containing "[" (the 1M-context variants) are the sharp edge: "[" is a YAML
+ *  indicator, so an unquoted opus[1m] parses fine in block style and throws in
+ *  flow style — which is what the template uses. */
+const setupSrc = fs.readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "../setup.ts"),
+  "utf8",
+);
+
+/** Pull DEFAULT_CONFIG out of the source and neutralise its one interpolation. */
+function defaultConfigYaml(): string {
+  const m = /const DEFAULT_CONFIG = `([\s\S]*?)`;/.exec(setupSrc);
+  if (!m) throw new Error("DEFAULT_CONFIG template literal not found in setup.ts");
+  return m[1].replace(/\$\{getPackageVersion\(\)\}/g, "0.0.0-test");
+}
+
+describe("setup.ts DEFAULT_CONFIG", () => {
+  it("is valid YAML", () => {
+    expect(() => YAML.parse(defaultConfigYaml())).not.toThrow();
+  });
+
+  it("parses every model id as a plain string", () => {
+    const cfg = YAML.parse(defaultConfigYaml()) as {
+      models: Record<string, { models: { id: unknown; label: unknown }[] }>;
+    };
+    for (const [engine, block] of Object.entries(cfg.models ?? {})) {
+      for (const m of block.models ?? []) {
+        expect(typeof m.id, `${engine} model id ${JSON.stringify(m.id)} must be a string`).toBe("string");
+        expect(String(m.id).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("keeps bracketed ids intact — an unquoted [1m] would parse as a sequence", () => {
+    const cfg = YAML.parse(defaultConfigYaml()) as {
+      models: Record<string, { models: { id: string }[] }>;
+    };
+    const ids = cfg.models.claude.models.map((m) => m.id);
+    for (const id of ["opus[1m]", "sonnet[1m]"]) {
+      expect(ids, `${id} must survive parsing verbatim`).toContain(id);
+    }
+  });
+
+  it("every engine default names a model present in that engine's roster", () => {
+    const cfg = YAML.parse(defaultConfigYaml()) as {
+      models: Record<string, { default: string; models: { id: string }[] }>;
+    };
+    for (const [engine, block] of Object.entries(cfg.models ?? {})) {
+      if (!block?.default) continue;
+      expect(block.models.map((m) => m.id), `${engine} default must exist in its roster`).toContain(block.default);
+    }
+  });
+});

--- a/packages/jinn/src/cli/setup.ts
+++ b/packages/jinn/src/cli/setup.ts
@@ -260,9 +260,20 @@ models:
     default: opus
     effortMechanism: claude-flag
     models:
+      # Bare aliases (opus/sonnet) run Claude Code's standard context window.
+      # The "[1m]" variants request the 1M-token window and are separate model
+      # ids, not a flag — "opus" and "opus[1m]" are different models to the CLI.
+      # Pick a [1m] entry if you run large personas or long agentic sessions;
+      # a big injected system prompt against the standard window compacts early
+      # and can thrash. Leave contextWindow unset unless you have measured it:
+      # a declared window that the engine does not honour is worse than none,
+      # and the gateway warns when observed context never approaches it.
       - { id: opus, label: "Opus (Latest)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
       - { id: sonnet, label: "Sonnet (Latest)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
       - { id: fable, label: "Fable (Latest)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
+      # Quoted: "[" is a YAML indicator, so a bare opus[1m] breaks flow style.
+      - { id: "opus[1m]", label: "Opus (1M context)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
+      - { id: "sonnet[1m]", label: "Sonnet (1M context)", supportsEffort: true, effortLevels: [low, medium, high, xhigh, max] }
   codex:
     default: gpt-5.5
     effortMechanism: codex-config

--- a/packages/jinn/src/sessions/manager.ts
+++ b/packages/jinn/src/sessions/manager.ts
@@ -40,6 +40,7 @@ import { logger } from "../shared/logger.js";
 import { resolveEffort } from "../shared/effort.js";
 import { effortLevelsForModel, engineAvailable, isKnownEngine, engineUnavailableMessage, contextWindowForModel } from "../shared/models.js";
 import { assessContextCeiling, reportContextCeiling } from "../shared/context-ceiling.js";
+import { assessContextPressure, pendingNudgeText, markNudgeDelivered, queueNudge, deliveredLevel, HANDOFF_META_KEYS } from "../shared/context-pressure.js";
 import { detectRateLimit, isDeadSessionError, rateLimitEngineLabel } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, isLikelyNearClaudeUsageLimit } from "../shared/usageAwareness.js";
 import { loadJobs } from "../cron/jobs.js";
@@ -136,6 +137,9 @@ export function mergeTransportMeta(
     "transcriptSyncedThrough",
     "delegationCompletionTracked",
     "delegationCompletionContract",
+    // Owned by the context-handoff feature. Derived from the module so the two
+    // can never drift: a lost level turns "nudge once" into "nudge every turn".
+    ...HANDOFF_META_KEYS,
   ]) {
     if (baseExisting[key] !== undefined) merged[key] = baseExisting[key];
   }
@@ -477,6 +481,11 @@ export class SessionManager {
         Number.isFinite(switchSyncSinceMs);
       const syncSinceIso = typeof syncMeta.claudeSyncSince === "string" ? syncMeta.claudeSyncSince : null;
       let promptToRun = msg.text;
+      // A handoff nudge owed from a previous turn rides this real turn's prompt
+      // rather than forcing a turn of its own: no extra cost, and it is simply
+      // dropped if the session never runs again.
+      const pendingHandoff = pendingNudgeText(syncMeta as Record<string, unknown>);
+      if (pendingHandoff) promptToRun = `${pendingHandoff}\n\n---\n\n${promptToRun}`;
       const syncSinceMs = typeof syncSinceIso === "string" ? new Date(syncSinceIso).getTime() : NaN;
       const claudeSyncRequested = engineAtTurnStart === "claude" && typeof syncSinceIso === "string" && Number.isFinite(syncSinceMs);
       const syncRequested = engineSyncRequested || claudeSyncRequested;
@@ -950,6 +959,32 @@ export class SessionManager {
             delete merged["engineSyncTarget"];
             delete merged["engineSyncSince"];
           }
+          // A nudge carried into this turn has now been delivered — clear it so
+          // it is not prepended again, and remember the level so the next
+          // assessment only escalates rather than repeating.
+          if (pendingHandoff && !wasInterrupted) {
+            markNudgeDelivered(merged, (syncMeta as Record<string, unknown>).contextHandoffPendingLevel);
+          }
+          // Long worker sessions re-send their whole context every turn. When one
+          // approaches its window, fire the org's existing handoff contract early
+          // (state to the work item, then DONE/BLOCKED) rather than letting it ride
+          // to an uncontrolled compaction. Operator chat is excluded — it has no
+          // one to hand off to. Never throws; diagnostics must not break a turn.
+          try {
+            const pressure = assessContextPressure({
+              contextTokens: result.contextTokens,
+              contextWindow: contextWindowForModel(this.config, engineAtTurnStart, modelForTurn, { exact: true }),
+              employee: session.employee,
+              alreadyNudged: deliveredLevel(merged),
+            });
+            if (pressure) {
+              queueNudge(merged, pressure);
+              logger.info(
+                `Session ${session.id} (${session.employee}) at ${Math.round(pressure.ratio * 100)}% of context ` +
+                  `(${pressure.contextTokens.toLocaleString()}/${pressure.contextWindow.toLocaleString()}) — queued ${pressure.level} handoff nudge`,
+              );
+            }
+          } catch { /* never break a turn on a diagnostic */ }
           return merged as any;
         })(),
         lastActivity: completedAt,

--- a/packages/jinn/src/sessions/manager.ts
+++ b/packages/jinn/src/sessions/manager.ts
@@ -38,7 +38,8 @@ import { SessionQueue } from "./queue.js";
 import { JINN_HOME } from "../shared/paths.js";
 import { logger } from "../shared/logger.js";
 import { resolveEffort } from "../shared/effort.js";
-import { effortLevelsForModel, engineAvailable, isKnownEngine, engineUnavailableMessage } from "../shared/models.js";
+import { effortLevelsForModel, engineAvailable, isKnownEngine, engineUnavailableMessage, contextWindowForModel } from "../shared/models.js";
+import { assessContextCeiling, reportContextCeiling } from "../shared/context-ceiling.js";
 import { detectRateLimit, isDeadSessionError, rateLimitEngineLabel } from "../shared/rateLimit.js";
 import { getClaudeExpectedResetAt, isLikelyNearClaudeUsageLimit } from "../shared/usageAwareness.js";
 import { loadJobs } from "../cron/jobs.js";
@@ -917,6 +918,25 @@ export class SessionManager {
           platformContextFingerprint,
         });
       }
+      // The highest context a model ever reaches is the ceiling it is actually
+      // being allowed. If it never approaches the window the roster declares,
+      // the model id we passed is not getting the window we think it is (e.g.
+      // Claude's bare `opus` alias caps at 200K where `opus[1m]` gives 1M) and
+      // sessions will compaction-thrash. Warns once per model; never throws.
+      reportContextCeiling(
+        engineAtTurnStart,
+        modelForTurn,
+        assessContextCeiling({
+          engine: engineAtTurnStart,
+          model: modelForTurn,
+          // `exact`: a model missing from the roster would otherwise report the
+          // engine default's window, and comparing one model's context against
+          // another's declared window is worse than not checking at all.
+          declaredWindow: contextWindowForModel(this.config, engineAtTurnStart, modelForTurn, { exact: true }),
+          currentTokens: result.contextTokens,
+          userPrompt: msg.text,
+        }),
+      );
       const updatedSession = completeSessionAttempt(session.id, attemptToken, {
         ...(typeof result.contextTokens === "number" ? { lastContextTokens: result.contextTokens } : {}),
         status: wasInterrupted ? "interrupted" : (result.error ? "error" : "idle"),

--- a/packages/jinn/src/shared/__tests__/context-ceiling.test.ts
+++ b/packages/jinn/src/shared/__tests__/context-ceiling.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  assessContextCeiling,
+  resetContextCeilingState,
+  SUSPECT_RATIO,
+  MIN_TURNS_SINCE_PEAK,
+  MIN_EVIDENCE_TOKENS,
+} from "../context-ceiling.js";
+
+/** Measured from the real incident (2026-07-24, transcript 1a6151f8): Opus
+ *  spawned via the bare `opus` alias got a 200K window while the roster
+ *  declared 1M — it peaked at 191,584 across 116 readings. Fable, on a genuine
+ *  1M window, peaked at 640,447 across 1021. Those two numbers are what the
+ *  thresholds are calibrated against. */
+const DECLARED_1M = 1_000_000;
+const BROKEN_PEAK = 191_584;
+const HEALTHY_PEAK = 640_447;
+
+/** Feed n turns at `tokens`, as manager.ts would.
+ *
+ *  Returns the last verdict, but with `warn`/`suspect` folded across the whole
+ *  run: `warn` is once-per-model, so the final verdict of a long run always
+ *  reads false even when it fired on turn 26. Asserting on the last verdict
+ *  alone silently passes — that flaw let a mutation removing MIN_EVIDENCE_TOKENS
+ *  survive. "Did it ever fire" is what these tests actually mean. */
+function feed(n: number, tokens: number, declared: number, model = "opus", userPrompt = "do the task") {
+  let last!: ReturnType<typeof assessContextCeiling>;
+  let everWarned = false;
+  let everSuspect = false;
+  for (let i = 0; i < n; i++) {
+    last = assessContextCeiling({
+      engine: "claude", model, declaredWindow: declared, currentTokens: tokens, userPrompt,
+    });
+    everWarned ||= last.warn;
+    everSuspect ||= last.suspect;
+  }
+  return { ...last, warn: everWarned, suspect: everSuspect };
+}
+
+beforeEach(() => resetContextCeilingState());
+
+describe("assessContextCeiling — detection", () => {
+  it("fires on the real incident's ceiling once there is enough evidence", () => {
+    const v = feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M);
+    expect(v.warn).toBe(true);
+    expect(v.observedCeiling).toBe(BROKEN_PEAK);
+    expect(v.ratio).toBeCloseTo(0.192, 3);
+  });
+
+  it("warns exactly once per model however long the thrash continues", () => {
+    const verdicts = Array.from({ length: 200 }, () =>
+      assessContextCeiling({
+        engine: "claude", model: "opus", declaredWindow: DECLARED_1M,
+        currentTokens: BROKEN_PEAK, userPrompt: "go",
+      }),
+    );
+    expect(verdicts.filter((v) => v.warn).length).toBe(1);
+  });
+
+  it("tracks each engine/model pair independently", () => {
+    feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M, "opus");
+    expect(feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M, "sonnet").warn).toBe(true);
+  });
+
+  it("remembers the peak — one big turn is enough to clear suspicion", () => {
+    assessContextCeiling({
+      engine: "claude", model: "opus", declaredWindow: DECLARED_1M,
+      currentTokens: HEALTHY_PEAK, userPrompt: "go",
+    });
+    expect(feed(MIN_TURNS_SINCE_PEAK * 2, 60_000, DECLARED_1M, "opus").warn).toBe(false);
+  });
+});
+
+describe("assessContextCeiling — false positives", () => {
+  it("never fires on the healthy 1M model from the same transcript", () => {
+    expect(feed(200, HEALTHY_PEAK, DECLARED_1M, "fable").warn).toBe(false);
+  });
+
+  it("stays silent before there is enough evidence", () => {
+    expect(feed(MIN_TURNS_SINCE_PEAK, BROKEN_PEAK, DECLARED_1M).suspect).toBe(false);
+  });
+
+  it("stays silent on light usage that never pushed the window", () => {
+    // Many turns, but never near MIN_EVIDENCE_TOKENS — proves nothing.
+    expect(feed(500, MIN_EVIDENCE_TOKENS - 1, DECLARED_1M, "chatty").warn).toBe(false);
+  });
+
+  it("stays silent when the roster declares the window honestly", () => {
+    // Same 191K ceiling, but the roster correctly says 200K.
+    expect(feed(200, BROKEN_PEAK, 200_000, "opus-honest").warn).toBe(false);
+  });
+
+  it("stays silent when the declared window is unknown", () => {
+    expect(feed(200, BROKEN_PEAK, undefined as unknown as number, "mystery").suspect).toBe(false);
+  });
+
+  it("excludes slash commands from evidence entirely", () => {
+    for (const cmd of ["/clear", "/compact", "  /compact  ", "/model opus"]) {
+      resetContextCeilingState();
+      expect(feed(200, BROKEN_PEAK, DECLARED_1M, "opus", cmd).suspect, `${cmd} must not count`).toBe(false);
+    }
+  });
+
+  it("does not mistake a path argument for a slash command", () => {
+    expect(feed(MIN_TURNS_SINCE_PEAK + 1, BROKEN_PEAK, DECLARED_1M, "opus", "read /etc/hosts").warn).toBe(true);
+  });
+});
+
+describe("assessContextCeiling — robustness", () => {
+  it("returns a fresh verdict object each call", () => {
+    const a = assessContextCeiling({ engine: "claude", model: "m", declaredWindow: DECLARED_1M, currentTokens: null });
+    (a as { suspect: boolean }).suspect = true;
+    const b = assessContextCeiling({ engine: "claude", model: "m", declaredWindow: DECLARED_1M, currentTokens: null });
+    expect(b.suspect).toBe(false);
+  });
+
+  it("never throws on malformed or hostile input", () => {
+    const bad = [0, -5, Number.NaN, Number.POSITIVE_INFINITY, null, undefined];
+    for (const tokens of bad) {
+      for (const declared of [DECLARED_1M, 0, -1, Number.NaN, undefined]) {
+        expect(() =>
+          assessContextCeiling({
+            engine: "claude", model: "opus",
+            declaredWindow: declared as number,
+            currentTokens: tokens as number,
+          }),
+        ).not.toThrow();
+      }
+    }
+  });
+
+  it("keeps the threshold inside the gap measured on real data", () => {
+    expect(BROKEN_PEAK / DECLARED_1M).toBeLessThan(SUSPECT_RATIO);
+    expect(HEALTHY_PEAK / DECLARED_1M).toBeGreaterThan(SUSPECT_RATIO);
+  });
+});

--- a/packages/jinn/src/shared/__tests__/context-pressure-lifecycle.test.ts
+++ b/packages/jinn/src/shared/__tests__/context-pressure-lifecycle.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { assessContextPressure, pendingNudgeText, markNudgeDelivered, queueNudge, deliveredLevel } from "../context-pressure.js";
+import { mergeTransportMeta } from "../../sessions/manager.js";
+
+/**
+ * The nudge is delivered through transportMeta across turns, so the parts that
+ * can actually break are the state transitions, not the threshold maths:
+ * queue → carry across a turn → prepend → clear → don't repeat → escalate once.
+ * This walks a session through them the way manager.ts does.
+ */
+
+const WINDOW = 1_000_000;
+
+/** Mirrors manager.ts turn-end: assess, and queue the nudge into meta. */
+function endTurn(meta: Record<string, unknown>, contextTokens: number, employee = "fight-process-lead") {
+  const next = { ...meta };
+  const carried = pendingNudgeText(next);
+  if (carried) markNudgeDelivered(next, next["contextHandoffPendingLevel"]);
+  const v = assessContextPressure({
+    contextTokens, contextWindow: WINDOW, employee, alreadyNudged: deliveredLevel(next),
+  });
+  if (v) queueNudge(next, v);
+  return next;
+}
+
+/** Mirrors manager.ts turn-start: prepend a pending nudge to the real prompt. */
+function startTurn(meta: Record<string, unknown>, prompt: string) {
+  const pending = pendingNudgeText(meta);
+  return pending ? `${pending}\n\n---\n\n${prompt}` : prompt;
+}
+
+describe("handoff nudge lifecycle", () => {
+  it("queues nothing while the session is comfortable", () => {
+    const meta = endTurn({}, 300_000);
+    expect(meta["contextHandoffPending"]).toBeUndefined();
+    expect(startTurn(meta, "do the thing")).toBe("do the thing");
+  });
+
+  it("queues at 70% and rides the NEXT real prompt rather than forcing a turn", () => {
+    const meta = endTurn({}, 720_000);
+    expect(meta["contextHandoffPending"]).toBeTypeOf("string");
+    const prompt = startTurn(meta, "continue the audit");
+    expect(prompt).toContain("Context checkpoint");
+    expect(prompt).toContain("continue the audit"); // the real work is preserved
+    expect(prompt.indexOf("Context checkpoint")).toBeLessThan(prompt.indexOf("continue the audit"));
+  });
+
+  it("clears after delivery so it is never prepended twice", () => {
+    let meta = endTurn({}, 720_000);
+    expect(startTurn(meta, "x")).toContain("Context checkpoint");
+    meta = endTurn(meta, 730_000);               // the turn that carried it completes
+    expect(startTurn(meta, "x")).toBe("x");       // gone
+    expect(meta["contextHandoffDelivered"]).toBe("wrap-up");
+  });
+
+  it("does not nag while the agent is still wrapping up", () => {
+    let meta = endTurn({}, 720_000);
+    meta = endTurn(meta, 750_000);
+    for (const tokens of [760_000, 780_000, 800_000, 840_000]) {
+      meta = endTurn(meta, tokens);
+      expect(startTurn(meta, "x"), `should stay quiet at ${tokens}`).toBe("x");
+    }
+  });
+
+  it("escalates once when the agent blows past the second threshold", () => {
+    let meta = endTurn({}, 720_000);
+    meta = endTurn(meta, 730_000);                // wrap-up delivered
+    meta = endTurn(meta, 880_000);                // crosses urgent
+    const prompt = startTurn(meta, "x");
+    expect(prompt).toContain("wrap up now");
+    meta = endTurn(meta, 890_000);                // urgent delivered
+    expect(meta["contextHandoffDelivered"]).toBe("urgent");
+    meta = endTurn(meta, 950_000);
+    expect(startTurn(meta, "x")).toBe("x");       // never again
+  });
+
+  it("survives a transport adapter overwriting metadata mid-session", () => {
+    const meta = endTurn({}, 720_000);
+    // A connector merges its own transportMeta; internal keys must survive.
+    const merged = mergeTransportMeta(meta as never, { channelName: "web" } as never) as Record<string, unknown>;
+    expect(merged["contextHandoffPending"]).toBe(meta["contextHandoffPending"]);
+    expect(startTurn(merged, "x")).toContain("Context checkpoint");
+  });
+
+  it("leaves operator chat alone through the whole lifecycle", () => {
+    let meta: Record<string, unknown> = {};
+    for (const tokens of [720_000, 880_000, 990_000]) {
+      meta = endTurn(meta, tokens, "");           // Genie: no employee
+      expect(startTurn(meta, "keep chatting")).toBe("keep chatting");
+    }
+  });
+
+  it("keeps the pending level when a connector's own metadata would clobber it", () => {
+    // mergeTransportMeta spreads incoming over existing, so the preserved-key
+    // list is the ONLY thing protecting an internal key that a transport
+    // adapter also happens to set. Without it the level is lost, `delivered` is
+    // never recorded, and the nudge re-fires on every subsequent turn.
+    const meta = endTurn({}, 720_000);
+    const clobbering = { contextHandoffPendingLevel: undefined, contextHandoffPending: undefined } as never;
+    const merged = mergeTransportMeta(meta as never, clobbering) as Record<string, unknown>;
+    expect(merged["contextHandoffPendingLevel"], "level must survive a clobbering merge").toBe("wrap-up");
+    expect(merged["contextHandoffPending"], "nudge must survive a clobbering merge").toBeTypeOf("string");
+  });
+
+  it("cleans up the level after delivery so no stale value can be re-recorded", () => {
+    let meta = endTurn({}, 720_000);
+    meta = endTurn(meta, 730_000);
+    expect(meta["contextHandoffDelivered"]).toBe("wrap-up");
+    expect(meta["contextHandoffPendingLevel"], "stale level must be removed").toBeUndefined();
+  });
+
+});

--- a/packages/jinn/src/shared/__tests__/context-pressure.test.ts
+++ b/packages/jinn/src/shared/__tests__/context-pressure.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { assessContextPressure, handoffNudgeText, HANDOFF_LEVELS } from "../context-pressure.js";
+
+const WINDOW = 1_000_000;
+const at = (pct: number) => Math.round(WINDOW * pct);
+
+const worker = (contextTokens: number, alreadyNudged: "wrap-up" | "urgent" | null = null) =>
+  assessContextPressure({ contextTokens, contextWindow: WINDOW, employee: "fight-process-lead", alreadyNudged });
+
+describe("assessContextPressure — firing", () => {
+  it("stays silent well below the first threshold", () => {
+    expect(worker(at(0.20))).toBeNull();
+    expect(worker(at(0.69))).toBeNull();
+  });
+
+  it("fires wrap-up at the first threshold", () => {
+    const v = worker(at(0.70));
+    expect(v?.level).toBe("wrap-up");
+    expect(v?.ratio).toBeCloseTo(0.70, 2);
+  });
+
+  it("escalates to urgent at the higher threshold", () => {
+    expect(worker(at(0.85))?.level).toBe("urgent");
+    expect(worker(at(0.97))?.level).toBe("urgent");
+  });
+
+  it("reports the numbers it decided on", () => {
+    const v = worker(at(0.75));
+    expect(v?.contextTokens).toBe(at(0.75));
+    expect(v?.contextWindow).toBe(WINDOW);
+  });
+});
+
+describe("assessContextPressure — never nags", () => {
+  it("does not repeat a level already delivered", () => {
+    expect(worker(at(0.72), "wrap-up")).toBeNull();
+    expect(worker(at(0.80), "wrap-up")).toBeNull();
+  });
+
+  it("still escalates from wrap-up to urgent", () => {
+    expect(worker(at(0.86), "wrap-up")?.level).toBe("urgent");
+  });
+
+  it("never re-fires once urgent has been delivered", () => {
+    expect(worker(at(0.90), "urgent")).toBeNull();
+    expect(worker(at(0.99), "urgent")).toBeNull();
+  });
+
+  it("does not regress to a lower level after escalating", () => {
+    // Context shrank after a compaction; the agent already got the urgent nudge.
+    expect(worker(at(0.71), "urgent")).toBeNull();
+  });
+});
+
+describe("assessContextPressure — scope", () => {
+  it("ignores operator chat — Genie has nobody to hand off to", () => {
+    for (const employee of [undefined, null, "", "   "]) {
+      expect(assessContextPressure({ contextTokens: at(0.95), contextWindow: WINDOW, employee })).toBeNull();
+    }
+  });
+
+  it("ignores sessions with no context reading yet", () => {
+    expect(assessContextPressure({ contextTokens: null, contextWindow: WINDOW, employee: "x" })).toBeNull();
+  });
+
+  it("ignores an unknown context window rather than guessing one", () => {
+    expect(assessContextPressure({ contextTokens: at(0.95), contextWindow: undefined, employee: "x" })).toBeNull();
+  });
+
+  it("never throws on malformed input", () => {
+    for (const t of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      for (const w of [0, -1, Number.NaN, undefined]) {
+        expect(() =>
+          assessContextPressure({ contextTokens: t, contextWindow: w as number, employee: "x" }),
+        ).not.toThrow();
+      }
+    }
+  });
+});
+
+describe("handoffNudgeText", () => {
+  it("names the contract the org already runs on", () => {
+    const text = handoffNudgeText(worker(at(0.70))!);
+    expect(text).toContain("DONE");
+    expect(text).toContain("BLOCKED");
+    expect(text).toContain("work item");
+  });
+
+  it("explicitly steers away from the destructive options", () => {
+    const text = handoffNudgeText(worker(at(0.70))!);
+    expect(text).toContain("/clear");
+    expect(text).toContain("/compact");
+    expect(text.toLowerCase()).toContain("do not run");
+  });
+
+  it("reports the real numbers so the agent can judge urgency", () => {
+    const text = handoffNudgeText(worker(at(0.70))!);
+    expect(text).toContain("70%");
+    expect(text).toContain((1_000_000).toLocaleString());
+  });
+
+  it("is more insistent at the urgent level", () => {
+    expect(handoffNudgeText(worker(at(0.70))!)).toContain("next safe stopping point");
+    expect(handoffNudgeText(worker(at(0.90))!)).toContain("wrap up now");
+  });
+});
+
+describe("thresholds", () => {
+  it("are ordered and inside the window", () => {
+    const ats = HANDOFF_LEVELS.map((l) => l.at);
+    expect(ats).toEqual([...ats].sort((a, b) => a - b));
+    for (const a of ats) { expect(a).toBeGreaterThan(0); expect(a).toBeLessThan(1); }
+  });
+
+  it("leave real headroom — a nudge at 100% would be useless", () => {
+    expect(Math.max(...HANDOFF_LEVELS.map((l) => l.at))).toBeLessThanOrEqual(0.9);
+  });
+});

--- a/packages/jinn/src/shared/context-ceiling.ts
+++ b/packages/jinn/src/shared/context-ceiling.ts
@@ -1,0 +1,172 @@
+/**
+ * Detects a declared context window that the engine does not actually honour.
+ *
+ * Why this exists: in July 2026 the roster declared Opus at 1M while the Claude
+ * CLI — handed the bare `opus` alias instead of `opus[1m]` — enforced 200K.
+ * Nothing compared the two, so sessions compaction-thrashed for weeks (63
+ * compaction boundaries in one transcript) before a human noticed. Correcting
+ * the number fixes that day; this makes the *next* wrong number announce itself.
+ *
+ * Mechanism: a peak that has stopped growing is a ceiling. We track the highest
+ * context a model has ever reached and how long that peak has held; once it has
+ * held across many turns without moving, and sits far below the declared
+ * window, the window we were told about is not the window being enforced.
+ *
+ * Two earlier designs were falsified by replaying the real transcript, and both
+ * failure modes are worth keeping in mind before changing the thresholds:
+ *
+ *  1. Classifying individual compaction events by the level they fired at.
+ *     Healthy Fable compacted at 280K–494K and broken Opus at 169K — these
+ *     overlap once the declared window is 1M, so it produced both a false
+ *     negative and a false positive on the very incident it was written for.
+ *  2. Comparing the running max against the declared window. Every model's max
+ *     is low early in its life, so this warned on the healthy model long before
+ *     it had climbed to its true 640K peak.
+ *
+ * What separates them is not the peak's height but its *stability*: below the
+ * 35% line the capped model held its peak for 79 turns while the healthy one
+ * never held one for more than 4 before climbing past it.
+ *
+ * Uses only what a turn already produced — no catalog, no network. That is a
+ * hard requirement: this must work on subscription auth.
+ */
+import { logger } from "./logger.js";
+
+/** A model that never exceeds this fraction of its declared window, despite
+ *  sustained use, is not being given that window. Measured: broken Opus
+ *  reached 0.19, healthy Fable 0.64. */
+export const SUSPECT_RATIO = 0.35;
+
+/** Absolute floor before any conclusion: below this, the model simply has not
+ *  been pushed hard enough to say anything about its ceiling. */
+export const MIN_EVIDENCE_TOKENS = 100_000;
+
+/** Turns the peak must hold without growing before it counts as a ceiling
+ *  rather than a still-climbing high-water mark. This is the load-bearing
+ *  threshold: a low max means nothing on its own, because every model's max is
+ *  low early on. Measured on the incident transcript — below the 35% line, the
+ *  capped model plateaued for 79 turns while the healthy one never plateaued
+ *  for more than 4 before climbing past it. */
+export const MIN_TURNS_SINCE_PEAK = 25;
+
+export interface ContextCeilingInput {
+  engine: string;
+  model?: string;
+  /** Declared window from the model roster, if any. */
+  declaredWindow?: number;
+  /** Context reading from the turn that just finished. */
+  currentTokens?: number | null;
+  /** The prompt that drove this turn. Slash commands (`/clear`, `/compact`,
+   *  `/model`) mutate context on purpose; they are excluded from evidence so a
+   *  user's own housekeeping cannot be mistaken for an enforced ceiling. */
+  userPrompt?: string;
+}
+
+export interface ContextCeilingVerdict {
+  /** Enough evidence gathered, and it points at a smaller real window. */
+  suspect: boolean;
+  /** Threshold crossed and not yet reported for this model. */
+  warn: boolean;
+  observedCeiling?: number;
+  declaredWindow?: number;
+  ratio?: number;
+  turns?: number;
+  turnsSincePeak?: number;
+}
+
+/** Returned by value, never by reference: a shared literal would let one
+ *  caller's mutation corrupt every later verdict. */
+const notSuspect = (): ContextCeilingVerdict => ({ suspect: false, warn: false });
+
+interface ModelEvidence {
+  turns: number;
+  maxObserved: number;
+  /** Turns since maxObserved last grew — how long the peak has held. */
+  turnsSincePeak: number;
+}
+
+/** Evidence per engine/model, and already-warned markers. Process-lifetime
+ *  only — a restart re-arms the warning, which is also when a config change
+ *  takes effect, so that is the behaviour we want. */
+const evidence = new Map<string, ModelEvidence>();
+const warned = new Set<string>();
+
+/** Test seam. */
+export function resetContextCeilingState(): void {
+  evidence.clear();
+  warned.clear();
+}
+
+function isPositiveFinite(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
+/** A prompt beginning with a slash command — the user deliberately mutating
+ *  context. Anchored to the start so "read /etc/hosts" is not mistaken for one. */
+function isContextMutatingCommand(prompt?: string): boolean {
+  return typeof prompt === "string" && /^\s*\//.test(prompt);
+}
+
+/**
+ * Record one turn's context reading and report whether the model's declared
+ * window now looks wrong. Total: every malformed input returns "not suspect"
+ * rather than throwing, because this runs inside the turn-completion path and
+ * must never break a turn.
+ */
+export function assessContextCeiling(input: ContextCeilingInput): ContextCeilingVerdict {
+  const { engine, model, declaredWindow, currentTokens, userPrompt } = input;
+
+  if (!isPositiveFinite(declaredWindow)) return notSuspect();
+  if (!isPositiveFinite(currentTokens)) return notSuspect();
+  // The user mutated context on purpose — not evidence about the window.
+  if (isContextMutatingCommand(userPrompt)) return notSuspect();
+
+  const key = `${engine}/${model ?? "default"}`;
+  const prior = evidence.get(key) ?? { turns: 0, maxObserved: 0, turnsSincePeak: 0 };
+  const grew = currentTokens > prior.maxObserved;
+  const next: ModelEvidence = {
+    turns: prior.turns + 1,
+    maxObserved: grew ? currentTokens : prior.maxObserved,
+    turnsSincePeak: grew ? 0 : prior.turnsSincePeak + 1,
+  };
+  evidence.set(key, next);
+
+  // A peak that is still growing is a high-water mark, not a ceiling — every
+  // model's max is low early on, so concluding here is what produced a false
+  // positive on the healthy model when this was first written.
+  if (next.turnsSincePeak < MIN_TURNS_SINCE_PEAK) return notSuspect();
+  if (next.maxObserved < MIN_EVIDENCE_TOKENS) return notSuspect();
+
+  const ratio = next.maxObserved / declaredWindow;
+  if (ratio >= SUSPECT_RATIO) return notSuspect(); // reaches a plausible fraction — healthy
+
+  const verdict: ContextCeilingVerdict = {
+    suspect: true,
+    warn: !warned.has(key),
+    observedCeiling: next.maxObserved,
+    declaredWindow,
+    ratio,
+    turns: next.turns,
+    turnsSincePeak: next.turnsSincePeak,
+  };
+  if (verdict.warn) warned.add(key);
+  return verdict;
+}
+
+/** Emit the warning for a verdict that earned one. Never throws. */
+export function reportContextCeiling(engine: string, model: string | undefined, v: ContextCeilingVerdict): void {
+  if (!v.warn) return;
+  try {
+    const pct = Math.round((v.ratio ?? 0) * 100);
+    logger.warn(
+      `Context window looks smaller than configured for ${engine}/${model ?? "default"}: ` +
+        `across ${v.turns} turns the context never exceeded ${v.observedCeiling?.toLocaleString()} tokens, ` +
+        `but the roster declares ${v.declaredWindow?.toLocaleString()} (${pct}%). ` +
+        `If the engine is enforcing a smaller window, sessions will compaction-thrash. ` +
+        `Verify the model id passed to the engine (Claude needs the [1m] suffix for a 1M window, e.g. "opus[1m]") ` +
+        `or correct contextWindow for this model in config.yaml.`,
+    );
+  } catch {
+    /* diagnostics must never break a turn */
+  }
+}

--- a/packages/jinn/src/shared/context-pressure.ts
+++ b/packages/jinn/src/shared/context-pressure.ts
@@ -1,0 +1,154 @@
+/**
+ * Deterministic context-pressure handoff for worker sessions.
+ *
+ * A long-lived agent session re-sends its whole accumulated context every turn.
+ * Measured on this codebase's own fleet: worker sessions averaged ~337K tokens
+ * per turn, of which only ~9% was conversation — the rest was tool results,
+ * tool inputs, and thinking. Sessions ran for days and thousands of turns.
+ *
+ * The wrong fixes, and why:
+ *   - `/clear` destroys working state with nothing externalised first.
+ *   - `/compact` is already automatic in Claude Code, and it is lossy in a way
+ *     the *model* chooses, leaving the surviving state trapped in a transcript.
+ *
+ * The right fix reuses the delegation contract the org already runs on: every
+ * delegation ends with `DONE` or `BLOCKED: <exact need>`, and work items are the
+ * durable ledger. Under context pressure we fire that contract early, so the
+ * agent decides what matters and writes it somewhere queryable. A session that
+ * needs compaction is evidence its state was never externalised.
+ *
+ * Delivery is deliberately passive: this only decides *that* a nudge is owed and
+ * records it. The text rides the next real turn's prompt, so it costs no extra
+ * turn and is silently dropped if the session never runs again.
+ */
+
+/** Fraction of the context window at which each nudge fires. Escalating, and
+ *  each level fires at most once per session. */
+export const HANDOFF_LEVELS = [
+  { level: "wrap-up" as const, at: 0.70 },
+  { level: "urgent" as const, at: 0.85 },
+];
+
+export type HandoffLevel = (typeof HANDOFF_LEVELS)[number]["level"];
+
+export interface ContextPressureInput {
+  /** Most recent turn's input-context size. */
+  contextTokens?: number | null;
+  /** Declared window for the model actually in use. */
+  contextWindow?: number;
+  /** Worker sessions only. An operator chat (no employee) cannot hand off —
+   *  the state is in the operator's head, so it is surfaced in the UI instead. */
+  employee?: string | null;
+  /** Highest level already delivered for this session, if any. */
+  alreadyNudged?: HandoffLevel | null;
+}
+
+export interface ContextPressureVerdict {
+  level: HandoffLevel;
+  ratio: number;
+  contextTokens: number;
+  contextWindow: number;
+}
+
+function isPositiveFinite(n: unknown): n is number {
+  return typeof n === "number" && Number.isFinite(n) && n > 0;
+}
+
+/** Rank so an escalation can be compared against what was already sent. */
+function rank(level: HandoffLevel | null | undefined): number {
+  if (!level) return -1;
+  return HANDOFF_LEVELS.findIndex((l) => l.level === level);
+}
+
+/**
+ * Decide whether this session is owed a handoff nudge. Pure and total: any
+ * malformed input yields null rather than throwing, because this runs on the
+ * turn-completion path and must never break a turn.
+ */
+export function assessContextPressure(input: ContextPressureInput): ContextPressureVerdict | null {
+  const { contextTokens, contextWindow, employee, alreadyNudged } = input;
+
+  // Operator chat: no employee means Genie, which has no one to hand off to.
+  if (!employee || !employee.trim()) return null;
+  if (!isPositiveFinite(contextTokens) || !isPositiveFinite(contextWindow)) return null;
+
+  const ratio = contextTokens / contextWindow;
+
+  // Highest level whose threshold is met.
+  let hit: HandoffLevel | null = null;
+  for (const l of HANDOFF_LEVELS) if (ratio >= l.at) hit = l.level;
+  if (!hit) return null;
+
+  // Escalate only — never repeat a level already delivered.
+  if (rank(hit) <= rank(alreadyNudged)) return null;
+
+  return { level: hit, ratio, contextTokens, contextWindow };
+}
+
+/* --- transportMeta state machine ------------------------------------------
+ * The nudge travels across turns in transportMeta. These three functions are
+ * the whole transition set; manager.ts calls them rather than open-coding the
+ * key handling, so the tests exercise the same code the gateway runs.
+ */
+
+export const HANDOFF_PENDING_KEY = "contextHandoffPending";
+export const HANDOFF_PENDING_LEVEL_KEY = "contextHandoffPendingLevel";
+export const HANDOFF_DELIVERED_KEY = "contextHandoffDelivered";
+
+/** transportMeta keys this feature owns — manager.ts must preserve all of them
+ *  across connector merges, or a lost level turns "nudge once" into "nudge
+ *  every turn". */
+export const HANDOFF_META_KEYS = [
+  HANDOFF_PENDING_KEY,
+  HANDOFF_PENDING_LEVEL_KEY,
+  HANDOFF_DELIVERED_KEY,
+] as const;
+
+/** The nudge owed to this session's next prompt, if any. */
+export function pendingNudgeText(meta: Record<string, unknown> | null | undefined): string | null {
+  const v = meta?.[HANDOFF_PENDING_KEY];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/** Record that a carried nudge reached the model: drop it and remember the
+ *  level so later assessments escalate instead of repeating. Mutates in place. */
+export function markNudgeDelivered(
+  meta: Record<string, unknown>,
+  levelFromTurnStart?: unknown,
+): void {
+  delete meta[HANDOFF_PENDING_KEY];
+  const level =
+    typeof levelFromTurnStart === "string" ? levelFromTurnStart
+    : typeof meta[HANDOFF_PENDING_LEVEL_KEY] === "string" ? (meta[HANDOFF_PENDING_LEVEL_KEY] as string)
+    : null;
+  if (level) meta[HANDOFF_DELIVERED_KEY] = level;
+  delete meta[HANDOFF_PENDING_LEVEL_KEY];
+}
+
+/** Queue a nudge onto the session's next prompt. Mutates in place. */
+export function queueNudge(meta: Record<string, unknown>, verdict: ContextPressureVerdict): void {
+  meta[HANDOFF_PENDING_KEY] = handoffNudgeText(verdict);
+  meta[HANDOFF_PENDING_LEVEL_KEY] = verdict.level;
+}
+
+/** Highest level already delivered for this session. */
+export function deliveredLevel(meta: Record<string, unknown> | null | undefined): HandoffLevel | null {
+  const v = meta?.[HANDOFF_DELIVERED_KEY];
+  return typeof v === "string" ? (v as HandoffLevel) : null;
+}
+
+/** The text prepended to the session's next real prompt. */
+export function handoffNudgeText(v: ContextPressureVerdict): string {
+  const pct = Math.round(v.ratio * 100);
+  const used = v.contextTokens.toLocaleString();
+  const win = v.contextWindow.toLocaleString();
+  const when =
+    v.level === "urgent"
+      ? "Stop taking on new work and wrap up now."
+      : "At your next safe stopping point, wrap up.";
+  return [
+    `[Jinn] Context checkpoint — you are at ${pct}% of your context window (${used} of ${win} tokens). ${when}`,
+    `Write your current state to the work item before you finish: what you found, what you decided, what remains, and the exact next action. Then end with \`DONE\` or \`BLOCKED: <exact need>\` so a fresh session can resume from the ledger without re-deriving anything.`,
+    `Do not run \`/clear\` or \`/compact\` — externalising to the work item is what preserves the work; compaction only shortens the transcript.`,
+  ].join("\n\n");
+}

--- a/packages/jinn/src/shared/models.ts
+++ b/packages/jinn/src/shared/models.ts
@@ -306,11 +306,24 @@ export function effortLevelsForModel(config: JinnConfig, engine: string, modelId
 }
 
 /** Context window (tokens) for a session's engine+model, or undefined if unknown. */
-export function contextWindowForModel(config: JinnConfig, engine: string, modelId?: string): number | undefined {
+/** Declared context window for a model.
+ *
+ *  By default an unlisted model falls back to the engine's default model, which
+ *  is right for display but wrong for comparisons: it would report model Y's
+ *  window for model X. Pass `exact` when the answer is only meaningful if this
+ *  specific model is actually in the roster. */
+export function contextWindowForModel(
+  config: JinnConfig,
+  engine: string,
+  modelId?: string,
+  opts?: { exact?: boolean },
+): number | undefined {
   const entry = getModelRegistry(config)[engine];
   if (!entry) return undefined;
+  const exactMatch = modelId ? entry.models.find((m) => m.id === modelId) : undefined;
+  if (opts?.exact) return exactMatch?.contextWindow;
   const model =
-    (modelId ? entry.models.find((m) => m.id === modelId) : undefined) ??
+    exactMatch ??
     entry.models.find((m) => m.id === entry.defaultModel) ??
     entry.models[0];
   return model?.contextWindow;


### PR DESCRIPTION
Two changes for long-running sessions.

## Background

Every model has a context limit, and the config declares what that limit is for each one. When the declared number is larger than the limit actually being enforced, Jinn thinks a session has room it doesn't have — so the engine compacts (summarises the conversation and drops history) far earlier and far more often than expected. Sessions get slower and lossier, and nothing points at why.

This is easy to hit by accident. Configure a model at 1M, but hand the engine a bare model alias instead of the explicit large-window variant, and the real ceiling can be a fraction of that. Nothing compares the two numbers, so the mismatch just quietly costs you.

## How I found this bug

I had Opus configured at 1M, but my sessions were compacting constantly — 63 compaction boundaries in a single transcript. The cause was the model id: the Claude CLI treats `opus` and `opus[1m]` as two different models, and the bare alias enforces 200K no matter what the config claims. Correcting my own model ids fixed my case, and since that's just a config change it isn't part of this PR. What is here is the general problem it exposed — nothing in Jinn was comparing the declared window against the one actually being enforced, so the mismatch stayed invisible for weeks.

## 1. Detect a window that isn't being honoured

You can't ask the engine what limit it's enforcing, but you can watch for it. This tracks the highest context a model has ever reached and how long that high-water mark has held. Once it stops rising and parks well below the declared number across many turns, the enforced ceiling is lower than configured — and it now says so, instead of someone working it out much later.

It also adds the explicit large-window model entries to the generated config template, with a note that they're separate model ids rather than a flag — which is the mistake that causes this in the first place.

## 2. Hand a worker off before it runs out of room

A session that fills its window compacts mid-task, which is the worst moment to lose detail. This watches context pressure and nudges a handoff while there's still room to write a clean summary and start fresh.

## Also

`contextWindowForModel` gains an `exact` option. By default, asking about a model that isn't in the config falls back to the engine's default model — fine when you're displaying a number, wrong when you're comparing declared against observed, because it would answer with a different model's window.

## Relationship to 0.28.4

`CLAUDE_CODE_AUTO_COMPACT_WINDOW` raises the compaction trigger so long sessions don't compact more often than the model requires. This is the other half: catching the case where the window was never what the config claimed.
