### PR TITLE
fix(claude): confirm the prompt was submitted, and surface a stalled turn

### DIFF
--- a/packages/jinn/src/engines/__tests__/claude-interactive-submit-wiring.test.ts
+++ b/packages/jinn/src/engines/__tests__/claude-interactive-submit-wiring.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The submit confirmation, exercised through `engine.run` rather than by calling
+ * `pasteAndSubmit` with a hand-stubbed `submitted()`.
+ *
+ * The mechanism is covered at the `pasteAndSubmit` level in claude-interactive.test.ts;
+ * what is only reachable here is the wiring: that a real hook arriving on the
+ * registry callback flips `promptSubmitted`, that `SessionStart` deliberately does
+ * not, that the cold-spawn and native-command paths are exempt, and that a
+ * settled turn writes no further CRs. Getting those wrong makes the confirmation
+ * either useless (a false ack strands the prompt in the composer, the failure
+ * this exists to catch) or actively harmful (CRs written into a PTY that has
+ * moved on to a different turn).
+ *
+ * Every assertion here was mutation-checked against the production code, so none
+ * of them passes vacuously. See the note at the end for the one guarantee that
+ * cannot be pinned this way.
+ */
+
+interface FakePty {
+  pid: number;
+  _exitCode: number | null;
+  _exitCb?: (e: { exitCode: number }) => void;
+  writes: string[];
+  onData: (cb: (d: string) => void) => void;
+  onExit: (cb: (e: { exitCode: number }) => void) => void;
+  kill: (signal?: string) => void;
+  write: (d: string) => void;
+  resize: (c: number, r: number) => void;
+  on: (event: string, cb: (...a: any[]) => void) => void;
+  fireExit: () => void;
+}
+
+const ptys: FakePty[] = [];
+function makeFakePty(): FakePty {
+  const p: FakePty = {
+    pid: 2000 + ptys.length,
+    _exitCode: null,
+    writes: [], // records instead of discarding — the CRs are the subject here
+    onData() {},
+    onExit(cb) { p._exitCb = cb; },
+    kill() {},
+    write(d: string) { p.writes.push(d); },
+    resize() {},
+    on() {},
+    fireExit() { p._exitCode = 0; p._exitCb?.({ exitCode: 0 }); },
+  };
+  return p;
+}
+
+vi.mock("node-pty", () => ({
+  spawn: vi.fn(() => { const p = makeFakePty(); ptys.push(p); return p; }),
+}));
+vi.mock("../sse-pty-proxy.js", () => ({
+  MAIN_AGENT_SENTINEL: "<!-- jinn-main-agent:5c1f -->",
+  SsePtyProxy: class {
+    port = 0;
+    constructor(_label: string, _onEvent: (e: unknown) => void) {}
+    async start() { return 41100; }
+    stop() {}
+  },
+}));
+vi.mock("../shared/claude-settings.js", () => ({
+  writeSessionSettings: () => "/tmp/fake-settings.json",
+}));
+
+import { InteractiveClaudeEngine } from "../claude-interactive.js";
+import { PtyLifecycleManager } from "../pty-lifecycle.js";
+
+const CR = "\r";
+const crs = (p: FakePty) => p.writes.filter((w) => w === CR).length;
+
+describe("InteractiveClaudeEngine — submit confirmation wiring", () => {
+  let lifecycle: PtyLifecycleManager;
+  let hookCb: ((h: any) => void) | undefined;
+  let engine: InteractiveClaudeEngine;
+
+  beforeEach(() => {
+    ptys.length = 0;
+    hookCb = undefined;
+    lifecycle = new PtyLifecycleManager({ maxLivePtys: 10 });
+    const hookRegistry = {
+      register: (_id: string, cb: (h: any) => void) => { hookCb = cb; },
+      unregister: () => {},
+    } as any;
+    engine = new InteractiveClaudeEngine(lifecycle, hookRegistry);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Turn 1 cold-spawns and completes via Stop, which leaves the PTY warm so the
+   *  next turn takes the paste-and-submit path. */
+  async function completeColdTurn(sessionId: string): Promise<FakePty> {
+    const turn = engine.run({ sessionId, prompt: "first", cwd: "/tmp" } as any);
+    await vi.advanceTimersByTimeAsync(20);
+    hookCb!({ hook_event_name: "SessionStart", session_id: "c1" });
+    hookCb!({ hook_event_name: "Stop", last_assistant_message: "done" });
+    const r = await turn;
+    expect(r.error).toBeUndefined();
+    const pty = ptys[0];
+    expect(pty).toBeDefined();
+    return pty;
+  }
+
+  it("takes UserPromptSubmit as the acknowledgement, and SessionStart as nothing", async () => {
+    vi.useFakeTimers();
+    const pty = await completeColdTurn("s-ack");
+    expect(engine.hasWarmPty("s-ack")).toBe(true);
+
+    void engine.run({ sessionId: "s-ack", prompt: "second", cwd: "/tmp" } as any);
+    await vi.advanceTimersByTimeAsync(20);
+    const before = crs(pty);
+
+    // The initial submit CR, 150ms after the bracketed paste.
+    await vi.advanceTimersByTimeAsync(200);
+    expect(crs(pty)).toBe(before + 1);
+
+    // A stale SessionStart — exactly what the idle spawn that warmed this PTY
+    // emits. Accepting it would confirm a submit that never happened.
+    hookCb!({ hook_event_name: "SessionStart", session_id: "c2" });
+    await vi.advanceTimersByTimeAsync(1600);
+    expect(crs(pty)).toBe(before + 2); // still retrying
+
+    hookCb!({ hook_event_name: "UserPromptSubmit", prompt: "second" });
+    const afterAck = crs(pty);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(crs(pty)).toBe(afterAck); // acknowledged: no further CRs
+
+    expect(engine.turnProgress("s-ack")?.awaitingSubmit).toBe(false);
+  });
+
+  it("reports awaitingSubmit only while the prompt is unacknowledged", async () => {
+    vi.useFakeTimers();
+    await completeColdTurn("s-progress");
+
+    void engine.run({ sessionId: "s-progress", prompt: "second", cwd: "/tmp" } as any);
+    await vi.advanceTimersByTimeAsync(20);
+
+    const pending = engine.turnProgress("s-progress");
+    expect(pending?.awaitingSubmit).toBe(true);
+    expect(pending?.activeTools).toBe(0);
+    expect(pending?.activeUpstream).toBe(false);
+    // lastProgressAt is the newest of turn start, last hook and last output, so
+    // it must be a real instant at or before now even before anything happens.
+    expect(pending?.lastProgressAt).toBeGreaterThan(0);
+    expect(pending?.lastProgressAt).toBeLessThanOrEqual(Date.now());
+
+    // A tool in flight is real work, so the gateway must not read this as quiet.
+    hookCb!({ hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: {} });
+    expect(engine.turnProgress("s-progress")?.activeTools).toBe(1);
+    // ...and any in-turn hook proves the prompt is running.
+    expect(engine.turnProgress("s-progress")?.awaitingSubmit).toBe(false);
+
+    hookCb!({ hook_event_name: "PostToolUse", tool_name: "Bash" });
+    expect(engine.turnProgress("s-progress")?.activeTools).toBe(0);
+  });
+
+  it("does not confirm a cold spawn, which carries its prompt in argv", async () => {
+    vi.useFakeTimers();
+    const turn = engine.run({ sessionId: "s-cold", prompt: "only", cwd: "/tmp" } as any);
+    await vi.advanceTimersByTimeAsync(20);
+
+    // Submitted by construction: nothing is pasted and no CR is due.
+    expect(engine.turnProgress("s-cold")?.awaitingSubmit).toBe(false);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(crs(ptys[0])).toBe(0);
+
+    hookCb!({ hook_event_name: "SessionStart", session_id: "c1" });
+    hookCb!({ hook_event_name: "Stop", last_assistant_message: "done" });
+    await turn;
+  });
+
+  it("does not confirm a native command, which never emits the hook", async () => {
+    vi.useFakeTimers();
+    const pty = await completeColdTurn("s-native");
+    const before = crs(pty);
+
+    void engine.run({ sessionId: "s-native", prompt: "/compact", cwd: "/tmp" } as any);
+    await vi.advanceTimersByTimeAsync(20);
+
+    // /compact runs locally and settles on its own timer. One CR submits it; a
+    // retry loop would fire spurious CRs at a prompt that already did its work.
+    expect(engine.turnProgress("s-native")?.awaitingSubmit).toBe(false);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(crs(pty)).toBe(before + 1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(crs(pty)).toBe(before + 1);
+  });
+
+  it("writes no further CRs once the turn settles unacknowledged", async () => {
+    vi.useFakeTimers();
+    const pty = await completeColdTurn("s-cancel");
+
+    const turn = engine.run({ sessionId: "s-cancel", prompt: "second", cwd: "/tmp" } as any);
+    await vi.advanceTimersByTimeAsync(200); // initial CR sent, prompt unacknowledged
+    const before = crs(pty);
+
+    // Settled without ever seeing UserPromptSubmit — the case where the loop
+    // would otherwise outlive its turn and submit whatever the composer holds
+    // when the warm PTY is handed to the next one.
+    engine.kill("s-cancel", "Interrupted: new message received");
+    await turn;
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(crs(pty)).toBe(before);
+    expect(engine.turnProgress("s-cancel")).toBeUndefined();
+  });
+
+  // NOT tested here: that run()'s finally calls entry.cancelSubmitConfirm().
+  // `submitted()` also reads resolver.isSettled, so a settled turn stops the loop
+  // at its next tick with or without that call — removing it changes no
+  // observable behaviour, confirmed by mutation. The only difference is that the
+  // interval lives ~1.5s longer, and timer counts cannot isolate it from the
+  // per-session timers armed alongside. The cancel stays as redundancy; the
+  // guarantee that matters is pinned by the test above.
+});

--- a/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
+++ b/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 // focused and CI-portable.
 vi.mock("node-pty", () => ({ spawn: vi.fn() }));
 
-import { TurnResolver, buildAttachmentSuffix, buildInteractiveArgs, claudeHookToDeltas, pasteAndSubmit, shouldSettleStalledTurn, sumTranscriptUsage } from "../claude-interactive.js";
+import { SUBMIT_ACK_HOOKS, TurnResolver, buildAttachmentSuffix, buildInteractiveArgs, claudeHookToDeltas, pasteAndSubmit, shouldSettleStalledTurn, sumTranscriptUsage } from "../claude-interactive.js";
 import { MAIN_AGENT_SENTINEL } from "../sse-pty-proxy.js";
 import { buildPromptWithPlatformContext } from "../platform-context.js";
 
@@ -204,153 +204,6 @@ describe("pasteAndSubmit", () => {
     vi.advanceTimersByTime(1);
     expect(writes).toEqual([`\x1b[200~${text}\x1b[201~`, "\r"]);
   });
-});
-
-/**
- * Regression guard for the silently-unsubmitted warm-PTY paste.
- *
- * Claude Code's TUI auto-attaches any bracketed-pasted token that resolves to a
- * real image file, entering an async encode during which keypresses — including
- * pasteAndSubmit's submit CR, fired on a fixed 150ms timer — are DISCARDED. Any
- * real screenshot takes longer than 150ms to encode, so the turn hung forever
- * with no error. Verified live: a 5.8MB PNG hangs at 150ms, submits at 400ms,
- * and submits at 150ms once backticked.
- *
- * This asserts on the composed bytes so it needs no live PTY. Newlines are NOT
- * the trigger (a zero-newline prompt with a real image path hangs too), so do
- * not "simplify" this into a newline check.
- */
-describe("buildAttachmentSuffix", () => {
-  // A bare absolute image path is what the TUI auto-attaches on.
-  const BARE_IMAGE_PATH = /(^|[\s(\[])(\/[^\s`'"]+\.(png|jpe?g|gif|webp|bmp|svg))(?=$|[\s)\]])/i;
-
-  it("never hands the TUI a bare image path", () => {
-    const suffix = buildAttachmentSuffix(["/Users/x/.jinn/uploads/2026-07-25/s/shot.png"]);
-    expect(BARE_IMAGE_PATH.test(suffix)).toBe(false);
-    expect(suffix).toBe("\n\nAttached files:\n- `/Users/x/.jinn/uploads/2026-07-25/s/shot.png`");
-  });
-
-  it("backticks every path when several are attached", () => {
-    const suffix = buildAttachmentSuffix(["/tmp/a.png", "/tmp/b.jpeg", "/tmp/notes.txt"]);
-    expect(BARE_IMAGE_PATH.test(suffix)).toBe(false);
-    expect(suffix).toBe("\n\nAttached files:\n- `/tmp/a.png`\n- `/tmp/b.jpeg`\n- `/tmp/notes.txt`");
-  });
-
-  it("keeps the composed warm-PTY payload free of bare image paths end to end", () => {
-    const payload = `Describe this${buildAttachmentSuffix(["/tmp/screenshot.png"])}`;
-    expect(BARE_IMAGE_PATH.test(payload)).toBe(false);
-    // Sanity-check the guard itself: the same payload unbackticked MUST match,
-    // otherwise this test would pass vacuously and lock in nothing.
-    expect(BARE_IMAGE_PATH.test("Describe this\n\nAttached files:\n- /tmp/screenshot.png")).toBe(true);
-  });
-});
-
-/**
- * Regression guard for the web-session accounting bug (#89) and, more
- * importantly, for the trap that fixing it exposes.
- *
- * A Claude transcript is CUMULATIVE — it holds every turn of the session. The
- * cost is added to a running total by accumulateSessionCost, so summing the
- * whole file on every turn counts an N-turn session quadratically. Codex
- * already reports a per-run delta; scoping by the turn's start timestamp is
- * what makes the two engines agree.
- */
-describe("sumTranscriptUsage — per-turn scoping", () => {
-  const line = (id: string, ts: string, input: number, output: number) =>
-    JSON.stringify({
-      type: "assistant",
-      timestamp: ts,
-      message: { id, usage: { input_tokens: input, output_tokens: output } },
-    });
-
-  // A two-turn session: turn 1 at 10:00, turn 2 at 10:05.
-  const TRANSCRIPT = [
-    line("m1", "2026-07-25T10:00:00.000Z", 1000, 100),
-    line("m2", "2026-07-25T10:05:00.000Z", 3000, 300),
-  ].join("\n");
-
-  const TURN_2_START = Date.parse("2026-07-25T10:04:00.000Z");
-
-  it("sums the whole session when unscoped", () => {
-    const u = sumTranscriptUsage(TRANSCRIPT);
-    expect(u.assistantTurns).toBe(2);
-    expect(u.inputTokens).toBe(4000);
-    expect(u.outputTokens).toBe(400);
-  });
-
-  it("counts only the current turn when scoped to its start", () => {
-    const u = sumTranscriptUsage(TRANSCRIPT, TURN_2_START);
-    // Turn 1's 1000/100 must NOT be re-counted into turn 2.
-    expect(u.assistantTurns).toBe(1);
-    expect(u.inputTokens).toBe(3000);
-    expect(u.outputTokens).toBe(300);
-  });
-
-  it("does not attribute an untimestamped line to the current turn", () => {
-    const withUndated = `${TRANSCRIPT}\n${JSON.stringify({
-      type: "assistant",
-      message: { id: "m3", usage: { input_tokens: 9999, output_tokens: 9999 } },
-    })}`;
-    const u = sumTranscriptUsage(withUndated, TURN_2_START);
-    expect(u.inputTokens).toBe(3000);
-    expect(u.assistantTurns).toBe(1);
-  });
-
-  it("still dedupes the double assistant line that --effort high emits", () => {
-    // Same message.id twice (thinking + text) with identical usage.
-    const dup = [
-      line("m9", "2026-07-25T10:05:00.000Z", 500, 50),
-      line("m9", "2026-07-25T10:05:01.000Z", 500, 50),
-    ].join("\n");
-    const u = sumTranscriptUsage(dup, TURN_2_START);
-    expect(u.assistantTurns).toBe(1);
-    expect(u.inputTokens).toBe(500);
-  });
-});
-
-/**
- * Regression guard for the session stuck at "thinking" forever.
- *
- * Observed 2026-07-25 on session 7e93171a: the turn spawned fresh
- * ("resume: none"), its SessionStart hook never landed, and its Stop hook was
- * lost. Missing-Stop recovery needs a Claude session id to locate the
- * transcript (`resolver.sessionId ?? opts.resumeSessionId`) — on a fresh spawn
- * BOTH are undefined, so the 2s recovery interval could only ever return early.
- * Nothing else settled the turn, so the session stayed "running" for 25+ minutes
- * and the messages queued behind it never dispatched.
- *
- * A sibling session with an engineSessionId recovered normally 17 minutes in,
- * which is exactly why this only bites id-less turns.
- */
-describe("shouldSettleStalledTurn", () => {
-  const MIN = 60_000;
-
-  it("settles the real stuck turn (25m elapsed, 24m quiet)", () => {
-    expect(shouldSettleStalledTurn(25 * MIN, 24 * MIN)).toBe(true);
-  });
-
-  it("leaves a long turn alone while it is still streaming", () => {
-    // 40m elapsed but output 10s ago — healthy, just slow.
-    expect(shouldSettleStalledTurn(40 * MIN, 10_000)).toBe(false);
-  });
-
-  it("leaves an early quiet gap alone", () => {
-    // Quiet for 6m but only 8m into the turn — recovery has not had its shot.
-    expect(shouldSettleStalledTurn(8 * MIN, 6 * MIN)).toBe(false);
-  });
-
-  it("requires BOTH bounds, not either", () => {
-    expect(shouldSettleStalledTurn(20 * MIN, 1 * MIN)).toBe(false);
-    expect(shouldSettleStalledTurn(1 * MIN, 20 * MIN)).toBe(false);
-  });
-
-  it("fires only after transcript recovery has had its window", () => {
-    // Recovery starts at 5m elapsed / 60s quiet; the backstop must sit well
-    // above it so a recoverable turn is never killed in favour of an error.
-    expect(shouldSettleStalledTurn(5 * MIN, 60_000)).toBe(false);
-    expect(shouldSettleStalledTurn(15 * MIN, 5 * MIN)).toBe(true);
-  });
-
 
   it("stops after one CR when no confirmation is requested", () => {
     vi.useFakeTimers();
@@ -505,4 +358,164 @@ describe("shouldSettleStalledTurn", () => {
     vi.advanceTimersByTime(60_000);
     expect(writes.filter((w) => w === "\r")).toHaveLength(0);
   });
+
+  it("accepts only hooks that prove THIS prompt is running", () => {
+    // What run() feeds the confirmation: any of these arriving means the pasted
+    // prompt reached the CLI. SessionStart must NOT count — the idle spawn that
+    // warmed this PTY fires it before the paste, so accepting it would confirm a
+    // submit that never happened and strand the text in the composer, which is
+    // the exact failure this whole path exists to catch.
+    for (const hook of ["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "StopFailure"]) {
+      expect(SUBMIT_ACK_HOOKS.has(hook)).toBe(true);
+    }
+    expect(SUBMIT_ACK_HOOKS.has("SessionStart")).toBe(false);
+    expect(SUBMIT_ACK_HOOKS.has("Notification")).toBe(false);
+  });
+});
+
+/**
+ * Regression guard for the silently-unsubmitted warm-PTY paste.
+ *
+ * Claude Code's TUI auto-attaches any bracketed-pasted token that resolves to a
+ * real image file, entering an async encode during which keypresses — including
+ * pasteAndSubmit's submit CR, fired on a fixed 150ms timer — are DISCARDED. Any
+ * real screenshot takes longer than 150ms to encode, so the turn hung forever
+ * with no error. Verified live: a 5.8MB PNG hangs at 150ms, submits at 400ms,
+ * and submits at 150ms once backticked.
+ *
+ * This asserts on the composed bytes so it needs no live PTY. Newlines are NOT
+ * the trigger (a zero-newline prompt with a real image path hangs too), so do
+ * not "simplify" this into a newline check.
+ */
+describe("buildAttachmentSuffix", () => {
+  // A bare absolute image path is what the TUI auto-attaches on.
+  const BARE_IMAGE_PATH = /(^|[\s(\[])(\/[^\s`'"]+\.(png|jpe?g|gif|webp|bmp|svg))(?=$|[\s)\]])/i;
+
+  it("never hands the TUI a bare image path", () => {
+    const suffix = buildAttachmentSuffix(["/Users/x/.jinn/uploads/2026-07-25/s/shot.png"]);
+    expect(BARE_IMAGE_PATH.test(suffix)).toBe(false);
+    expect(suffix).toBe("\n\nAttached files:\n- `/Users/x/.jinn/uploads/2026-07-25/s/shot.png`");
+  });
+
+  it("backticks every path when several are attached", () => {
+    const suffix = buildAttachmentSuffix(["/tmp/a.png", "/tmp/b.jpeg", "/tmp/notes.txt"]);
+    expect(BARE_IMAGE_PATH.test(suffix)).toBe(false);
+    expect(suffix).toBe("\n\nAttached files:\n- `/tmp/a.png`\n- `/tmp/b.jpeg`\n- `/tmp/notes.txt`");
+  });
+
+  it("keeps the composed warm-PTY payload free of bare image paths end to end", () => {
+    const payload = `Describe this${buildAttachmentSuffix(["/tmp/screenshot.png"])}`;
+    expect(BARE_IMAGE_PATH.test(payload)).toBe(false);
+    // Sanity-check the guard itself: the same payload unbackticked MUST match,
+    // otherwise this test would pass vacuously and lock in nothing.
+    expect(BARE_IMAGE_PATH.test("Describe this\n\nAttached files:\n- /tmp/screenshot.png")).toBe(true);
+  });
+});
+
+/**
+ * Regression guard for the web-session accounting bug (#89) and, more
+ * importantly, for the trap that fixing it exposes.
+ *
+ * A Claude transcript is CUMULATIVE — it holds every turn of the session. The
+ * cost is added to a running total by accumulateSessionCost, so summing the
+ * whole file on every turn counts an N-turn session quadratically. Codex
+ * already reports a per-run delta; scoping by the turn's start timestamp is
+ * what makes the two engines agree.
+ */
+describe("sumTranscriptUsage — per-turn scoping", () => {
+  const line = (id: string, ts: string, input: number, output: number) =>
+    JSON.stringify({
+      type: "assistant",
+      timestamp: ts,
+      message: { id, usage: { input_tokens: input, output_tokens: output } },
+    });
+
+  // A two-turn session: turn 1 at 10:00, turn 2 at 10:05.
+  const TRANSCRIPT = [
+    line("m1", "2026-07-25T10:00:00.000Z", 1000, 100),
+    line("m2", "2026-07-25T10:05:00.000Z", 3000, 300),
+  ].join("\n");
+
+  const TURN_2_START = Date.parse("2026-07-25T10:04:00.000Z");
+
+  it("sums the whole session when unscoped", () => {
+    const u = sumTranscriptUsage(TRANSCRIPT);
+    expect(u.assistantTurns).toBe(2);
+    expect(u.inputTokens).toBe(4000);
+    expect(u.outputTokens).toBe(400);
+  });
+
+  it("counts only the current turn when scoped to its start", () => {
+    const u = sumTranscriptUsage(TRANSCRIPT, TURN_2_START);
+    // Turn 1's 1000/100 must NOT be re-counted into turn 2.
+    expect(u.assistantTurns).toBe(1);
+    expect(u.inputTokens).toBe(3000);
+    expect(u.outputTokens).toBe(300);
+  });
+
+  it("does not attribute an untimestamped line to the current turn", () => {
+    const withUndated = `${TRANSCRIPT}\n${JSON.stringify({
+      type: "assistant",
+      message: { id: "m3", usage: { input_tokens: 9999, output_tokens: 9999 } },
+    })}`;
+    const u = sumTranscriptUsage(withUndated, TURN_2_START);
+    expect(u.inputTokens).toBe(3000);
+    expect(u.assistantTurns).toBe(1);
+  });
+
+  it("still dedupes the double assistant line that --effort high emits", () => {
+    // Same message.id twice (thinking + text) with identical usage.
+    const dup = [
+      line("m9", "2026-07-25T10:05:00.000Z", 500, 50),
+      line("m9", "2026-07-25T10:05:01.000Z", 500, 50),
+    ].join("\n");
+    const u = sumTranscriptUsage(dup, TURN_2_START);
+    expect(u.assistantTurns).toBe(1);
+    expect(u.inputTokens).toBe(500);
+  });
+});
+
+/**
+ * Regression guard for the session stuck at "thinking" forever.
+ *
+ * Observed 2026-07-25 on session 7e93171a: the turn spawned fresh
+ * ("resume: none"), its SessionStart hook never landed, and its Stop hook was
+ * lost. Missing-Stop recovery needs a Claude session id to locate the
+ * transcript (`resolver.sessionId ?? opts.resumeSessionId`) — on a fresh spawn
+ * BOTH are undefined, so the 2s recovery interval could only ever return early.
+ * Nothing else settled the turn, so the session stayed "running" for 25+ minutes
+ * and the messages queued behind it never dispatched.
+ *
+ * A sibling session with an engineSessionId recovered normally 17 minutes in,
+ * which is exactly why this only bites id-less turns.
+ */
+describe("shouldSettleStalledTurn", () => {
+  const MIN = 60_000;
+
+  it("settles the real stuck turn (25m elapsed, 24m quiet)", () => {
+    expect(shouldSettleStalledTurn(25 * MIN, 24 * MIN)).toBe(true);
+  });
+
+  it("leaves a long turn alone while it is still streaming", () => {
+    // 40m elapsed but output 10s ago — healthy, just slow.
+    expect(shouldSettleStalledTurn(40 * MIN, 10_000)).toBe(false);
+  });
+
+  it("leaves an early quiet gap alone", () => {
+    // Quiet for 6m but only 8m into the turn — recovery has not had its shot.
+    expect(shouldSettleStalledTurn(8 * MIN, 6 * MIN)).toBe(false);
+  });
+
+  it("requires BOTH bounds, not either", () => {
+    expect(shouldSettleStalledTurn(20 * MIN, 1 * MIN)).toBe(false);
+    expect(shouldSettleStalledTurn(1 * MIN, 20 * MIN)).toBe(false);
+  });
+
+  it("fires only after transcript recovery has had its window", () => {
+    // Recovery starts at 5m elapsed / 60s quiet; the backstop must sit well
+    // above it so a recoverable turn is never killed in favour of an error.
+    expect(shouldSettleStalledTurn(5 * MIN, 60_000)).toBe(false);
+    expect(shouldSettleStalledTurn(15 * MIN, 5 * MIN)).toBe(true);
+  });
+
 });

--- a/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
+++ b/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
@@ -351,6 +351,7 @@ describe("shouldSettleStalledTurn", () => {
     expect(shouldSettleStalledTurn(15 * MIN, 5 * MIN)).toBe(true);
   });
 
+
   it("stops after one CR when no confirmation is requested", () => {
     vi.useFakeTimers();
     const writes: string[] = [];
@@ -438,6 +439,60 @@ describe("shouldSettleStalledTurn", () => {
     settled = true;
     vi.advanceTimersByTime(60_000);
     expect(writes.filter((w) => w === "\r")).toHaveLength(1);
+  });
+
+  it("does not retry or report while the CLI is busy", () => {
+    // Claude Code queues a pasted prompt behind a turn already running and fires
+    // no UserPromptSubmit until it dequeues, so a queued prompt looks exactly
+    // like a swallowed CR. Spraying CRs at a busy TUI, then declaring a live
+    // turn lost, is the failure mode this gate exists to prevent.
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const retries: number[] = [];
+    let busy = true;
+    pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "queued work", {
+      submitted: () => false,
+      busy: () => busy,
+      onRetry: (n) => retries.push(n),
+      onUnconfirmed: () => { throw new Error("must not report while the CLI is busy"); },
+      intervalMs: 1000,
+      attempts: 2,
+    });
+    vi.advanceTimersByTime(150);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(1); // the optimistic CR
+
+    // Long enough to burn the whole budget if the gate were not honoured.
+    vi.advanceTimersByTime(60_000);
+    expect(retries).toEqual([]);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(1);
+
+    // Work finishes without an acknowledgement: now retrying is correct.
+    busy = false;
+    vi.advanceTimersByTime(1000);
+    expect(retries).toEqual([1]);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(2);
+  });
+
+  it("reports rather than settling, leaving the verdict to the stall backstop", () => {
+    // pasteAndSubmit must never decide a turn is dead: it has only the absence of
+    // a signal to go on, and that signal is legitimately absent for live work.
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const reported: number[] = [];
+    const cancel = pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "queued work", {
+      submitted: () => false,
+      onUnconfirmed: (n) => reported.push(n),
+      intervalMs: 1000,
+      attempts: 2,
+    });
+    vi.advanceTimersByTime(150 + 3 * 1000);
+    expect(reported).toEqual([2]);
+    // Reporting is terminal for the loop — no further CRs, and no side effect
+    // beyond the callback.
+    vi.advanceTimersByTime(60_000);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(3); // initial + 2 retries
+    expect(reported).toEqual([2]);
+    cancel();
   });
 
   it("cancel() before the initial CR suppresses the submit entirely", () => {

--- a/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
+++ b/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
@@ -350,4 +350,104 @@ describe("shouldSettleStalledTurn", () => {
     expect(shouldSettleStalledTurn(5 * MIN, 60_000)).toBe(false);
     expect(shouldSettleStalledTurn(15 * MIN, 5 * MIN)).toBe(true);
   });
+
+  it("stops after one CR when no confirmation is requested", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "hello");
+    vi.advanceTimersByTime(60_000);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(1);
+  });
+
+  it("re-sends CR until the engine acknowledges the prompt", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const retries: number[] = [];
+    let submitted = false;
+    pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "queued work", {
+      submitted: () => submitted,
+      onRetry: (n) => retries.push(n),
+      onUnconfirmed: () => { throw new Error("must not give up — the prompt was acknowledged"); },
+      intervalMs: 1000,
+      attempts: 3,
+    });
+    vi.advanceTimersByTime(150);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(1); // the optimistic CR
+
+    // The swallowed-CR case: nothing acknowledges, so the loop retries.
+    vi.advanceTimersByTime(1000);
+    expect(retries).toEqual([1]);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(2);
+
+    // The CLI finally takes it — retries must stop immediately, and no further CR
+    // may be written (an extra CR would submit an empty prompt on the next turn).
+    submitted = true;
+    vi.advanceTimersByTime(10_000);
+    expect(retries).toEqual([1]);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(2);
+  });
+
+  it("gives up after the retry budget so the turn can be failed instead of hanging", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const gaveUp: number[] = [];
+    pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "queued work", {
+      submitted: () => false,
+      onUnconfirmed: (n) => gaveUp.push(n),
+      intervalMs: 1000,
+      attempts: 3,
+    });
+    vi.advanceTimersByTime(150 + 3 * 1000);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(4); // initial + 3 retries
+    expect(gaveUp).toEqual([]);
+    vi.advanceTimersByTime(1000); // the sweep after the budget is spent
+    expect(gaveUp).toEqual([3]);
+    // And it must stop writing — not spin CRs into the PTY forever.
+    vi.advanceTimersByTime(60_000);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(4);
+  });
+
+  it("cancel() stops the retry loop, so a settled turn cannot type into the next one", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const cancel = pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "queued work", {
+      submitted: () => false,
+      onUnconfirmed: () => { throw new Error("cancelled loops must not report"); },
+      intervalMs: 1000,
+      attempts: 5,
+    });
+    vi.advanceTimersByTime(150);
+    cancel();
+    vi.advanceTimersByTime(60_000);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(1);
+  });
+
+  it("treats a settled turn as no longer needing submission", () => {
+    // run() wires `submitted` to include resolver.isSettled, so an early interrupt
+    // stops the retry loop immediately rather than typing into a dead turn.
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    let settled = false;
+    pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "queued work", {
+      submitted: () => settled, // stands in for `promptSubmitted || resolver.isSettled`
+      onUnconfirmed: () => { throw new Error("a settled turn must not be reported unconfirmed"); },
+      intervalMs: 1000,
+      attempts: 3,
+    });
+    vi.advanceTimersByTime(150);
+    settled = true;
+    vi.advanceTimersByTime(60_000);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(1);
+  });
+
+  it("cancel() before the initial CR suppresses the submit entirely", () => {
+    vi.useFakeTimers();
+    const writes: string[] = [];
+    const cancel = pasteAndSubmit({ write: (d: string) => writes.push(d) } as any, "queued work", {
+      submitted: () => false,
+    });
+    cancel(); // turn died inside the 150ms paste-settle beat
+    vi.advanceTimersByTime(60_000);
+    expect(writes.filter((w) => w === "\r")).toHaveLength(0);
+  });
 });

