### PR TITLE
fix(migrations): let a no-op migration complete without symlink permission

### DIFF
--- a/packages/jinn/src/gateway/__tests__/instance-migration-api.test.ts
+++ b/packages/jinn/src/gateway/__tests__/instance-migration-api.test.ts
@@ -44,6 +44,24 @@ function seedBundle() {
   fs.writeFileSync(path.join(dir, "MIGRATION.md"), "# migration\n")
 }
 
+/** The shape every patch release actually ships: a required chain bridge that
+ *  changes no files. `AGENTS.md` is a symlink here because that is what
+ *  `jinn setup` creates, and it used to drag the snapshot through
+ *  fs.symlinkSync. */
+function seedEmptyBundle() {
+  seedBundle()
+  fs.symlinkSync("CLAUDE.md", path.join(home, "AGENTS.md"))
+  const dir = path.join(migrationsDir, "0.26.0")
+  fs.rmSync(path.join(dir, "files"), { recursive: true, force: true })
+  fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify({
+    schemaVersion: 1,
+    version: "0.26.0",
+    baseVersion: "0.25.0",
+    generatedFrom: { baseRef: "v0.25.0", headRef: "WORKTREE" },
+    files: [],
+  }, null, 2) + "\n")
+}
+
 function responseCapture() {
   let status = 200
   const chunks: Buffer[] = []
@@ -198,6 +216,32 @@ describe("instance migration API", () => {
     fs.writeFileSync(path.join(migrationsDir, "0.26.0/files/target/CLAUDE.md"), "tampered")
     expect((await request("GET", "/api/instance-migration")).status).toBe(500)
     expect(registry.listSessions()).toHaveLength(0)
+  })
+
+  it("opens an empty required bundle end to end, over a symlinked AGENTS.md", async () => {
+    // The case that was dead on Windows: 0.27.0 and every 0.28.x ship
+    // "files": [], and the snapshot dragged AGENTS.md through fs.symlinkSync
+    // regardless, so the open route 500'd as "temporarily unavailable" and the
+    // instance could never leave the migration gate.
+    seedEmptyBundle()
+    const pending = await request("GET", "/api/instance-migration")
+    expect(pending.body).toMatchObject({ required: true, fromVersion: "0.25.0", toVersion: "0.26.0" })
+    expect(pending.body.changedFiles ?? []).toEqual([])
+
+    const opened = await request("POST", "/api/instance-migration/open", { migrationKey: pending.body.migrationKey })
+
+    expect(opened.status).toBe(201)
+    expect(opened.body).toMatchObject({ reused: false, migrationKey: pending.body.migrationKey })
+    expect(opened.body).not.toHaveProperty("remedy")
+    expect(dispatched).toHaveLength(1)
+
+    // The snapshot still exists and holds the receipt the completion gate reads,
+    // and nothing was materialized under it.
+    const snapshotDir = path.join(home, ".migration-snapshots", pending.body.migrationKey)
+    expect(JSON.parse(fs.readFileSync(path.join(snapshotDir, "snapshot.json"), "utf8")).files).toEqual([])
+    expect(fs.existsSync(path.join(snapshotDir, "AGENTS.md"))).toBe(false)
+    // The instance's own symlink is untouched.
+    expect(fs.lstatSync(path.join(home, "AGENTS.md")).isSymbolicLink()).toBe(true)
   })
 
   it("classifies a refused symlink so the operator is told which knob to turn", () => {

--- a/packages/jinn/src/gateway/__tests__/instance-migration-api.test.ts
+++ b/packages/jinn/src/gateway/__tests__/instance-migration-api.test.ts
@@ -199,4 +199,24 @@ describe("instance migration API", () => {
     expect((await request("GET", "/api/instance-migration")).status).toBe(500)
     expect(registry.listSessions()).toHaveLength(0)
   })
+
+  it("classifies a refused symlink so the operator is told which knob to turn", () => {
+    // Windows without SeCreateSymbolicLinkPrivilege reports EPERM from
+    // fs.symlinkSync. Collapsing that into a bare "service unavailable" hid a
+    // fixable local condition behind a message that reads as a transient outage.
+    const denied = Object.assign(new Error("EPERM: operation not permitted, symlink 'CLAUDE.md' -> '/snap/AGENTS.md'"), {
+      code: "EPERM",
+      syscall: "symlink",
+    })
+    expect(api.isSymlinkPrivilegeError(denied)).toBe(true)
+    expect(api.isSymlinkPrivilegeError(Object.assign(new Error("nope"), { code: "EACCES", syscall: "symlink" }))).toBe(true)
+    // Message-only fallback, for errors that lost their syscall metadata.
+    expect(api.isSymlinkPrivilegeError(new Error("EPERM: operation not permitted, symlink 'a' -> 'b'"))).toBe(true)
+
+    // Unrelated failures must NOT claim a symlink remedy.
+    expect(api.isSymlinkPrivilegeError(Object.assign(new Error("ENOSPC: no space"), { code: "ENOSPC", syscall: "write" }))).toBe(false)
+    expect(api.isSymlinkPrivilegeError(new Error("existing migration snapshot failed verification"))).toBe(false)
+    expect(api.isSymlinkPrivilegeError("EPERM symlink")).toBe(false)
+    expect(api.isSymlinkPrivilegeError(undefined)).toBe(false)
+  })
 })

--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -2381,18 +2381,17 @@ export async function handleApiRequest(
         const opened = await openInstanceMigration(pending, req, context);
         return json(res, opened, opened.reused ? 200 : 201);
       } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        logger.error(`Instance migration session could not open: ${detail}`);
-        // Carry the cause to the operator. Collapsing every failure into one
-        // opaque sentence turned a fixable local problem (a missing Windows
-        // symlink privilege) into an apparent outage of the migration service,
-        // with nothing in the UI pointing at the real fix.
+        logger.error(`Instance migration session could not open: ${error instanceof Error ? error.message : String(error)}`);
+        // Name the one cause the operator can actually act on. Collapsing every
+        // failure into one opaque sentence turned a fixable local problem (a
+        // missing Windows symlink privilege) into an apparent outage of the
+        // migration service, with nothing in the UI pointing at the real fix.
+        // The raw message stays in the log: it carries absolute instance paths.
         return json(res, {
           error: "Could not create the migration snapshot and COO handoff",
           code: "MIGRATION_OPEN_FAILED",
-          detail,
-          ...(isSymlinkPrivilegeError(error)
-            ? { remedy: "Creating the migration snapshot needs symlink permission. On Windows, enable Developer Mode (Settings > System > For developers) or run the gateway elevated, then restart Jinn and retry." }
+          ...(process.platform === "win32" && isSymlinkPrivilegeError(error)
+            ? { remedy: "Creating the migration snapshot needs symlink permission. Enable Developer Mode (Settings > System > For developers) or run the gateway elevated, then restart Jinn and retry." }
             : {}),
         }, 500);
       }

--- a/packages/jinn/src/gateway/api.ts
+++ b/packages/jinn/src/gateway/api.ts
@@ -427,6 +427,17 @@ function retireUnacceptedInstanceMigrationSession(sessionKey: string): void {
   });
 }
 