--- a/packages/jinn/src/engines/claude-interactive.ts
+++ b/packages/jinn/src/engines/claude-interactive.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import * as pty from "node-pty";
-import type { InterruptibleEngine, EngineRunOpts, EngineResult, EngineRateLimitInfo, StreamDelta } from "../shared/types.js";
+import type { InterruptibleEngine, EngineRunOpts, EngineResult, EngineRateLimitInfo, StreamDelta, TurnProgress } from "../shared/types.js";
 import { logger } from "../shared/logger.js";
 import { JINN_HOME, CLAUDE_SETTINGS_DIR, HOOK_RELAY_SCRIPT, CLAUDE_LIMITS_DIR } from "../shared/paths.js";
 import { cleanupSessionSettings, writeSessionSettings } from "../shared/claude-settings.js";
@@ -545,6 +545,18 @@ export function shouldSettleStalledTurn(elapsedMs: number, quietMs: number): boo
   return elapsedMs >= TURN_STALL_TIMEOUT_MS && quietMs >= TURN_STALL_QUIET_MS;
 }
 
+/** Warm-PTY submit confirmation. The CR that submits a bracketed paste is not
+ *  guaranteed to land — a 30-line paste into a TUI that is mid-redraw (or near
+ *  auto-compact) can swallow it, stranding the text in the composer while the
+ *  gateway waits forever on a turn that never started. UserPromptSubmit is the
+ *  CLI's acknowledgement; until it arrives, re-send the CR. Every window here is
+ *  bounded so an unsubmittable prompt fails loudly instead of hanging. */
+const SUBMIT_CONFIRM_INTERVAL_MS = 1500;
+const SUBMIT_CONFIRM_ATTEMPTS = 3;
+/** Hooks that prove the pasted prompt is running. SessionStart is excluded on
+ *  purpose: the idle spawn that warmed this PTY fires it before the paste. */
+const SUBMIT_ACK_HOOKS = new Set(["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "StopFailure"]);
+
 /** Claude Code built-in slash commands that run locally and never produce a new
  *  assistant API turn. Two behaviours, both handled by the native-command path:
  *   - Context mutators (/compact, /clear, /model) end without firing a Stop hook;
@@ -569,13 +581,57 @@ export function isNativeClaudeCommand(prompt: string): boolean {
   return first !== undefined && NATIVE_CLAUDE_COMMANDS.has(first);
 }
 
+/** Per-session bookkeeping for the turn currently in flight. Everything here is
+ *  in-memory and lives exactly as long as run() is pending, which is also exactly
+ *  the window in which the gateway's 5s heartbeat is asserting status:"running".
+ *  turnProgress() reads it so that assertion can be checked instead of trusted. */
+interface ActiveTurn {
+  resolver: TurnResolver;
+  onStream?: (d: StreamDelta) => void;
+  boundProc?: pty.IPty;
+  /** Suppresses auto-compaction summaries from leaking into the chat stream. */
+  gate?: CompactionStreamGate;
+  /** Local tool calls in flight (PreToolUse seen, PostToolUse not yet). A long
+   *  tool is real work, so a quiet PTY with tools running is NOT a stall. */
+  activeTools: number;
+  startedAt: number;
+  /** Last hook of any kind — proof of life independent of PTY redraw noise. */
+  lastHookAt: number;
+  /** Set once the CLI acknowledges the prompt. False forever = swallowed submit. */
+  promptSubmitted: boolean;
+  /** Stops the submit-confirmation retry loop; called when the turn settles. */
+  cancelSubmitConfirm?: () => void;
+}
+
+/** Optional submit acknowledgement probe for pasteAndSubmit. Supplied by the
+ *  gateway-driven warm-PTY path, where an unsubmitted prompt is an invisible hang;
+ *  omitted for raw WS input, where a human is at the keyboard and can press Enter. */
+export interface SubmitConfirmation {
+  /** True once the CLI acknowledged the prompt (UserPromptSubmit or any in-turn hook). */
+  submitted: () => boolean;
+  /** Called before each re-sent CR. */
+  onRetry?: (attempt: number) => void;
+  /** Called when the retries are exhausted and the prompt is still unacknowledged. */
+  onUnconfirmed?: (attempts: number) => void;
+  /** Test overrides. */
+  intervalMs?: number;
+  attempts?: number;
+}
+
 /** Bracketed-paste `text` into a PTY then submit with CR after a 150ms beat.
  *  Phase 0 finding: bracketed-paste does NOT neutralize a leading /, @, or ! —
  *  they still trigger the slash-command / mention / bash-mode handlers and the
  *  turn is never submitted. neutralizeForPaste() prepends a space for mentions,
  *  bash-mode, and jinn-skill slash commands, while letting engine-native commands
  *  (/compact, /clear, /model, …) pass through raw so the TUI actually runs them.
- *  Shared by injectPrompt() (warm-PTY first turn) and writeStdin() (raw WS input). */
+ *  Shared by injectPrompt() (warm-PTY first turn) and writeStdin() (raw WS input).
+ *
+ *  Pass `confirm` to make the submit verified rather than assumed: the CR is
+ *  re-sent until the CLI acknowledges the prompt, and `onUnconfirmed` fires if it
+ *  never does. Backticking attachment paths (below) removes the known trigger for
+ *  a swallowed CR; this covers the ones we have not characterised — a large paste
+ *  into a TUI mid-redraw, or one near auto-compact. Returns a cancel function —
+ *  the caller MUST call it when the turn settles (see the cancellation note). */
 /**
  * Compose the "Attached files:" suffix, with every path wrapped in backticks.
  *
@@ -602,10 +658,46 @@ export function buildAttachmentSuffix(attachments: readonly string[]): string {
   return "\n\nAttached files:\n" + attachments.map((a) => `- \`${a}\``).join("\n");
 }
 
-export function pasteAndSubmit(proc: Pick<pty.IPty, "write">, text: string): void {
+export function pasteAndSubmit(
+  proc: Pick<pty.IPty, "write">,
+  text: string,
+  confirm?: SubmitConfirmation,
+): () => void {
   const payload = neutralizeForPaste(text);
   proc.write(`\x1b[200~${payload}\x1b[201~`);
-  setTimeout(() => proc.write("\r"), 150);
+  let retryTimer: NodeJS.Timeout | undefined;
+  const submitTimer = setTimeout(() => {
+    proc.write("\r");
+    if (!confirm) return;
+    const maxAttempts = confirm.attempts ?? SUBMIT_CONFIRM_ATTEMPTS;
+    let attempt = 0;
+    retryTimer = setInterval(() => {
+      if (confirm.submitted()) {
+        if (retryTimer) clearInterval(retryTimer);
+        retryTimer = undefined;
+        return;
+      }
+      if (attempt >= maxAttempts) {
+        if (retryTimer) clearInterval(retryTimer);
+        retryTimer = undefined;
+        confirm.onUnconfirmed?.(attempt);
+        return;
+      }
+      attempt += 1;
+      confirm.onRetry?.(attempt);
+      proc.write("\r");
+    }, confirm.intervalMs ?? SUBMIT_CONFIRM_INTERVAL_MS);
+    retryTimer.unref?.();
+  }, 150);
+  // Cancellation is not optional: a turn that settles for any other reason (user
+  // interrupt, PTY death, engine switch) must stop this loop, or it would keep
+  // writing CRs into a PTY that now belongs to a DIFFERENT turn — submitting
+  // whatever that turn's composer happens to hold.
+  return () => {
+    clearTimeout(submitTimer);
+    if (retryTimer) clearInterval(retryTimer);
+    retryTimer = undefined;
+  };
 }
 
 export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngine {
@@ -616,7 +708,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
    *  released by a kill->respawn race can't poison the freshly-started turn.
    *  `onStream` is the current turn's delta callback; the per-PTY SSE proxy routes
    *  parsed events here (a PTY outlives its turn, so the proxy looks this up live). */
-  private active = new Map<string, { resolver: TurnResolver; onStream?: (d: StreamDelta) => void; boundProc?: pty.IPty; gate?: CompactionStreamGate }>();
+  private active = new Map<string, ActiveTurn>();
   /** Sessions with an in-flight async idle-spawn (proxy.start awaited) — prevents
    *  a second ensureIdleSpawn from racing in a duplicate PTY during that gap. */
   private idleSpawning = new Set<string>();
@@ -811,10 +903,17 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       native: nativeCommand,
       shouldDeferStopFailure: () => this.hasActiveUpstream(jinnSessionId),
     });