+/** A snapshot failure caused by the platform refusing symlink creation. Windows
+ *  needs SeCreateSymbolicLinkPrivilege (Developer Mode or elevation) and reports
+ *  EPERM; the operator can fix it, but only if told which knob to turn. */
+export function isSymlinkPrivilegeError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  const syscall = (error as NodeJS.ErrnoException).syscall;
+  if (syscall === "symlink" && (code === "EPERM" || code === "EACCES")) return true;
+  return /symlink/i.test(error.message) && /EPERM|EACCES|operation not permitted|denied/i.test(error.message);
+}
+
 async function openInstanceMigration(
   pending: PendingInstanceMigration,
   req: HttpRequest,
@@ -2370,8 +2381,20 @@ export async function handleApiRequest(
         const opened = await openInstanceMigration(pending, req, context);
         return json(res, opened, opened.reused ? 200 : 201);
       } catch (error) {
-        logger.error(`Instance migration session could not open: ${error instanceof Error ? error.message : String(error)}`);
-        return json(res, { error: "Could not create the migration snapshot and COO handoff", code: "MIGRATION_OPEN_FAILED" }, 500);
+        const detail = error instanceof Error ? error.message : String(error);
+        logger.error(`Instance migration session could not open: ${detail}`);
+        // Carry the cause to the operator. Collapsing every failure into one
+        // opaque sentence turned a fixable local problem (a missing Windows
+        // symlink privilege) into an apparent outage of the migration service,
+        // with nothing in the UI pointing at the real fix.
+        return json(res, {
+          error: "Could not create the migration snapshot and COO handoff",
+          code: "MIGRATION_OPEN_FAILED",
+          detail,
+          ...(isSymlinkPrivilegeError(error)
+            ? { remedy: "Creating the migration snapshot needs symlink permission. On Windows, enable Developer Mode (Settings > System > For developers) or run the gateway elevated, then restart Jinn and retry." }
+            : {}),
+        }, 500);
       }
     }
 

--- a/packages/jinn/src/migrations/__tests__/snapshot.test.ts
+++ b/packages/jinn/src/migrations/__tests__/snapshot.test.ts
@@ -132,7 +132,8 @@ describe("migration snapshots", () => {
     expect(second).toEqual({ path: first.path, reused: true })
     expect(verifyMigrationSnapshot(options)).toBe(true)
     expect(fs.readFileSync(path.join(first.path, "skills/stock/SKILL.md"), "utf8")).toBe("custom skill\n")
-    expect(fs.lstatSync(path.join(first.path, "AGENTS.md")).isSymbolicLink()).toBe(true)
+    // AGENTS.md is a symlink: carried in the receipt, not recreated on disk.
+    expect(fs.existsSync(path.join(first.path, "AGENTS.md"))).toBe(false)
     expect(fs.statSync(path.join(first.path, "CLAUDE.md")).mode & 0o777).toBe(0o640)
     expect(fs.existsSync(path.join(first.path, "secrets"))).toBe(false)
     expect(JSON.parse(fs.readFileSync(path.join(first.path, "snapshot.json"), "utf8"))).toMatchObject({
@@ -185,10 +186,42 @@ describe("migration snapshots", () => {
       changedFiles: [{ path: "skills/stock/SKILL.md", operation: "modify" as const }],
     }
     const snapshot = createMigrationSnapshot(options)
-    expect(fs.lstatSync(path.join(snapshot.path, "AGENTS.md")).isSymbolicLink()).toBe(true)
     expect(fs.existsSync(path.join(snapshot.path, "CLAUDE.md"))).toBe(true)
     expect(fs.existsSync(path.join(snapshot.path, "config.yaml"))).toBe(true)
+    expect(fs.existsSync(path.join(snapshot.path, "skills/stock/SKILL.md"))).toBe(true)
     expect(verifyMigrationSnapshot(options)).toBe(true)
+  })
+
+  it("records a symlink in the receipt without recreating one on disk", () => {
+    // A symlink's whole content is its target, which the receipt already holds
+    // with its hash, so materializing one adds nothing and costs a privilege
+    // Windows withholds by default. A non-empty bundle would otherwise hit the
+    // same EPERM the empty-bundle case above avoids.
+    const home = fixture()
+    const options = {
+      instanceHome: home,
+      migrationKey: "e".repeat(64),
+      fromVersion: "0.25.0",
+      toVersion: "0.26.0",
+      changedFiles: [{ path: "skills/stock/SKILL.md", operation: "modify" as const }],
+    }
+    const snapshot = createMigrationSnapshot(options)
+
+    expect(fs.existsSync(path.join(snapshot.path, "AGENTS.md"))).toBe(false)
+    const entry = JSON.parse(fs.readFileSync(path.join(snapshot.path, "snapshot.json"), "utf8"))
+      .files.find((file: { path: string }) => file.path === "AGENTS.md")
+    expect(entry).toMatchObject({ state: "symlink", linkTarget: "CLAUDE.md", sha256: hash("CLAUDE.md") })
+    expect(verifyMigrationSnapshot(options)).toBe(true)
+
+    // A snapshot written by an older build still has the link on disk. It is
+    // sound, so it must keep verifying rather than throw on the next open.
+    fs.symlinkSync("CLAUDE.md", path.join(snapshot.path, "AGENTS.md"))
+    expect(verifyMigrationSnapshot(options)).toBe(true)
+
+    // ...but a link that disagrees with the receipt is still a corrupt snapshot.
+    fs.unlinkSync(path.join(snapshot.path, "AGENTS.md"))
+    fs.symlinkSync("elsewhere.md", path.join(snapshot.path, "AGENTS.md"))
+    expect(verifyMigrationSnapshot(options)).toBe(false)
   })
 
   it("refuses unsafe, excluded, and escaping paths", () => {

--- a/packages/jinn/src/migrations/__tests__/snapshot.test.ts
+++ b/packages/jinn/src/migrations/__tests__/snapshot.test.ts
@@ -142,6 +142,55 @@ describe("migration snapshots", () => {
     })
   })
 
+  it("materializes nothing for an empty bundle, so a no-op migration needs no symlink privilege", () => {
+    // Patch upgrades routinely ship empty bridges (0.28.3 and 0.28.4 both have
+    // "files": []). The snapshot used to copy config.yaml/CLAUDE.md/AGENTS.md
+    // regardless, and AGENTS.md is a symlink in the layout `jinn setup` creates —
+    // so on Windows without SeCreateSymbolicLinkPrivilege the snapshot threw
+    // EPERM and the migration could never complete.
+    const home = fixture()
+    const options = {
+      instanceHome: home,
+      migrationKey: "c".repeat(64),
+      fromVersion: "0.28.2",
+      toVersion: "0.28.4",
+      changedFiles: [],
+    }
+    const snapshot = createMigrationSnapshot(options)
+
+    // No entries copied at all — in particular no symlink was created.
+    expect(fs.existsSync(path.join(snapshot.path, "AGENTS.md"))).toBe(false)
+    expect(fs.existsSync(path.join(snapshot.path, "CLAUDE.md"))).toBe(false)
+    expect(fs.existsSync(path.join(snapshot.path, "config.yaml"))).toBe(false)
+    expect(JSON.parse(fs.readFileSync(path.join(snapshot.path, "snapshot.json"), "utf8")).files).toEqual([])
+
+    // The directory and receipt still exist and verify, which is what the
+    // completion gate requires before it will advance the version marker.
+    expect(verifyMigrationSnapshot(options)).toBe(true)
+    expect(createMigrationSnapshot(options)).toEqual({ path: snapshot.path, reused: true })
+
+    // The instance itself is untouched.
+    expect(fs.lstatSync(path.join(home, "AGENTS.md")).isSymbolicLink()).toBe(true)
+  })
+
+  it("still snapshots the context files when the bundle has records to compare", () => {
+    // Guard the narrow scope of the fix above: a real migration must keep its
+    // three-way comparison material.
+    const home = fixture()
+    const options = {
+      instanceHome: home,
+      migrationKey: "d".repeat(64),
+      fromVersion: "0.25.0",
+      toVersion: "0.26.0",
+      changedFiles: [{ path: "skills/stock/SKILL.md", operation: "modify" as const }],
+    }
+    const snapshot = createMigrationSnapshot(options)
+    expect(fs.lstatSync(path.join(snapshot.path, "AGENTS.md")).isSymbolicLink()).toBe(true)
+    expect(fs.existsSync(path.join(snapshot.path, "CLAUDE.md"))).toBe(true)
+    expect(fs.existsSync(path.join(snapshot.path, "config.yaml"))).toBe(true)
+    expect(verifyMigrationSnapshot(options)).toBe(true)
+  })
+
   it("refuses unsafe, excluded, and escaping paths", () => {
     const home = fixture()
     for (const changedPath of ["../outside", "secrets/token", "sessions/registry.db", "/tmp/outside"]) {

--- a/packages/jinn/src/migrations/snapshot.ts
+++ b/packages/jinn/src/migrations/snapshot.ts
@@ -111,12 +111,19 @@ function inspectSource(instanceHome: string, relative: string): SnapshotEntry {
 
 function copyEntry(instanceHome: string, snapshotRoot: string, entry: SnapshotEntry): void {
   if (entry.state === "missing") return
+  // A symlink's entire content is its target, and the receipt already records the
+  // target and its sha256, so a link on disk preserves nothing the receipt does
+  // not. Recreating one costs SeCreateSymbolicLinkPrivilege, which Windows
+  // withholds unless Developer Mode is on or the process is elevated: an instance
+  // whose AGENTS.md is a symlink (the layout `jinn setup` creates when the
+  // privilege IS available) could not snapshot at all afterwards, and the failure
+  // surfaced only as "the migration service is temporarily unavailable".
+  if (entry.state === "symlink") return
   const source = safePath(instanceHome, entry.path)
   const destination = path.join(snapshotRoot, entry.path)
   fs.mkdirSync(path.dirname(destination), { recursive: true })
-  if (entry.state === "symlink") fs.symlinkSync(entry.linkTarget!, destination)
-  else fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL)
-  if (entry.mode !== undefined && entry.state === "file") fs.chmodSync(destination, entry.mode)
+  fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL)
+  if (entry.mode !== undefined) fs.chmodSync(destination, entry.mode)
 }
 
 function snapshotPath(options: MigrationSnapshotOptions): string {
@@ -268,10 +275,18 @@ export function verifyMigrationSnapshot(options: MigrationSnapshotOptions): bool
         }
         continue
       }
-      const stat = fs.lstatSync(saved)
       if (entry.state === "symlink") {
-        if (!stat.isSymbolicLink() || fs.readlinkSync(saved) !== entry.linkTarget || sha(fs.readlinkSync(saved)) !== entry.sha256) return false
-      } else if (!stat.isFile() || sha(fs.readFileSync(saved)) !== entry.sha256 || (stat.mode & 0o777) !== entry.mode) return false
+        // Verified from the receipt, which holds the whole of a symlink's content.
+        // The link is no longer materialized (see copyEntry), so accept its absence
+        // — and equally accept a snapshot written before that change, which still
+        // has one on disk, rather than failing an otherwise sound snapshot.
+        if (typeof entry.linkTarget !== "string" || sha(entry.linkTarget) !== entry.sha256) return false
+        const existing = fs.lstatSync(saved, { throwIfNoEntry: false })
+        if (existing && (!existing.isSymbolicLink() || fs.readlinkSync(saved) !== entry.linkTarget)) return false
+        continue
+      }
+      const stat = fs.lstatSync(saved)
+      if (!stat.isFile() || sha(fs.readFileSync(saved)) !== entry.sha256 || (stat.mode & 0o777) !== entry.mode) return false
     }
     if (options.materialization && !verifyMaterializedPayloads(root, options.materialization)) return false
     return true

--- a/packages/jinn/src/migrations/snapshot.ts
+++ b/packages/jinn/src/migrations/snapshot.ts
@@ -77,6 +77,19 @@ function safePath(instanceHome: string, relative: string): string {
 }
 
 function selectedPaths(options: MigrationSnapshotOptions): string[] {
+  // No changed records means no three-way comparison to perform, so the context
+  // files below have nothing to support. Materializing them anyway is not merely
+  // wasted work: an instance whose AGENTS.md is a symlink (the layout `jinn setup`
+  // creates) forces fs.symlinkSync, which Windows refuses without
+  // SeCreateSymbolicLinkPrivilege — so a no-op patch migration became impossible
+  // to complete there, surfacing only as "the migration service is temporarily
+  // unavailable". Empty bundles are the common case for patch upgrades.
+  //
+  // Both createMigrationSnapshot and verifyMigrationSnapshot derive their file
+  // set from here, so the snapshot and its verification stay consistent; the
+  // snapshot directory and snapshot.json are still written, which is what the
+  // completion receipt needs.
+  if (options.changedFiles.length === 0) return []
   const paths = new Set(options.changedFiles.map((file) => file.path))
   paths.add("config.yaml")
   paths.add("CLAUDE.md")

--- a/packages/web/src/components/migration/__tests__/instance-migration-gate.test.tsx
+++ b/packages/web/src/components/migration/__tests__/instance-migration-gate.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { InstanceMigrationGate } from "../instance-migration-gate"
-import type { InstanceMigration } from "@/lib/api"
+import { ApiError, type InstanceMigration } from "@/lib/api"
 
 const dismissedStorageKey = "jinn.instance-migration.dismissed-key"
 
@@ -255,5 +255,39 @@ describe("InstanceMigrationGate", () => {
     expect(banner.outerHTML).not.toContain("var(--system-purple)")
     expect(banner.outerHTML).not.toContain("var(--system-blue)")
     expect(banner.textContent).not.toContain("Action")
+  })
+})
+
+describe("InstanceMigrationGate: actionable open failures", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("shows the server's remedy instead of the generic unavailable message", async () => {
+    // A refused symlink is a local, fixable condition. "Temporarily unavailable"
+    // reads as "wait and retry" for something that never clears on its own.
+    const remedy = "Creating the migration snapshot needs symlink permission. On Windows, enable Developer Mode (Settings > System > For developers) or run the gateway elevated, then restart Jinn and retry."
+    const open = vi.fn().mockRejectedValue(
+      new ApiError(500, "Could not create the migration snapshot and COO handoff", "MIGRATION_OPEN_FAILED", undefined, remedy),
+    )
+    setup({ open })
+
+    await userEvent.click(await screen.findByRole("button", { name: /open with coo/i }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toContain("Developer Mode")
+    expect(alert.textContent).not.toMatch(/temporarily unavailable/i)
+  })
+
+  it("falls back to the generic message when the server offers no remedy", async () => {
+    const open = vi.fn().mockRejectedValue(
+      new ApiError(500, "Could not create the migration snapshot and COO handoff", "MIGRATION_OPEN_FAILED"),
+    )
+    setup({ open })
+
+    await userEvent.click(await screen.findByRole("button", { name: /open with coo/i }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toMatch(/temporarily unavailable/i)
   })
 })

--- a/packages/web/src/components/migration/instance-migration-gate.tsx
+++ b/packages/web/src/components/migration/instance-migration-gate.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { Check, ChevronRight, Copy } from "lucide-react"
-import { api, type InstanceMigration, type OpenInstanceMigrationResult } from "@/lib/api"
+import { ApiError, api, type InstanceMigration, type OpenInstanceMigrationResult } from "@/lib/api"
 import { queryKeys } from "@/lib/query-keys"
 import { Button } from "@/components/ui/button"
 import {
@@ -97,6 +97,7 @@ export function InstanceMigrationGate({
     },
     onError: () => { launching.current = false },
   })
+  const launchRemedy = launch.error instanceof ApiError ? launch.error.remedy : undefined
 
   if (!migration && query.isError) {
     return (
@@ -189,7 +190,14 @@ export function InstanceMigrationGate({
 
             {(query.isError || launch.isError) && (
               <div className="mt-5 rounded-[var(--radius-lg)] bg-[var(--fill-secondary)] p-3 text-[length:var(--text-footnote)] text-[var(--text-secondary)]" role="alert">
-                The migration service is temporarily unavailable. Your reminder remains here.
+                {launchRemedy ? (
+                  // A cause the operator can actually act on beats a generic
+                  // "temporarily unavailable", which reads as "wait and retry"
+                  // for a condition that will never clear on its own.
+                  <span>{launchRemedy}</span>
+                ) : (
+                  <span>The migration service is temporarily unavailable. Your reminder remains here.</span>
+                )}
                 <Button className="ml-2 min-h-10" size="sm" variant="ghost" onClick={() => void query.refetch()}>Retry migration check</Button>
               </div>
             )}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -117,13 +117,17 @@ export class ApiError extends Error {
   readonly status: number
   readonly code?: string
   readonly currentVersion?: number
+  /** Operator-actionable guidance from the server, when the failure is one the
+   *  operator can fix locally (e.g. a missing OS privilege). Shown verbatim. */
+  readonly remedy?: string
 
-  constructor(status: number, message: string, code?: string, currentVersion?: number) {
+  constructor(status: number, message: string, code?: string, currentVersion?: number, remedy?: string) {
     super(message)
     this.name = "ApiError"
     this.status = status
     this.code = code
     this.currentVersion = currentVersion
+    this.remedy = remedy
   }
 }
 
@@ -144,6 +148,7 @@ async function responseError(res: Response): Promise<ApiError> {
   let message = `API error: ${res.status}`
   let code: string | undefined
   let currentVersion: number | undefined
+  let remedy: string | undefined
   try {
     const body = await res.json();
     if (body.error) message = String(body.error)
@@ -152,10 +157,11 @@ async function responseError(res: Response): Promise<ApiError> {
     if (typeof body.currentVersion === "number" && Number.isSafeInteger(body.currentVersion) && body.currentVersion >= 0) {
       currentVersion = body.currentVersion
     }
+    if (typeof body.remedy === "string" && body.remedy.trim()) remedy = body.remedy.trim()
   } catch {
     // Response wasn't JSON; status remains the typed UI-safe discriminator.
   }
-  return new ApiError(res.status, message, code, currentVersion)
+  return new ApiError(res.status, message, code, currentVersion, remedy)
 }
 
 async function get<T>(path: string, init?: RequestInit): Promise<T> {


### PR DESCRIPTION
A patch upgrade that changes no instance files cannot complete on Windows without symlink privilege, and the dashboard reports it as "the migration service is temporarily unavailable" — which reads as a transient outage for a condition that never clears on its own. Both halves are fixed here: the snapshot no longer materializes symlinks at all, and a failure now says what actually went wrong.

---

**Who this reaches.** `jinn setup` has had a symlink→copy fallback for `AGENTS.md` since v0.19.0 (`cli/setup.ts:551-570`), so an instance created *without* the privilege has a regular file and never reaches `fs.symlinkSync`. The affected layout is an instance whose `AGENTS.md` **is** a symlink and which now runs without the privilege: created with Developer Mode on and later off, elevated at setup but not at runtime, or a `~/.jinn` synced from a POSIX machine. Narrower than "every Windows instance" — but not hypothetical: the instance this was found on has the symlink, and its gateway log carries the `EPERM ... symlink` twice, once per upgrade attempt.

**An empty bundle still demanded a snapshot.** `selectedPaths()` unconditionally added `config.yaml`, `CLAUDE.md` and `AGENTS.md` regardless of whether the bundle carried any changed records. With no changed records there is no three-way comparison for those context files to support, so it now returns nothing. Creation and verification both derive their file set from that one function, so they stay consistent by construction, and the snapshot directory and `snapshot.json` are still written — which is what the completion receipt and its gate require.

That alone would have unblocked patch upgrades and left feature upgrades broken on the same machine (0.26.0 ships 16 files, 0.28.0 ships 4), so the general fix is folded in: **`copyEntry` no longer materializes symlinks.** The receipt already records `linkTarget` and its sha256, which is the entire content of a symlink, and no code path restores a snapshot from disk — the snapshot is a verification artifact plus a home for the completion receipt. `verifyMigrationSnapshot` checks the link from the receipt and accepts either its absence or a link left by an older build, so snapshots written before this change keep verifying rather than throwing `existing migration snapshot failed verification` on the next open. A bundle that does carry records keeps all of its comparison material; that is pinned by a test.

**The failure said nothing useful.** Every error from `openInstanceMigration` collapsed into one opaque sentence, so a fixable local condition looked like a service outage with nothing pointing at the remedy. The route now attaches a `remedy` naming Developer Mode when the platform refused a symlink, and the dialog shows it in place of the generic message. The raw error stays in the log and out of the body, per the convention the rest of `api.ts` follows.

Note that with `copyEntry` no longer creating symlinks, that classifier is a **backstop** rather than the live path for this bug — the snapshot itself no longer asks for the privilege. It is kept because the message is the difference between a fixable condition and an apparent outage for any other symlink-dependent failure in this route.

**Verification.** An empty required bundle now opens end to end through the API over a symlinked `AGENTS.md`: 201, snapshot receipt with `"files": []`, nothing materialized under it, the instance's own symlink untouched. The snapshot suite pins that a symlink is recorded but not recreated, that a pre-existing on-disk link still verifies, and that one disagreeing with the receipt does not.

Note for reviewers on Windows: `snapshot.test.ts` has one pre-existing failure here (`expected 438 to be 416`), a POSIX permission assertion Windows cannot satisfy. It fails on `main` as well and is addressed in #97.