-    const entry: { resolver: TurnResolver; onStream?: (d: StreamDelta) => void; boundProc?: pty.IPty; activeTools: number } = {
+    const entry: ActiveTurn = {
       resolver,
       onStream: opts.onStream,
       activeTools: 0,
+      startedAt: turnStartedAt,
+      lastHookAt: turnStartedAt,
+      // Only the warm-PTY paste has to earn this flag. The cold-spawn path carries
+      // the prompt in argv, so it is submitted by construction; native commands are
+      // exempt because no acknowledgement is expected for them (see injectPrompt
+      // below) and awaitingSubmit must not mean "waiting for a signal we never want".
+      promptSubmitted: !warm || nativeCommand,
     };
     let turnMarkedStarted = false;
     let watchdog: NodeJS.Timeout | undefined;
@@ -827,6 +926,14 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       // Register BEFORE spawning so a fast SessionStart is buffered+drained, not lost.
       this.hookRegistry.register(jinnSessionId, (h) => {
         resolver.onHook(h);
+        entry.lastHookAt = Date.now();
+        // Submit acknowledgement. UserPromptSubmit is the direct signal; the in-turn
+        // hooks are accepted too because none of them can fire before a prompt is
+        // running. SessionStart is deliberately NOT accepted — it can arrive from the
+        // idle spawn that preceded this turn and would falsely confirm the submit.
+        if (SUBMIT_ACK_HOOKS.has(h.hook_event_name)) {
+          entry.promptSubmitted = true;
+        }
         // tool_use markers + intermediate text stream from the per-PTY SSE proxy
         // in true order. The hook only supplies tool_result; SSE has no local tool
         // completion event because tools execute between assistant messages.
@@ -845,7 +952,30 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
         // between getWarm() above and the proc.write() inside injectPrompt.
         this.lifecycle.turnStarted(jinnSessionId);
         turnMarkedStarted = true;
-        this.injectPrompt(warm, opts);
+        // Native commands (/compact, /clear, /model) run locally and settle via
+        // nativeCommandTimer; they need not emit UserPromptSubmit at all, so
+        // confirming them would re-send CRs at a prompt that already did its work.
+        // Same exclusion the lost-Stop recovery makes below, for the same reason.
+        entry.cancelSubmitConfirm = this.injectPrompt(warm, opts, nativeCommand ? undefined : {
+          // A settled turn is no longer ours to submit — stop either way. Without
+          // this the loop would outlive an early interrupt until run()'s finally.
+          submitted: () => entry.promptSubmitted || resolver.isSettled,
+          onRetry: (attempt) => logger.warn(
+            `InteractiveClaudeEngine: prompt submit unacknowledged for ${jinnSessionId} — re-sending CR (attempt ${attempt})`,
+          ),
+          // Every retry failed: the CLI is not going to take this prompt. Settle the
+          // turn instead of leaving run() pending forever — the heartbeat would keep
+          // asserting status:"running" and no other watchdog covers a live PTY that
+          // simply never started a turn. The pasted text is still in the composer, so
+          // the operator (or a resume) loses nothing.
+          onUnconfirmed: (attempts) => {
+            logger.warn(
+              `InteractiveClaudeEngine: prompt never submitted for ${jinnSessionId} after ${attempts} retries ` +
+              `— settling turn as interrupted (text remains in the CLI composer)`,
+            );
+            resolver.interrupt("Interrupted: the engine never acknowledged the prompt (submit not confirmed)");
+          },
+        });
         entry.boundProc = (warm as any)._proc as pty.IPty | undefined;
       } else {
         const handle = await this.spawn(jinnSessionId, opts, settingsPath);
@@ -937,6 +1067,8 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       if (watchdog) clearInterval(watchdog);
       if (nativeCommandTimer) clearInterval(nativeCommandTimer);
       if (lostStopRecoveryTimer) clearInterval(lostStopRecoveryTimer);
+      // MUST run before the PTY can be handed to another turn — see pasteAndSubmit.
+      entry.cancelSubmitConfirm?.();
       this.hookRegistry.unregister(jinnSessionId);
       this.active.delete(jinnSessionId);
       if (turnMarkedStarted) this.lifecycle.turnEnded(jinnSessionId); // manager decides kill vs keep-warm
@@ -1216,14 +1348,14 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
   }
 
   /** Inject a follow-up prompt into a warm PTY via bracketed-paste + CR. */
-  private injectPrompt(handle: PtyHandle, opts: EngineRunOpts): void {
+  private injectPrompt(handle: PtyHandle, opts: EngineRunOpts, confirm?: SubmitConfirmation): (() => void) | undefined {
     const proc = (handle as any)._proc as pty.IPty | undefined;
-    if (!proc) return;
+    if (!proc) return undefined;
     let text = buildPromptWithPlatformContext(opts);
     if (opts.attachments?.length) {
       text += buildAttachmentSuffix(opts.attachments);
     }
-    pasteAndSubmit(proc, text);
+    return pasteAndSubmit(proc, text, confirm);
   }
 
   subscribeWithSnapshot(
@@ -1288,6 +1420,30 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
   /** True only while a turn is in flight (distinct from "PTY is warm"). */
   isTurnRunning(sessionId: string): boolean {
     return this.active.has(sessionId);
+  }
+
+  /** Observable progress for the in-flight turn, or undefined if none is running.
+   *
+   *  isTurnRunning() answers "does the gateway think a turn exists" — it is a
+   *  bookkeeping lookup, so it stays true for a wedged turn forever. This answers
+   *  the question that actually matters: is that turn *getting anywhere*. The
+   *  reconciler uses it to catch hangs the heartbeat cannot (the heartbeat runs for
+   *  as long as run() is pending, so a fresh heartbeat proves only that the gateway
+   *  is still waiting), and serializeSession uses it to show stall in the UI.
+   *
+   *  PTY output alone is a weak signal — the TUI redraws its footer while idle at
+   *  the prompt — so hooks and tool state are reported alongside it and callers
+   *  weigh them together. */
+  turnProgress(sessionId: string): TurnProgress | undefined {
+    const entry = this.active.get(sessionId);
+    if (!entry) return undefined;
+    return {
+      turnStartedAt: entry.startedAt,
+      lastProgressAt: Math.max(entry.startedAt, entry.lastHookAt, this.lastOutputAt.get(sessionId) ?? 0),
+      awaitingSubmit: !entry.promptSubmitted,
+      activeTools: entry.activeTools,
+      activeUpstream: this.hasActiveUpstream(sessionId),
+    };
   }
 
   /** True iff a warm PTY exists for this session (in the lifecycle manager). */

--- a/packages/jinn/src/engines/claude-interactive.ts
+++ b/packages/jinn/src/engines/claude-interactive.ts
@@ -560,7 +560,7 @@ const SUBMIT_CONFIRM_INTERVAL_MS = 1500;
 const SUBMIT_CONFIRM_ATTEMPTS = 12;
 /** Hooks that prove the pasted prompt is running. SessionStart is excluded on
  *  purpose: the idle spawn that warmed this PTY fires it before the paste. */
-const SUBMIT_ACK_HOOKS = new Set(["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "StopFailure"]);
+export const SUBMIT_ACK_HOOKS = new Set(["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "StopFailure"]);
 
 /** Claude Code built-in slash commands that run locally and never produce a new
  *  assistant API turn. Two behaviours, both handled by the native-command path:

--- a/packages/jinn/src/engines/claude-interactive.ts
+++ b/packages/jinn/src/engines/claude-interactive.ts
@@ -1460,7 +1460,6 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
     const entry = this.active.get(sessionId);
     if (!entry) return undefined;
     return {
-      turnStartedAt: entry.startedAt,
       lastProgressAt: Math.max(entry.startedAt, entry.lastHookAt, this.lastOutputAt.get(sessionId) ?? 0),
       awaitingSubmit: !entry.promptSubmitted,
       activeTools: entry.activeTools,

--- a/packages/jinn/src/engines/claude-interactive.ts
+++ b/packages/jinn/src/engines/claude-interactive.ts
@@ -546,13 +546,18 @@ export function shouldSettleStalledTurn(elapsedMs: number, quietMs: number): boo
 }
 
 /** Warm-PTY submit confirmation. The CR that submits a bracketed paste is not
- *  guaranteed to land — a 30-line paste into a TUI that is mid-redraw (or near
- *  auto-compact) can swallow it, stranding the text in the composer while the
- *  gateway waits forever on a turn that never started. UserPromptSubmit is the
- *  CLI's acknowledgement; until it arrives, re-send the CR. Every window here is
- *  bounded so an unsubmittable prompt fails loudly instead of hanging. */
+ *  guaranteed to land — the TUI discards keypresses while it is busy, and
+ *  backticking attachment paths only removes the one trigger we characterised
+ *  (image auto-attach). When the CR is lost the text strands in the composer and
+ *  the turn never starts. UserPromptSubmit is the CLI's acknowledgement; until it
+ *  arrives, re-send the CR.
+ *
+ *  Retrying is the whole value here: a CR re-sent a second or two later succeeds
+ *  where the fixed 150ms one failed. Deciding the prompt is dead is NOT part of
+ *  the job — shouldSettleStalledTurn owns that, and a premature verdict would
+ *  kill live work. So the window is generous and the outcome is a log line. */
 const SUBMIT_CONFIRM_INTERVAL_MS = 1500;
-const SUBMIT_CONFIRM_ATTEMPTS = 3;
+const SUBMIT_CONFIRM_ATTEMPTS = 12;
 /** Hooks that prove the pasted prompt is running. SessionStart is excluded on
  *  purpose: the idle spawn that warmed this PTY fires it before the paste. */
 const SUBMIT_ACK_HOOKS = new Set(["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "StopFailure"]);
@@ -609,9 +614,19 @@ interface ActiveTurn {
 export interface SubmitConfirmation {
   /** True once the CLI acknowledged the prompt (UserPromptSubmit or any in-turn hook). */
   submitted: () => boolean;
+  /** True while the CLI is demonstrably doing real work — an upstream request in
+   *  flight or a local tool running.
+   *
+   *  Both the retry and the give-up must pause on this. Claude Code QUEUES a
+   *  pasted prompt behind a turn already running (a human typing in the CLI/xterm
+   *  view, say) and fires no UserPromptSubmit until it dequeues. Without this
+   *  gate, a queued-but-perfectly-alive prompt looks identical to a swallowed CR:
+   *  we would spray CRs at a busy TUI and then report a healthy turn as lost. */
+  busy?: () => boolean;
   /** Called before each re-sent CR. */
   onRetry?: (attempt: number) => void;
-  /** Called when the retries are exhausted and the prompt is still unacknowledged. */
+  /** Called when the retries are exhausted and the prompt is still unacknowledged.
+   *  Reporting only — settling the turn is shouldSettleStalledTurn's job. */
   onUnconfirmed?: (attempts: number) => void;
   /** Test overrides. */
   intervalMs?: number;
@@ -677,6 +692,10 @@ export function pasteAndSubmit(
         retryTimer = undefined;
         return;
       }
+      // Real work in flight: the prompt is queued, not lost. Hold the loop open
+      // without spending an attempt — neither retrying nor reporting is correct
+      // while the CLI is demonstrably busy.
+      if (confirm.busy?.()) return;
       if (attempt >= maxAttempts) {
         if (retryTimer) clearInterval(retryTimer);
         retryTimer = undefined;
@@ -960,21 +979,24 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
           // A settled turn is no longer ours to submit — stop either way. Without
           // this the loop would outlive an early interrupt until run()'s finally.
           submitted: () => entry.promptSubmitted || resolver.isSettled,
+          // Claude Code queues a pasted prompt behind a turn already running and
+          // fires no UserPromptSubmit until it dequeues, so a queued prompt is
+          // indistinguishable from a swallowed CR by acknowledgement alone. Pause
+          // on any evidence of real work rather than acting on that ambiguity.
+          busy: () => this.hasActiveUpstream(jinnSessionId) || entry.activeTools > 0,
           onRetry: (attempt) => logger.warn(
             `InteractiveClaudeEngine: prompt submit unacknowledged for ${jinnSessionId} — re-sending CR (attempt ${attempt})`,
           ),
-          // Every retry failed: the CLI is not going to take this prompt. Settle the
-          // turn instead of leaving run() pending forever — the heartbeat would keep
-          // asserting status:"running" and no other watchdog covers a live PTY that
-          // simply never started a turn. The pasted text is still in the composer, so
-          // the operator (or a resume) loses nothing.
-          onUnconfirmed: (attempts) => {
-            logger.warn(
-              `InteractiveClaudeEngine: prompt never submitted for ${jinnSessionId} after ${attempts} retries ` +
-              `— settling turn as interrupted (text remains in the CLI composer)`,
-            );
-            resolver.interrupt("Interrupted: the engine never acknowledged the prompt (submit not confirmed)");
-          },
+          // Report only. Settling here would mean ruling a turn dead from the
+          // absence of a signal, and the signal is genuinely absent in cases where
+          // the turn is alive; shouldSettleStalledTurn already owns that verdict
+          // with far more evidence. Losing the CR costs the backstop's window
+          // rather than seconds, but the retries above are what usually recover it
+          // — a CR re-sent a second later lands where the 150ms one did not.
+          onUnconfirmed: (attempts) => logger.warn(
+            `InteractiveClaudeEngine: prompt still unacknowledged for ${jinnSessionId} after ${attempts} re-sent CRs; `
+            + `text may be stranded in the CLI composer. Leaving the turn to the stall backstop.`,
+          ),
         });
         entry.boundProc = (warm as any)._proc as pty.IPty | undefined;
       } else {

--- a/packages/jinn/src/gateway/__tests__/session-serialization.test.ts
+++ b/packages/jinn/src/gateway/__tests__/session-serialization.test.ts
@@ -53,7 +53,6 @@ function makeContext(
 
 /** An engine that reports turn progress, as the interactive Claude engine does. */
 function makeProgressEngine(progress: {
-  turnStartedAt: number;
   lastProgressAt: number;
   awaitingSubmit: boolean;
   activeTools: number;
@@ -163,7 +162,6 @@ describe("serializeSession", () => {
 describe("serializeSession: turnProgress", () => {
   const NOW = new Date("2026-06-01T00:00:00.000Z").getTime();
   const live = {
-    turnStartedAt: NOW - 5_000,
     lastProgressAt: NOW - 5_000,
     awaitingSubmit: false,
     activeTools: 0,

--- a/packages/jinn/src/gateway/__tests__/session-serialization.test.ts
+++ b/packages/jinn/src/gateway/__tests__/session-serialization.test.ts
@@ -37,6 +37,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 function makeContext(
   backgroundActivity?: ApiContext["backgroundActivity"],
   transportByKey: Record<string, "idle" | "queued" | "running" | "error" | "interrupted"> = {},
+  engine?: unknown,
 ): ApiContext {
   return {
     backgroundActivity,
@@ -45,8 +46,20 @@ function makeContext(
         getPendingCount: () => 0,
         getTransportState: (key: string) => transportByKey[key] ?? "idle",
       }),
+      getEngine: () => engine,
     },
   } as unknown as ApiContext;
+}
+
+/** An engine that reports turn progress, as the interactive Claude engine does. */
+function makeProgressEngine(progress: {
+  turnStartedAt: number;
+  lastProgressAt: number;
+  awaitingSubmit: boolean;
+  activeTools: number;
+  activeUpstream: boolean;
+} | null) {
+  return { turnProgress: () => progress };
 }
 
 describe("serializeSession", () => {
@@ -144,5 +157,63 @@ describe("serializeSession", () => {
 
     expect(index.has("parent")).toBe(false);
     expect(serializeSession(parent, context, index).delegatedActivity).toBeNull();
+  });
+});
+
+describe("serializeSession: turnProgress", () => {
+  const NOW = new Date("2026-06-01T00:00:00.000Z").getTime();
+  const live = {
+    turnStartedAt: NOW - 5_000,
+    lastProgressAt: NOW - 5_000,
+    awaitingSubmit: false,
+    activeTools: 0,
+    activeUpstream: false,
+  };
+
+  it("reports the instant for any live turn, with no staleness verdict of its own", () => {
+    // The client owns the threshold: a stalled session emits nothing, so a verdict
+    // computed here would never be delivered. Five seconds in is still reported.
+    const session = makeSession({ status: "running" });
+    const context = makeContext(undefined, {}, makeProgressEngine(live));
+
+    expect(serializeSession(session, context).turnProgress).toEqual({
+      lastProgressAt: NOW - 5_000,
+      awaitingSubmit: false,
+    });
+  });
+
+  it("passes through awaitingSubmit so the row can say why it is quiet", () => {
+    const session = makeSession({ status: "running" });
+    const context = makeContext(undefined, {}, makeProgressEngine({ ...live, awaitingSubmit: true }));
+
+    expect(serializeSession(session, context).turnProgress?.awaitingSubmit).toBe(true);
+  });
+
+  it.each([
+    { label: "a tool is running", progress: { ...live, activeTools: 1 } },
+    { label: "an upstream request is in flight", progress: { ...live, activeUpstream: true } },
+  ])("stays silent while $label", ({ progress }) => {
+    // State, not time — the server is the right place to judge it, and both edges
+    // emit hooks, so the clearing refetch is guaranteed.
+    const session = makeSession({ status: "running" });
+    const context = makeContext(undefined, {}, makeProgressEngine(progress));
+
+    expect(serializeSession(session, context).turnProgress).toBeNull();
+  });
+
+  it("stays silent when no turn is in flight, or the session is not running", () => {
+    const idle = makeContext(undefined, {}, makeProgressEngine(null));
+    expect(serializeSession(makeSession({ status: "running" }), idle).turnProgress).toBeNull();
+
+    const running = makeContext(undefined, {}, makeProgressEngine(live));
+    expect(serializeSession(makeSession({ status: "idle" }), running).turnProgress).toBeNull();
+    expect(serializeSession(makeSession({ status: "waiting" }), running).turnProgress).toBeNull();
+  });
+
+  it("stays silent for engines that cannot report progress at all", () => {
+    const session = makeSession({ status: "running", engine: "codex" });
+
+    expect(serializeSession(session, makeContext()).turnProgress).toBeNull();
+    expect(serializeSession(session, makeContext(undefined, {}, {})).turnProgress).toBeNull();
   });
 });

--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import yaml from "js-yaml";
 import type { ChatBlock, ChatBlockEnvelope, CronJob, DelegatedActivity, Employee, Engine, IncomingMessage, JinnConfig, JsonObject, Session, StreamDelta, Target } from "../shared/types.js";
-import { isInterruptibleEngine, STRUCTURED_MESSAGE_BODY_MAX_CHARS } from "../shared/types.js";
+import { isInterruptibleEngine, reportsTurnProgress, STRUCTURED_MESSAGE_BODY_MAX_CHARS } from "../shared/types.js";
 import { compactEmployeeRole } from "../shared/employee-role.js";
 export { compactEmployeeRole } from "../shared/employee-role.js";
 import {
@@ -1982,6 +1982,26 @@ export function buildSessionDelegatedActivityIndex(
   return buildDelegatedActivityIndex(sessions, activeSessionIds);
 }
 
+/** How long an in-flight turn may produce nothing before the UI says so. Well below
+ *  the reconciler's kill threshold on purpose: the operator should see a session go
+ *  amber — and get the chance to interrupt or resend it themselves — long before
+ *  anything is reclaimed automatically. */
+const TURN_STALL_VISIBLE_MS = 90_000;
+
+/** Derived stall state for the UI. Null unless a turn is in flight AND it has gone
+ *  quiet with no tools or upstream work to explain the silence. */
+function computeTurnStall(session: Session, context: ApiContext): Session["turnStall"] {
+  if (session.status !== "running") return null;
+  const engine = context.sessionManager.getEngine(session.engine);
+  if (!engine || !reportsTurnProgress(engine)) return null;
+  const progress = engine.turnProgress(session.id);
+  if (!progress) return null;
+  if (progress.activeTools > 0 || progress.activeUpstream) return null;
+  const stalledForMs = Date.now() - progress.lastProgressAt;
+  if (stalledForMs < TURN_STALL_VISIBLE_MS) return null;
+  return { stalledForMs, awaitingSubmit: progress.awaitingSubmit };
+}
+
 export function serializeSession(
   session: Session,
   context: ApiContext,
@@ -1997,6 +2017,7 @@ export function serializeSession(
     ...session,
     queueDepth,
     transportState,
+    turnStall: computeTurnStall(session, context),
     backgroundActivity: bg && !bgIsStale
       ? { activeStreams: bg.activeStreams, lastActivityAt: new Date(bg.lastActivityAt).toISOString() }
       : null,

--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -1997,9 +1997,10 @@ function computeTurnStall(session: Session, context: ApiContext): Session["turnS
   const progress = engine.turnProgress(session.id);
   if (!progress) return null;
   if (progress.activeTools > 0 || progress.activeUpstream) return null;
-  const stalledForMs = Date.now() - progress.lastProgressAt;
-  if (stalledForMs < TURN_STALL_VISIBLE_MS) return null;
-  return { stalledForMs, awaitingSubmit: progress.awaitingSubmit };
+  if (Date.now() - progress.lastProgressAt < TURN_STALL_VISIBLE_MS) return null;
+  // Ship the instant, not the elapsed time: a duration frozen at serialize time
+  // would stop advancing between refetches.
+  return { lastProgressAt: progress.lastProgressAt, awaitingSubmit: progress.awaitingSubmit };
 }
 
 export function serializeSession(

--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -1982,24 +1982,28 @@ export function buildSessionDelegatedActivityIndex(
   return buildDelegatedActivityIndex(sessions, activeSessionIds);
 }
 
-/** How long an in-flight turn may produce nothing before the UI says so. Well below
- *  the reconciler's kill threshold on purpose: the operator should see a session go
- *  amber — and get the chance to interrupt or resend it themselves — long before
- *  anything is reclaimed automatically. */
-const TURN_STALL_VISIBLE_MS = 90_000;
-
-/** Derived stall state for the UI. Null unless a turn is in flight AND it has gone
- *  quiet with no tools or upstream work to explain the silence. */
-function computeTurnStall(session: Session, context: ApiContext): Session["turnStall"] {
+/** The in-flight turn's progress instant, for the UI to age itself.
+ *
+ *  Deliberately carries no staleness verdict. A stalled session emits no events —
+ *  that is what stalled means — so nothing invalidates the sessions query, and a
+ *  server-side "is it stale yet?" would only reach the client if something else
+ *  happened to trigger a refetch. The feature exists to surface a silent failure,
+ *  so it must not depend on activity to be delivered.
+ *
+ *  Instead this reports the instant for any live turn. The client already receives
+ *  a serialize at turn start, so it holds the value while the session is healthy
+ *  and its own clock decides when the silence has gone on too long.
+ *
+ *  Null while a tool or upstream request explains the quiet — that is state rather
+ *  than time, so the server is the right place to judge it — and both transitions
+ *  emit hooks, hence events, hence a refetch. */
+function computeLiveTurnProgress(session: Session, context: ApiContext): Session["turnProgress"] {
   if (session.status !== "running") return null;
   const engine = context.sessionManager.getEngine(session.engine);
   if (!engine || !reportsTurnProgress(engine)) return null;
   const progress = engine.turnProgress(session.id);
   if (!progress) return null;
   if (progress.activeTools > 0 || progress.activeUpstream) return null;
-  if (Date.now() - progress.lastProgressAt < TURN_STALL_VISIBLE_MS) return null;
-  // Ship the instant, not the elapsed time: a duration frozen at serialize time
-  // would stop advancing between refetches.
   return { lastProgressAt: progress.lastProgressAt, awaitingSubmit: progress.awaitingSubmit };
 }
 
@@ -2018,7 +2022,7 @@ export function serializeSession(
     ...session,
     queueDepth,
     transportState,
-    turnStall: computeTurnStall(session, context),
+    turnProgress: computeLiveTurnProgress(session, context),
     backgroundActivity: bg && !bgIsStale
       ? { activeStreams: bg.activeStreams, lastActivityAt: new Date(bg.lastActivityAt).toISOString() }
       : null,

--- a/packages/jinn/src/shared/__tests__/claude-settings.test.ts
+++ b/packages/jinn/src/shared/__tests__/claude-settings.test.ts
@@ -16,6 +16,13 @@ describe("claude-settings", () => {
     expect(s.appendSystemPrompt).toBe("SYS");
   });
 
+  it("registers UserPromptSubmit — the warm-PTY submit confirmation depends on it", () => {
+    // Without this hook a swallowed CR is indistinguishable from a slow turn, and
+    // claude-interactive's retry loop has nothing to wait for.
+    const s = buildSessionSettings({ sessionId: "jinn-abc", relayScript: "/h/relay.mjs" });
+    expect(s.hooks.UserPromptSubmit[0].hooks[0].command).toBe("node '/h/relay.mjs' 'jinn-abc'");
+  });
+
   it("shell-quotes hook relay paths and session ids", () => {
     const s = buildSessionSettings({ sessionId: "jinn ' tricky", relayScript: "/tmp/path with spaces/relay's.mjs" });
     const stop = s.hooks.Stop[0].hooks[0];

--- a/packages/jinn/src/shared/claude-settings.ts
+++ b/packages/jinn/src/shared/claude-settings.ts
@@ -14,8 +14,14 @@ interface HookMatcher { hooks: HookCommand[]; }
 // StopFailure fires INSTEAD of Stop when an API error ends the turn (rate_limit,
 // billing_error, server_error, …) — confirmed by the Phase 0 spike. It is the
 // structured rate-limit signal, so it must be registered alongside Stop.
+// UserPromptSubmit is the CLI's authoritative "this prompt is now running"
+// acknowledgement. The warm-PTY path submits by writing a CR after a bracketed
+// paste, and that CR can be swallowed (large paste mid-redraw, TUI busy) — leaving
+// the text sitting in the composer while the gateway waits on a turn that never
+// started. Registering this hook turns "did the submit land?" from a guess into a
+// fact; claude-interactive.ts retries the CR until it arrives.
 export interface ClaudeSettings {
-  hooks: Record<"SessionStart" | "Stop" | "StopFailure" | "PreToolUse" | "PostToolUse", HookMatcher[]>;
+  hooks: Record<"SessionStart" | "UserPromptSubmit" | "Stop" | "StopFailure" | "PreToolUse" | "PostToolUse", HookMatcher[]>;
   statusLine?: HookCommand;
   appendSystemPrompt?: string;
 }
@@ -55,6 +61,7 @@ export function buildSessionSettings(opts: SessionSettingsOpts): ClaudeSettings 
   return {
     hooks: {
       SessionStart: [cmd()],
+      UserPromptSubmit: [cmd()],
       Stop: [cmd()],
       StopFailure: [cmd()],
       PreToolUse: [cmd()],

--- a/packages/jinn/src/shared/types.ts
+++ b/packages/jinn/src/shared/types.ts
@@ -420,7 +420,14 @@ export interface Session {
    *  observable progress for a while. Null when the turn is healthy or none runs.
    *  Lets the UI distinguish a wedged session from a hard-thinking one — they are
    *  otherwise identical, indefinitely. */
-  turnStall?: { stalledForMs: number; awaitingSubmit: boolean } | null;
+  turnStall?: {
+    /** Epoch ms of the last observable progress — an INSTANT, not a duration.
+     *  A duration computed server-side freezes at whatever the last serialize
+     *  returned, so the label would stop ticking between refetches; the client
+     *  derives the age from this instead. */
+    lastProgressAt: number;
+    awaitingSubmit: boolean;
+  } | null;
   /** Serialize-time only (derived, never persisted): active employee sessions
    *  anywhere below this session in the parent/child tree. */
   delegatedActivity?: DelegatedActivity | null;

--- a/packages/jinn/src/shared/types.ts
+++ b/packages/jinn/src/shared/types.ts
@@ -158,6 +158,30 @@ export function isInterruptibleEngine(engine: Engine): engine is InterruptibleEn
   return "kill" in engine && "isAlive" in engine && "killAll" in engine;
 }
 
+/** Observable progress of an in-flight engine turn. Reported by engines that can
+ *  distinguish "a turn exists" from "a turn is getting somewhere" — the gateway's
+ *  turn heartbeat cannot, because it ticks for exactly as long as run() is pending
+ *  and so reads healthy for a permanently wedged turn. */
+export interface TurnProgress {
+  turnStartedAt: number;
+  /** Newest of: turn start, last hook, last engine output. */
+  lastProgressAt: number;
+  /** The prompt was handed to the engine but never acknowledged as started. */
+  awaitingSubmit: boolean;
+  /** Local tool calls in flight. A long tool is real work, not a stall. */
+  activeTools: number;
+  /** Upstream API requests in flight (background subagents/tasks). */
+  activeUpstream: boolean;
+}
+
+export interface TurnProgressEngine extends Engine {
+  turnProgress(sessionId: string): TurnProgress | undefined;
+}
+
+export function reportsTurnProgress(engine: Engine): engine is TurnProgressEngine {
+  return typeof (engine as Partial<TurnProgressEngine>).turnProgress === "function";
+}
+
 export interface EngineRunOpts {
   prompt: string;
   resumeSessionId?: string;
@@ -392,6 +416,11 @@ export interface Session {
    *  work — the CLI still has upstream API requests in flight (background
    *  subagents/tasks) after the turn settled. Null when none. */
   backgroundActivity?: { activeStreams: number; lastActivityAt: string } | null;
+  /** Serialize-time only (derived, never persisted): the in-flight turn has made no
+   *  observable progress for a while. Null when the turn is healthy or none runs.
+   *  Lets the UI distinguish a wedged session from a hard-thinking one — they are
+   *  otherwise identical, indefinitely. */
+  turnStall?: { stalledForMs: number; awaitingSubmit: boolean } | null;
   /** Serialize-time only (derived, never persisted): active employee sessions
    *  anywhere below this session in the parent/child tree. */
   delegatedActivity?: DelegatedActivity | null;

--- a/packages/jinn/src/shared/types.ts
+++ b/packages/jinn/src/shared/types.ts
@@ -163,7 +163,6 @@ export function isInterruptibleEngine(engine: Engine): engine is InterruptibleEn
  *  turn heartbeat cannot, because it ticks for exactly as long as run() is pending
  *  and so reads healthy for a permanently wedged turn. */
 export interface TurnProgress {
-  turnStartedAt: number;
   /** Newest of: turn start, last hook, last engine output. */
   lastProgressAt: number;
   /** The prompt was handed to the engine but never acknowledged as started. */

--- a/packages/jinn/src/shared/types.ts
+++ b/packages/jinn/src/shared/types.ts
@@ -416,15 +416,17 @@ export interface Session {
    *  work — the CLI still has upstream API requests in flight (background
    *  subagents/tasks) after the turn settled. Null when none. */
   backgroundActivity?: { activeStreams: number; lastActivityAt: string } | null;
-  /** Serialize-time only (derived, never persisted): the in-flight turn has made no
-   *  observable progress for a while. Null when the turn is healthy or none runs.
-   *  Lets the UI distinguish a wedged session from a hard-thinking one — they are
-   *  otherwise identical, indefinitely. */
-  turnStall?: {
-    /** Epoch ms of the last observable progress — an INSTANT, not a duration.
-     *  A duration computed server-side freezes at whatever the last serialize
-     *  returned, so the label would stop ticking between refetches; the client
-     *  derives the age from this instead. */
+  /** Serialize-time only (derived, never persisted): the in-flight turn's progress,
+   *  for the UI to age itself. Null when no turn runs, or while a tool or upstream
+   *  request explains the quiet.
+   *
+   *  Carries no staleness verdict on purpose. A stalled session emits no events, so
+   *  nothing invalidates the sessions query and a server-side verdict would only
+   *  arrive if something unrelated triggered a refetch — the feature exists to
+   *  surface a silent failure, so it cannot depend on activity to be delivered. The
+   *  client holds this instant from turn start and its own clock decides. */
+  turnProgress?: {
+    /** Epoch ms of the last observable progress — an INSTANT, not a duration. */
     lastProgressAt: number;
     awaitingSubmit: boolean;
   } | null;

--- a/packages/web/src/components/chat/__tests__/chat-sidebar-helpers.test.ts
+++ b/packages/web/src/components/chat/__tests__/chat-sidebar-helpers.test.ts
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, renderHook, screen } from '@testing-library/react'
 import { createElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { isFocusedSession } from '../chat-route-helpers'
-import { formatStallAge, getStatusDot, getTurnStall, hasBackgroundActivity, isArchivedSession, isDirectSession, isRecentError, isVisibleSource, pickDeleteFallbackId, pickNeighborSessionId, resolveRowIdentity, shouldFloatPinned, WorkflowSessionChip } from '../chat-sidebar'
+import { formatStallAge, getStatusDot, getTurnStall, hasBackgroundActivity, isArchivedSession, isDirectSession, isRecentError, isVisibleSource, pickDeleteFallbackId, pickNeighborSessionId, resolveRowIdentity, shouldFloatPinned, TURN_STALL_VISIBLE_MS, useStallClock, WorkflowSessionChip } from '../chat-sidebar'
 
 afterEach(() => {
   vi.useRealTimers()
@@ -297,34 +297,92 @@ describe('getTurnStall', () => {
   const NOW = 1_000_000_000
 
   it('derives the age from the reported instant', () => {
-    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW - 90_000, awaitingSubmit: false } }, NOW)).toEqual({
+    expect(getTurnStall({ id: 's', turnProgress: { lastProgressAt: NOW - 90_000, awaitingSubmit: false } }, NOW)).toEqual({
       stalledForMs: 90_000,
       awaitingSubmit: false,
     })
-    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW - 5_000, awaitingSubmit: true } }, NOW)).toEqual({
-      stalledForMs: 5_000,
+    expect(getTurnStall({ id: 's', turnProgress: { lastProgressAt: NOW - 10 * 60_000, awaitingSubmit: true } }, NOW)).toEqual({
+      stalledForMs: 10 * 60_000,
       awaitingSubmit: true,
     })
+  })
+
+  it('applies the staleness threshold itself, so a healthy live turn is not amber', () => {
+    // The server reports the instant for ANY live turn and passes no verdict —
+    // a stalled session emits no events, so a server-side verdict would never be
+    // delivered. The threshold therefore has to live here.
+    const fresh = { id: 's', turnProgress: { lastProgressAt: NOW - 5_000, awaitingSubmit: false } }
+    expect(getTurnStall(fresh, NOW)).toBeNull()
+    expect(getTurnStall(fresh, NOW + TURN_STALL_VISIBLE_MS)).not.toBeNull()
+  })
+
+  it('crosses the threshold on its own clock, with no new payload', () => {
+    // The case the whole design exists for: one serialize at turn start, then the
+    // session goes silent and never emits again. Nothing refetches; the row must
+    // still turn amber.
+    const atTurnStart = { id: 's', turnProgress: { lastProgressAt: NOW, awaitingSubmit: false } }
+    expect(getTurnStall(atTurnStart, NOW + 30_000)).toBeNull()
+    expect(getTurnStall(atTurnStart, NOW + 2 * 60_000)?.stalledForMs).toBe(2 * 60_000)
+    expect(getTurnStall(atTurnStart, NOW + 60 * 60_000)?.stalledForMs).toBe(60 * 60_000)
   })
 
   it('keeps advancing as time passes without a refetch', () => {
     // The whole reason the server sends an instant rather than a duration: a
     // server-computed elapsed time freezes at the last serialize, so the label
     // would read "2m" forever while an hour went by.
-    const session = { id: 's', turnStall: { lastProgressAt: NOW, awaitingSubmit: false } }
+    const session = { id: 's', turnProgress: { lastProgressAt: NOW, awaitingSubmit: false } }
     expect(getTurnStall(session, NOW + 2 * 60_000)?.stalledForMs).toBe(2 * 60_000)
     expect(getTurnStall(session, NOW + 60 * 60_000)?.stalledForMs).toBe(60 * 60_000)
   })
 
   it('tolerates gateways that predate the field, and rejects junk', () => {
     expect(getTurnStall({ id: 's' }, NOW)).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: null }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnProgress: null }, NOW)).toBeNull()
     // Nothing elapsed yet, or a clock skewed into the future.
-    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW, awaitingSubmit: false } }, NOW)).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW + 5_000, awaitingSubmit: false } }, NOW)).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: 0, awaitingSubmit: false } }, NOW)).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NaN, awaitingSubmit: false } }, NOW)).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { awaitingSubmit: true } as never }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnProgress: { lastProgressAt: NOW, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnProgress: { lastProgressAt: NOW + 5_000, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnProgress: { lastProgressAt: 0, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnProgress: { lastProgressAt: NaN, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnProgress: { awaitingSubmit: true } as never }, NOW)).toBeNull()
+  })
+})
+
+describe('useStallClock', () => {
+  it('advances on its own, so the amber row appears without any server traffic', () => {
+    vi.useFakeTimers()
+    try {
+      const { result, rerender, unmount } = renderHook(() => useStallClock())
+      const first = result.current
+      expect(typeof first).toBe('number')
+
+      // No tick yet: the value is stable, so React does not re-render in a loop.
+      rerender()
+      expect(result.current).toBe(first)
+
+      act(() => {
+        vi.advanceTimersByTime(TURN_STALL_VISIBLE_MS)
+      })
+      expect(result.current - first).toBeGreaterThanOrEqual(TURN_STALL_VISIBLE_MS)
+
+      // The interval is torn down with the last listener rather than left running.
+      unmount()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not tick for rows with nothing in flight', () => {
+    // Every visible row calls this hook. A row that cannot stall must not subscribe,
+    // or a quiet list would re-render itself every 15s forever.
+    vi.useFakeTimers()
+    try {
+      const { unmount } = renderHook(() => useStallClock(false))
+      expect(vi.getTimerCount()).toBe(0)
+      unmount()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 
@@ -341,7 +399,7 @@ describe('getStatusDot: a stalled turn must not look like a working one', () => 
 
   it('paints a stalled turn amber and STILL, with the elapsed time in the label', () => {
     const dot = getStatusDot(
-      { id: 's1', status: 'running', turnStall: { lastProgressAt: Date.now() - 51 * 60_000, awaitingSubmit: false } },
+      { id: 's1', status: 'running', turnProgress: { lastProgressAt: Date.now() - 51 * 60_000, awaitingSubmit: false } },
       read,
     )
     expect(dot).toEqual({ color: 'var(--system-orange)', label: 'no output for 51m', pulse: false })
@@ -349,7 +407,7 @@ describe('getStatusDot: a stalled turn must not look like a working one', () => 
 
   it('names the unaccepted-prompt case specifically — it has a different fix', () => {
     const dot = getStatusDot(
-      { id: 's1', status: 'running', turnStall: { lastProgressAt: Date.now() - 120_000, awaitingSubmit: true } },
+      { id: 's1', status: 'running', turnProgress: { lastProgressAt: Date.now() - 120_000, awaitingSubmit: true } },
       read,
     )
     expect(dot?.color).toBe('var(--system-orange)')
@@ -359,7 +417,7 @@ describe('getStatusDot: a stalled turn must not look like a working one', () => 
 
   it('ignores stall state on a session that is not running', () => {
     const dot = getStatusDot(
-      { id: 's1', status: 'idle', turnStall: { lastProgressAt: Date.now() - 999_000, awaitingSubmit: true } },
+      { id: 's1', status: 'idle', turnProgress: { lastProgressAt: Date.now() - 999_000, awaitingSubmit: true } },
       read,
     )
     expect(dot).toBeNull()

--- a/packages/web/src/components/chat/__tests__/chat-sidebar-helpers.test.ts
+++ b/packages/web/src/components/chat/__tests__/chat-sidebar-helpers.test.ts
@@ -294,24 +294,37 @@ describe('formatStallAge', () => {
 })
 
 describe('getTurnStall', () => {
-  it('reads the gateway-derived stall state', () => {
-    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: 90_000, awaitingSubmit: false } })).toEqual({
+  const NOW = 1_000_000_000
+
+  it('derives the age from the reported instant', () => {
+    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW - 90_000, awaitingSubmit: false } }, NOW)).toEqual({
       stalledForMs: 90_000,
       awaitingSubmit: false,
     })
-    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: 5_000, awaitingSubmit: true } })).toEqual({
+    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW - 5_000, awaitingSubmit: true } }, NOW)).toEqual({
       stalledForMs: 5_000,
       awaitingSubmit: true,
     })
   })
 
+  it('keeps advancing as time passes without a refetch', () => {
+    // The whole reason the server sends an instant rather than a duration: a
+    // server-computed elapsed time freezes at the last serialize, so the label
+    // would read "2m" forever while an hour went by.
+    const session = { id: 's', turnStall: { lastProgressAt: NOW, awaitingSubmit: false } }
+    expect(getTurnStall(session, NOW + 2 * 60_000)?.stalledForMs).toBe(2 * 60_000)
+    expect(getTurnStall(session, NOW + 60 * 60_000)?.stalledForMs).toBe(60 * 60_000)
+  })
+
   it('tolerates gateways that predate the field, and rejects junk', () => {
-    expect(getTurnStall({ id: 's' })).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: null })).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: 0, awaitingSubmit: false } })).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: -1, awaitingSubmit: false } })).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: NaN, awaitingSubmit: false } })).toBeNull()
-    expect(getTurnStall({ id: 's', turnStall: { awaitingSubmit: true } as never })).toBeNull()
+    expect(getTurnStall({ id: 's' }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: null }, NOW)).toBeNull()
+    // Nothing elapsed yet, or a clock skewed into the future.
+    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NOW + 5_000, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: 0, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { lastProgressAt: NaN, awaitingSubmit: false } }, NOW)).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { awaitingSubmit: true } as never }, NOW)).toBeNull()
   })
 })
 
@@ -328,7 +341,7 @@ describe('getStatusDot: a stalled turn must not look like a working one', () => 
 
   it('paints a stalled turn amber and STILL, with the elapsed time in the label', () => {
     const dot = getStatusDot(
-      { id: 's1', status: 'running', turnStall: { stalledForMs: 51 * 60_000, awaitingSubmit: false } },
+      { id: 's1', status: 'running', turnStall: { lastProgressAt: Date.now() - 51 * 60_000, awaitingSubmit: false } },
       read,
     )
     expect(dot).toEqual({ color: 'var(--system-orange)', label: 'no output for 51m', pulse: false })
@@ -336,7 +349,7 @@ describe('getStatusDot: a stalled turn must not look like a working one', () => 
 
   it('names the unaccepted-prompt case specifically — it has a different fix', () => {
     const dot = getStatusDot(
-      { id: 's1', status: 'running', turnStall: { stalledForMs: 120_000, awaitingSubmit: true } },
+      { id: 's1', status: 'running', turnStall: { lastProgressAt: Date.now() - 120_000, awaitingSubmit: true } },
       read,
     )
     expect(dot?.color).toBe('var(--system-orange)')
@@ -346,7 +359,7 @@ describe('getStatusDot: a stalled turn must not look like a working one', () => 
 
   it('ignores stall state on a session that is not running', () => {
     const dot = getStatusDot(
-      { id: 's1', status: 'idle', turnStall: { stalledForMs: 999_000, awaitingSubmit: true } },
+      { id: 's1', status: 'idle', turnStall: { lastProgressAt: Date.now() - 999_000, awaitingSubmit: true } },
       read,
     )
     expect(dot).toBeNull()

--- a/packages/web/src/components/chat/__tests__/chat-sidebar-helpers.test.ts
+++ b/packages/web/src/components/chat/__tests__/chat-sidebar-helpers.test.ts
@@ -3,7 +3,7 @@ import { createElement } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { isFocusedSession } from '../chat-route-helpers'
-import { hasBackgroundActivity, isArchivedSession, isDirectSession, isRecentError, isVisibleSource, pickDeleteFallbackId, pickNeighborSessionId, resolveRowIdentity, shouldFloatPinned, WorkflowSessionChip } from '../chat-sidebar'
+import { formatStallAge, getStatusDot, getTurnStall, hasBackgroundActivity, isArchivedSession, isDirectSession, isRecentError, isVisibleSource, pickDeleteFallbackId, pickNeighborSessionId, resolveRowIdentity, shouldFloatPinned, WorkflowSessionChip } from '../chat-sidebar'
 
 afterEach(() => {
   vi.useRealTimers()
@@ -280,5 +280,75 @@ describe('pickDeleteFallbackId (the ONE post-delete fallback decision)', () => {
     expect(pickDeleteFallbackId(['only'], ['only'], 'only')).toBeNull()
     expect(pickDeleteFallbackId([], [], 'gone')).toBeNull()
     expect(pickDeleteFallbackId([], ['gone'], 'gone')).toBeNull()
+  })
+})
+
+describe('formatStallAge', () => {
+  it('reads coarsely — the operator needs "too long", not a stopwatch', () => {
+    expect(formatStallAge(30_000)).toBe('under a minute')
+    expect(formatStallAge(60_000)).toBe('1m')
+    expect(formatStallAge(51 * 60_000)).toBe('51m')
+    expect(formatStallAge(60 * 60_000)).toBe('1h')
+    expect(formatStallAge(64 * 60_000)).toBe('1h 4m')
+  })
+})
+
+describe('getTurnStall', () => {
+  it('reads the gateway-derived stall state', () => {
+    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: 90_000, awaitingSubmit: false } })).toEqual({
+      stalledForMs: 90_000,
+      awaitingSubmit: false,
+    })
+    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: 5_000, awaitingSubmit: true } })).toEqual({
+      stalledForMs: 5_000,
+      awaitingSubmit: true,
+    })
+  })
+
+  it('tolerates gateways that predate the field, and rejects junk', () => {
+    expect(getTurnStall({ id: 's' })).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: null })).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: 0, awaitingSubmit: false } })).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: -1, awaitingSubmit: false } })).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { stalledForMs: NaN, awaitingSubmit: false } })).toBeNull()
+    expect(getTurnStall({ id: 's', turnStall: { awaitingSubmit: true } as never })).toBeNull()
+  })
+})
+
+describe('getStatusDot: a stalled turn must not look like a working one', () => {
+  const read = new Set(['s1'])
+
+  it('paints a working turn blue and pulsing', () => {
+    expect(getStatusDot({ id: 's1', status: 'running' }, read)).toEqual({
+      color: 'var(--system-blue)',
+      label: 'running',
+      pulse: true,
+    })
+  })
+
+  it('paints a stalled turn amber and STILL, with the elapsed time in the label', () => {
+    const dot = getStatusDot(
+      { id: 's1', status: 'running', turnStall: { stalledForMs: 51 * 60_000, awaitingSubmit: false } },
+      read,
+    )
+    expect(dot).toEqual({ color: 'var(--system-orange)', label: 'no output for 51m', pulse: false })
+  })
+
+  it('names the unaccepted-prompt case specifically — it has a different fix', () => {
+    const dot = getStatusDot(
+      { id: 's1', status: 'running', turnStall: { stalledForMs: 120_000, awaitingSubmit: true } },
+      read,
+    )
+    expect(dot?.color).toBe('var(--system-orange)')
+    expect(dot?.label).toMatch(/prompt not accepted by the engine/)
+    expect(dot?.pulse).toBe(false)
+  })
+
+  it('ignores stall state on a session that is not running', () => {
+    const dot = getStatusDot(
+      { id: 's1', status: 'idle', turnStall: { stalledForMs: 999_000, awaitingSubmit: true } },
+      read,
+    )
+    expect(dot).toBeNull()
   })
 })

--- a/packages/web/src/components/chat/chat-sidebar.tsx
+++ b/packages/web/src/components/chat/chat-sidebar.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState, useRef, useCallback, useMemo, startTransition } from "react"
+import React, { useEffect, useState, useRef, useCallback, useMemo, useSyncExternalStore, startTransition } from "react"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import { useQueryClient } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
@@ -61,7 +61,7 @@ interface Session {
   delegatedActivity?: DelegatedActivity | null
   /** The in-flight turn has produced nothing for a while; derived by the gateway.
    *  A running session and a wedged one are otherwise indistinguishable. */
-  turnStall?: { lastProgressAt: number; awaitingSubmit: boolean } | null
+  turnProgress?: { lastProgressAt: number; awaitingSubmit: boolean } | null
   [key: string]: unknown
 }
 
@@ -399,22 +399,73 @@ export function isRecentError(
   return nowMs - ts < RECENT_ERROR_WINDOW_MS
 }
 
-/** Read the gateway-derived stall state off a session, tolerating older payloads
- *  (a gateway that predates the field simply never reports a stall).
+/** How long a live turn may produce nothing before the row says so. Well below the
+ *  gateway reconciler's kill threshold on purpose: the operator should see a session
+ *  go amber — and get the chance to interrupt or resend it themselves — long before
+ *  anything is reclaimed automatically. */
+export const TURN_STALL_VISIBLE_MS = 90_000
+
+/** Read stall state off a session, tolerating older payloads (a gateway that
+ *  predates the field simply never reports progress).
  *
- *  The server sends `lastProgressAt` — an instant — and the age is derived here
- *  at render time. A server-computed duration would freeze at the last refetch,
- *  so the label would sit at "no output for 2m" while an hour passed. */
+ *  The staleness verdict lives HERE, not on the server. A stalled session emits no
+ *  events, so nothing invalidates the sessions query — a server-side verdict would
+ *  only arrive if something unrelated triggered a refetch, and the whole point is
+ *  to surface a session that generates no signals. The client receives the progress
+ *  instant at turn start, while the session is still healthy, and `useStallClock`
+ *  re-renders on a timer so this crosses the threshold with no network round-trip. */
 export function getTurnStall(
   session: Session,
   now: number = Date.now(),
 ): { stalledForMs: number; awaitingSubmit: boolean } | null {
-  const stall = session.turnStall
-  const at = stall?.lastProgressAt
-  if (!stall || typeof at !== "number" || !Number.isFinite(at) || at <= 0) return null
+  const progress = session.turnProgress
+  const at = progress?.lastProgressAt
+  if (!progress || typeof at !== "number" || !Number.isFinite(at) || at <= 0) return null
   const stalledForMs = now - at
-  if (stalledForMs <= 0) return null
-  return { stalledForMs, awaitingSubmit: !!stall.awaitingSubmit }
+  if (stalledForMs < TURN_STALL_VISIBLE_MS) return null
+  return { stalledForMs, awaitingSubmit: !!progress.awaitingSubmit }
+}
+
+/** One interval for the whole sidebar, shared via an external store.
+ *
+ *  A per-row timer would mean one interval per session; this keeps a single timer
+ *  that only runs while something is subscribed, and only exists to re-render so
+ *  getTurnStall can re-evaluate its own clock. */
+const stallClock = (() => {
+  const listeners = new Set<() => void>()
+  let now = Date.now()
+  let timer: ReturnType<typeof setInterval> | undefined
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener)
+      if (!timer) {
+        // The clock stops with the last listener, so the cached value can be
+        // arbitrarily old by the time the sidebar mounts again. React re-reads the
+        // snapshot right after subscribing, so refreshing here is picked up.
+        now = Date.now()
+        timer = setInterval(() => {
+          now = Date.now()
+          for (const l of listeners) l()
+        }, 15_000)
+      }
+      return () => {
+        listeners.delete(listener)
+        if (listeners.size === 0 && timer) {
+          clearInterval(timer)
+          timer = undefined
+        }
+      }
+    },
+    get: () => now,
+  }
+})()
+
+/** Ticks only for rows that could actually stall. A row with nothing in flight has
+ *  no age to advance, so it stays out of the listener set entirely and the interval
+ *  does not exist at all while the list is quiet. */
+const noStallClock = () => () => {}
+export function useStallClock(active = true): number {
+  return useSyncExternalStore(active ? stallClock.subscribe : noStallClock, stallClock.get, stallClock.get)
 }
 
 /** Coarse elapsed label — "2m", "51m", "1h 4m". Deliberately low-precision: the
@@ -436,12 +487,13 @@ export function getStatusDot(
   session: Session,
   readSet: Set<string>,
   forceUnread = false,
+  now: number = Date.now(),
 ): StatusDotState | null {
   if (session.status === "running") {
     // A stalled turn must not look like a working one. Same blue-dot spinner for
     // both is exactly why a 51-minute hang can sit unnoticed: amber + an elapsed
     // count is the difference between "thinking" and "go look at this".
-    const stall = getTurnStall(session)
+    const stall = getTurnStall(session, now)
     if (stall) {
       return {
         color: "var(--system-orange)",
@@ -588,7 +640,8 @@ const SessionRow = React.memo(function SessionRow({
   updateSessionTitle,
 }: SessionRowProps) {
   const sessionIsActive = session.id === selectedId
-  const sessionDot = getStatusDot(session, readSessions)
+  const stallNow = useStallClock(session.status === "running")
+  const sessionDot = getStatusDot(session, readSessions, false, stallNow)
   const sessionTitle = fixTitle(session.title, session.employee)
   const displayTitle = cleanPreview(sessionTitle) || sessionTitle
   const sessionTime = formatTime(getSessionActivity(session))
@@ -772,7 +825,8 @@ const FlatSessionRow = React.memo(function FlatSessionRow({
   updateSessionTitle,
 }: FlatSessionRowProps) {
   const isActive = session.id === selectedId
-  const dot = getStatusDot(session, readSessions)
+  const stallNow = useStallClock(session.status === "running")
+  const dot = getStatusDot(session, readSessions, false, stallNow)
   const rawTitle = fixTitle(session.title, session.employee)
   const displayTitle = cleanPreview(rawTitle) || "Untitled"
   const time = formatTime(getSessionActivity(session))
@@ -982,7 +1036,8 @@ const EmployeeRow = React.memo(function EmployeeRow({
   )
   // The group dot reflects the latest session's live state, but escalates to an
   // "unread" accent dot when any chat in the group is unread.
-  const empDot = getStatusDot(latestSession, readSessions, hasUnread)
+  const stallNow = useStallClock(latestSession?.status === "running")
+  const empDot = getStatusDot(latestSession, readSessions, hasUnread, stallNow)
 
   const sessionRowProps = {
     selectedId,

--- a/packages/web/src/components/chat/chat-sidebar.tsx
+++ b/packages/web/src/components/chat/chat-sidebar.tsx
@@ -59,6 +59,9 @@ interface Session {
   backgroundActivity?: BackgroundActivity | null
   /** Active descendant employee sessions; derived by the gateway. */
   delegatedActivity?: DelegatedActivity | null
+  /** The in-flight turn has produced nothing for a while; derived by the gateway.
+   *  A running session and a wedged one are otherwise indistinguishable. */
+  turnStall?: { stalledForMs: number; awaitingSubmit: boolean } | null
   [key: string]: unknown
 }
 
@@ -396,16 +399,51 @@ export function isRecentError(
   return nowMs - ts < RECENT_ERROR_WINDOW_MS
 }
 
+/** Read the gateway-derived stall state off a session, tolerating older payloads
+ *  (a gateway that predates the field simply never reports a stall). */
+export function getTurnStall(session: Session): { stalledForMs: number; awaitingSubmit: boolean } | null {
+  const stall = session.turnStall
+  if (!stall || typeof stall.stalledForMs !== "number" || !Number.isFinite(stall.stalledForMs)) return null
+  if (stall.stalledForMs <= 0) return null
+  return { stalledForMs: stall.stalledForMs, awaitingSubmit: !!stall.awaitingSubmit }
+}
+
+/** Coarse elapsed label — "2m", "51m", "1h 4m". Deliberately low-precision: the
+ *  operator needs to know it has been too long, not the exact second. */
+export function formatStallAge(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000)
+  if (totalMinutes < 1) return "under a minute"
+  if (totalMinutes < 60) return `${totalMinutes}m`
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`
+}
+
 // Resolve the attention-state dot for a session. Returns null for the resting
 // "read" state so no dot is painted (quiet at rest). Optionally treat the row
 // as unread even when this session is read (e.g. a grouped employee row whose
 // other chats are unread).
-function getStatusDot(
+export function getStatusDot(
   session: Session,
   readSet: Set<string>,
   forceUnread = false,
 ): StatusDotState | null {
-  if (session.status === "running") return { color: "var(--system-blue)", label: "running", pulse: true }
+  if (session.status === "running") {
+    // A stalled turn must not look like a working one. Same blue-dot spinner for
+    // both is exactly why a 51-minute hang can sit unnoticed: amber + an elapsed
+    // count is the difference between "thinking" and "go look at this".
+    const stall = getTurnStall(session)
+    if (stall) {
+      return {
+        color: "var(--system-orange)",
+        label: stall.awaitingSubmit
+          ? `prompt not accepted by the engine (stuck ${formatStallAge(stall.stalledForMs)})`
+          : `no output for ${formatStallAge(stall.stalledForMs)}`,
+        pulse: false, // a still dot reads as stuck; pulsing reads as working
+      }
+    }
+    return { color: "var(--system-blue)", label: "running", pulse: true }
+  }
   if (isRecentError(session.status, getSessionActivity(session), Date.now())) {
     return { color: "var(--system-red)", label: "error", pulse: false }
   }
@@ -414,6 +452,42 @@ function getStatusDot(
   // which would read like an error. Calm grey stays visible without alarming.
   if (forceUnread || !readSet.has(session.id)) return { color: "var(--text-secondary)", label: "unread", pulse: false }
   return null
+}
+
+/** Row-level "this needs a look" chips.
+ *
+ *  Both facts here were previously unobservable: a wedged session rendered exactly
+ *  like a working one indefinitely, and the queue piling up behind it was not shown
+ *  at all — so the only way to find a stuck employee was to go looking for one. */
+function SessionAttentionChips({ session }: { session: Session }) {
+  const stall = session.status === "running" ? getTurnStall(session) : null
+  const queued = typeof session.queueDepth === "number" ? session.queueDepth : 0
+  if (!stall && queued <= 0) return null
+  return (
+    <span className="flex shrink-0 items-center gap-1.5">
+      {stall ? (
+        <span
+          title={
+            stall.awaitingSubmit
+              ? "The engine never accepted this prompt. Open the CLI view to resend it, or interrupt the session."
+              : `The turn is still in flight but has produced no output for ${formatStallAge(stall.stalledForMs)}.`
+          }
+          style={{ background: "color-mix(in srgb, var(--system-orange) 14%, transparent)" }}
+          className="shrink-0 rounded-sm px-1 text-[10px] font-medium tabular-nums text-[var(--system-orange)]"
+        >
+          {stall.awaitingSubmit ? "not accepted" : `stalled ${formatStallAge(stall.stalledForMs)}`}
+        </span>
+      ) : null}
+      {queued > 0 ? (
+        <span
+          title={`${queued} queued message${queued === 1 ? "" : "s"} waiting on this session`}
+          className="shrink-0 rounded-sm bg-[var(--fill-secondary)] px-1 text-[10px] font-medium tabular-nums text-[var(--text-secondary)]"
+        >
+          {queued} queued
+        </span>
+      ) : null}
+    </span>
+  )
 }
 
 function StatusDot({
@@ -785,7 +859,10 @@ const FlatSessionRow = React.memo(function FlatSessionRow({
                   }}
                 />
               ) : (
-                <div className="truncate text-[11px] text-[var(--text-tertiary)]">{displayTitle}</div>
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="min-w-0 truncate text-[11px] text-[var(--text-tertiary)]">{displayTitle}</span>
+                  <SessionAttentionChips session={session} />
+                </div>
               )}
             </div>
           </button>

--- a/packages/web/src/components/chat/chat-sidebar.tsx
+++ b/packages/web/src/components/chat/chat-sidebar.tsx
@@ -61,7 +61,7 @@ interface Session {
   delegatedActivity?: DelegatedActivity | null
   /** The in-flight turn has produced nothing for a while; derived by the gateway.
    *  A running session and a wedged one are otherwise indistinguishable. */
-  turnStall?: { stalledForMs: number; awaitingSubmit: boolean } | null
+  turnStall?: { lastProgressAt: number; awaitingSubmit: boolean } | null
   [key: string]: unknown
 }
 
@@ -400,12 +400,21 @@ export function isRecentError(
 }
 
 /** Read the gateway-derived stall state off a session, tolerating older payloads
- *  (a gateway that predates the field simply never reports a stall). */
-export function getTurnStall(session: Session): { stalledForMs: number; awaitingSubmit: boolean } | null {
+ *  (a gateway that predates the field simply never reports a stall).
+ *
+ *  The server sends `lastProgressAt` — an instant — and the age is derived here
+ *  at render time. A server-computed duration would freeze at the last refetch,
+ *  so the label would sit at "no output for 2m" while an hour passed. */
+export function getTurnStall(
+  session: Session,
+  now: number = Date.now(),
+): { stalledForMs: number; awaitingSubmit: boolean } | null {
   const stall = session.turnStall
-  if (!stall || typeof stall.stalledForMs !== "number" || !Number.isFinite(stall.stalledForMs)) return null
-  if (stall.stalledForMs <= 0) return null
-  return { stalledForMs: stall.stalledForMs, awaitingSubmit: !!stall.awaitingSubmit }
+  const at = stall?.lastProgressAt
+  if (!stall || typeof at !== "number" || !Number.isFinite(at) || at <= 0) return null
+  const stalledForMs = now - at
+  if (stalledForMs <= 0) return null
+  return { stalledForMs, awaitingSubmit: !!stall.awaitingSubmit }
 }
 
 /** Coarse elapsed label — "2m", "51m", "1h 4m". Deliberately low-precision: the


### PR DESCRIPTION
A warm-PTY turn is submitted by bracketed-pasting the prompt and writing a CR 150ms later, and nothing checks that the CR landed. When it is swallowed, the text sits in the composer, the turn never starts, and the session is pinned at `running` with its queue frozen behind it — rendered in the dashboard exactly like healthy work. This confirms the submit instead of assuming it, and makes a stalled turn visible.

> Rebased onto current `main`. `88ddd669` landed the attachment-submit fix and a terminal stall backstop while this was open, so everything that overlapped is gone: no reconciler changes, and **nothing here settles a turn**.

---

**Backticking attachment paths fixed one cause; this covers the rest.** That fix removes the characterised trigger — the TUI's async image encode discarding keypresses — at the source, which is the right fix for it. But it is not the only way to lose the CR. On a live instance, two of the three wedges I traced had no attachment involved at all: a large paste into a TUI mid-redraw, and one sitting at `3% until auto-compact`. Each produced the same signature — a finished previous turn, `[Pasted text #N +M lines]` still in the composer, no spinner, no error, no Stop hook.

**The confirmation retries; it does not decide.** `UserPromptSubmit` is the CLI's acknowledgement, and the CR is re-sent until it arrives — a CR re-sent a second later lands where the 150ms one did not, which is where the value is. If the acknowledgement never comes, `onUnconfirmed` **logs a warning and nothing else**. It does not settle the turn:

- Ruling a turn dead from the absence of a signal is wrong when the signal is genuinely absent for live work: Claude Code queues a prompt behind a running turn and emits no `UserPromptSubmit` until it dequeues, so queued and swallowed are indistinguishable by acknowledgement alone. The retry loop pauses on `hasActiveUpstream() || activeTools > 0` rather than acting on that ambiguity.
- `shouldSettleStalledTurn` already owns the verdict, with far more evidence. Losing a CR costs that backstop's window rather than seconds.
- Because no error string is produced here, the `startsWith("Interrupted")` quiet-preempt path stays unreachable, and the composer-merge exposure stays at the backstop's existing rate rather than being made ~150× more likely.

The retry loop is cancelled when the turn settles for any reason — otherwise it would keep writing CRs into a PTY that has moved on to a different turn, submitting whatever that composer happens to hold.

Two paths are deliberately exempt. Cold spawn carries its prompt in argv, so it is submitted by construction. Native commands (`/compact`, `/clear`, `/model`) settle through `nativeCommandTimer` and need not emit the hook, so confirming them would fire spurious CRs at a prompt that already did its work — the same exclusion the lost-Stop recovery makes.

**`turnProgress()` reports, it does not decide.** It exposes last-progress time, whether the prompt was acknowledged, in-flight local tool count, and upstream activity. It exists so the state can be read from outside the engine.

**Because until now it could not be seen.** A wedged session and a hard-thinking one were pixel-identical, indefinitely: same pulsing blue dot, no elapsed time, no queue depth anywhere in the UI. Three separate wedges on one instance went unnoticed for hours each — the first for 3h18m with twelve inter-employee callbacks queued behind it — and were found only by querying the session database directly.

A stalled session's dot is now amber and *still*, since a pulse reads as working, labelled `no output for 51m` or naming the unaccepted-prompt case, which has a different remedy. Rows carry queue depth, so a backlog piling up behind a wedged employee is legible without opening anything.

**The staleness verdict is the client's, deliberately.** The gateway serializes `turnProgress` — `lastProgressAt` plus `awaitingSubmit` — for any live turn and passes no judgement. A wedged session emits no events, so nothing invalidates the sessions query; a server-computed verdict would only arrive if something unrelated triggered a refetch, and the feature exists to surface a session that generates no signals. The client holds the instant from turn start, while the session is still healthy, and `TURN_STALL_VISIBLE_MS` is applied against a local clock driven by one shared 15s `useSyncExternalStore` tick — rows with nothing in flight never subscribe, so a quiet list arms no timer. The row therefore turns amber with no network round-trip.

What stays server-side is `turnProgress: null` while a tool or upstream request explains the quiet. That is state rather than time, and both edges of it emit hooks — hence events, hence a refetch — so the clearing signal is guaranteed.

**Tests.** At the `pasteAndSubmit` level: the retry loop, the cancellation contract, the settled-turn guard, the busy pause, and report-not-settle. Through `engine.run`: that a real `UserPromptSubmit` on the hook callback sets `promptSubmitted` while `SessionStart` does not, the cold-spawn and native-command exemptions, `turnProgress()` from the real engine, and that a turn settled unacknowledged writes no further CRs — each mutation-checked so none passes vacuously. Server-side: `turnProgress` reported 5s into a turn, null while a tool or upstream request is in flight, null for non-running sessions and engines that cannot report. Client-side: the threshold applied locally, one payload from turn start crossing it unaided and still advancing an hour later, and the shared clock arming no timer when idle.

One guarantee is deliberately left untested and marked as such in the test file: that `run()`'s `finally` calls `cancelSubmitConfirm()`. `submitted()` also reads `resolver.isSettled`, so removing that call changes no observable behaviour — verified by mutation — and it remains as redundancy rather than as an untested claim.
