### PR TITLE
fix(skills): stop a trailing backslash escaping the Windows arg quoting

### DIFF
--- a/packages/jinn/src/cli/__tests__/skills-shell-security.test.ts
+++ b/packages/jinn/src/cli/__tests__/skills-shell-security.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const spawnSync = vi.hoisted(() => vi.fn(() => ({ status: 0 })));
 
@@ -8,19 +8,12 @@ vi.mock("node:child_process", () => ({
 
 import { quoteWindowsArg, runNpxSkills } from "../skills.js";
 
-// The two platforms defend this differently and the difference is the point:
-// POSIX passes argv with no shell at all, while Windows cannot spawn npx.cmd
-// without a shell (EINVAL since Node 18.20.2, the BatBadBut mitigation) and so
-// relies on rejecting metacharacters plus correct quoting. Asserting the POSIX
-// contract on both hid the Windows path from review entirely.
-const onWindows = process.platform === "win32";
-
-beforeEach(() => {
-  spawnSync.mockClear();
-});
-
 describe("skills CLI process spawning", () => {
-  it.skipIf(onWindows)("passes user-controlled skill args as argv with shell disabled", () => {
+  // The POSIX contract. The Windows branch cannot pass argv with the shell
+  // disabled — npx.cmd is unspawnable that way — and lives in
+  // skills-windows-spawn.test.ts, which stubs process.platform so those cases
+  // execute on CI instead of skipping on a non-Windows runner.
+  it.skipIf(process.platform === "win32")("passes user-controlled skill args as argv with shell disabled", () => {
     runNpxSkills(["add", "owner/repo; touch /tmp/pwned", "-g", "-y"], "pipe");
 
     expect(spawnSync).toHaveBeenCalledWith(
@@ -29,43 +22,40 @@ describe("skills CLI process spawning", () => {
       { stdio: "pipe", shell: false },
     );
   });
-
-  it.skipIf(!onWindows)("quotes every argument and never reaches a shell unquoted", () => {
-    const status = runNpxSkills(["add", "owner/repo; touch /tmp/pwned", "-g", "-y"], "pipe");
-
-    expect(status).toEqual({ status: 0 });
-    expect(spawnSync).toHaveBeenCalledWith(
-      "npx",
-      ['"skills"', '"add"', '"owner/repo; touch /tmp/pwned"', '"-g"', '"-y"'],
-      { stdio: "pipe", shell: true },
-    );
-  });
-
-  it.skipIf(!onWindows)("refuses arguments carrying cmd.exe metacharacters instead of quoting them", () => {
-    for (const payload of ['a" & calc & "b', "x | whoami", "x & calc", "x > out", "x ^ y", "%PATH%", "back`tick", "line\nbreak"]) {
-      spawnSync.mockClear();
-      expect(runNpxSkills(["add", payload], "pipe")).toEqual({ status: 1 });
-      expect(spawnSync).not.toHaveBeenCalled();
-    }
-  });
 });
 
+/**
+ * Windows parses a command line with MSVCRT rules: a run of backslashes is
+ * literal except immediately before a quote, where 2n backslashes yield n
+ * literal backslashes and the quote still closes the string.
+ *
+ * Platform-independent, so these run everywhere.
+ */
 describe("quoteWindowsArg", () => {
-  // Windows parses a command line with MSVCRT rules: backslashes before a quote
-  // escape it. Naive `"${arg}"` therefore let a trailing backslash consume the
-  // closing quote and smuggle a literal " into the child's argv — the exact
-  // character the metacharacter filter rejects.
-  it("doubles a trailing backslash run so the closing quote survives", () => {
+  it("doubles an odd trailing backslash run so the closing quote survives", () => {
     expect(quoteWindowsArg("trailing\\")).toBe('"trailing\\\\"');
+    expect(quoteWindowsArg("three\\\\\\")).toBe('"three\\\\\\\\\\\\"');
+  });
+
+  it("doubles an even trailing run too, which would otherwise be silently halved", () => {
     expect(quoteWindowsArg("two\\\\")).toBe('"two\\\\\\\\"');
+    expect(quoteWindowsArg("four\\\\\\\\")).toBe('"four\\\\\\\\\\\\\\\\"');
+  });
+
+  it("handles a directory argument ending in a separator", () => {
+    // The realistic input: `jinn skills add C:\skills\mine\`.
+    expect(quoteWindowsArg("C:\\path\\")).toBe('"C:\\path\\\\"');
+    expect(quoteWindowsArg("C:\\skills\\mine\\")).toBe('"C:\\skills\\mine\\\\"');
   });
 
   it("leaves interior backslashes alone so Windows paths stay intact", () => {
     expect(quoteWindowsArg("C:\\path\\to\\skill")).toBe('"C:\\path\\to\\skill"');
+    expect(quoteWindowsArg("a\\b\\c")).toBe('"a\\b\\c"');
   });
 
   it("quotes ordinary arguments without altering them", () => {
     expect(quoteWindowsArg("owner/repo")).toBe('"owner/repo"');
     expect(quoteWindowsArg("owner/repo; touch /tmp/pwned")).toBe('"owner/repo; touch /tmp/pwned"');
+    expect(quoteWindowsArg("")).toBe('""');
   });
 });

--- a/packages/jinn/src/cli/__tests__/skills-shell-security.test.ts
+++ b/packages/jinn/src/cli/__tests__/skills-shell-security.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSync = vi.hoisted(() => vi.fn(() => ({ status: 0 })));
 
@@ -6,10 +6,21 @@ vi.mock("node:child_process", () => ({
   spawnSync,
 }));
 
-import { runNpxSkills } from "../skills.js";
+import { quoteWindowsArg, runNpxSkills } from "../skills.js";
+
+// The two platforms defend this differently and the difference is the point:
+// POSIX passes argv with no shell at all, while Windows cannot spawn npx.cmd
+// without a shell (EINVAL since Node 18.20.2, the BatBadBut mitigation) and so
+// relies on rejecting metacharacters plus correct quoting. Asserting the POSIX
+// contract on both hid the Windows path from review entirely.
+const onWindows = process.platform === "win32";
+
+beforeEach(() => {
+  spawnSync.mockClear();
+});
 
 describe("skills CLI process spawning", () => {
-  it("passes user-controlled skill args as argv with shell disabled", () => {
+  it.skipIf(onWindows)("passes user-controlled skill args as argv with shell disabled", () => {
     runNpxSkills(["add", "owner/repo; touch /tmp/pwned", "-g", "-y"], "pipe");
 
     expect(spawnSync).toHaveBeenCalledWith(
@@ -17,5 +28,44 @@ describe("skills CLI process spawning", () => {
       ["skills", "add", "owner/repo; touch /tmp/pwned", "-g", "-y"],
       { stdio: "pipe", shell: false },
     );
+  });
+
+  it.skipIf(!onWindows)("quotes every argument and never reaches a shell unquoted", () => {
+    const status = runNpxSkills(["add", "owner/repo; touch /tmp/pwned", "-g", "-y"], "pipe");
+
+    expect(status).toEqual({ status: 0 });
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npx",
+      ['"skills"', '"add"', '"owner/repo; touch /tmp/pwned"', '"-g"', '"-y"'],
+      { stdio: "pipe", shell: true },
+    );
+  });
+
+  it.skipIf(!onWindows)("refuses arguments carrying cmd.exe metacharacters instead of quoting them", () => {
+    for (const payload of ['a" & calc & "b', "x | whoami", "x & calc", "x > out", "x ^ y", "%PATH%", "back`tick", "line\nbreak"]) {
+      spawnSync.mockClear();
+      expect(runNpxSkills(["add", payload], "pipe")).toEqual({ status: 1 });
+      expect(spawnSync).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe("quoteWindowsArg", () => {
+  // Windows parses a command line with MSVCRT rules: backslashes before a quote
+  // escape it. Naive `"${arg}"` therefore let a trailing backslash consume the
+  // closing quote and smuggle a literal " into the child's argv — the exact
+  // character the metacharacter filter rejects.
+  it("doubles a trailing backslash run so the closing quote survives", () => {
+    expect(quoteWindowsArg("trailing\\")).toBe('"trailing\\\\"');
+    expect(quoteWindowsArg("two\\\\")).toBe('"two\\\\\\\\"');
+  });
+
+  it("leaves interior backslashes alone so Windows paths stay intact", () => {
+    expect(quoteWindowsArg("C:\\path\\to\\skill")).toBe('"C:\\path\\to\\skill"');
+  });
+
+  it("quotes ordinary arguments without altering them", () => {
+    expect(quoteWindowsArg("owner/repo")).toBe('"owner/repo"');
+    expect(quoteWindowsArg("owner/repo; touch /tmp/pwned")).toBe('"owner/repo; touch /tmp/pwned"');
   });
 });

--- a/packages/jinn/src/cli/__tests__/skills-windows-spawn.test.ts
+++ b/packages/jinn/src/cli/__tests__/skills-windows-spawn.test.ts
@@ -45,4 +45,34 @@ describe("runNpxSkills on Windows", () => {
     expect(spawnSync).not.toHaveBeenCalled();
     err.mockRestore();
   });
+
+  // Windows parses a command line with MSVCRT rules, where backslashes before a
+  // quote escape it. A bare `"${arg}"` therefore let an argument ending in a
+  // backslash consume its own closing quote: `dir\` reached the child as `dir"`,
+  // taking the following argument with it. Directory arguments end in a
+  // backslash routinely, so this is ordinary input, not a crafted one.
+  it("doubles a trailing backslash run so the argument cannot swallow the next", () => {
+    setPlatform("win32");
+
+    const result = runNpxSkills(["add", "C:\\skills\\mine\\", "-g"], "pipe");
+
+    expect(result.status).toBe(0);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npx",
+      ['"skills"', '"add"', '"C:\\skills\\mine\\\\"', '"-g"'],
+      { stdio: "pipe", shell: true },
+    );
+  });
+
+  it("leaves interior backslashes untouched so ordinary paths are unchanged", () => {
+    setPlatform("win32");
+
+    runNpxSkills(["add", "C:\\path\\to\\skill"], "pipe");
+
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npx",
+      ['"skills"', '"add"', '"C:\\path\\to\\skill"'],
+      { stdio: "pipe", shell: true },
+    );
+  });
 });

--- a/packages/jinn/src/cli/skills.ts
+++ b/packages/jinn/src/cli/skills.ts
@@ -121,6 +121,25 @@ export function findExistingSkill(name: string): { name: string; dir: string } |
 /** Characters that could break out of a cmd.exe command line. */
 const WINDOWS_UNSAFE_ARG = /["&|<>^%`\r\n]/;
 
+/**
+ * Quote one argument for a Windows command line.
+ *
+ * Windows programs parse their own command line with MSVCRT rules, where a run
+ * of backslashes immediately before a quote escapes it. Wrapping bare in
+ * `"${arg}"` therefore breaks for any argument ending in a backslash: `trailing\`
+ * became `"trailing\"`, the closing quote was consumed, and the child received
+ * `trailing"` — smuggling in exactly the quote character WINDOWS_UNSAFE_ARG
+ * exists to reject, and letting one argument swallow the next.
+ *
+ * A run of 2n backslashes before the closing quote yields n literal
+ * backslashes and still terminates the string, so double only that final run.
+ * Interior backslashes are literal and must not be touched, or every Windows
+ * path argument would be mangled.
+ */
+export function quoteWindowsArg(arg: string): string {
+  return `"${arg.replace(/(\\+)$/, "$1$1")}"`;
+}
+
 export function runNpxSkills(args: string[], stdio: "inherit" | "pipe" = "inherit"): { status: number | null } {
   if (process.platform === "win32") {
     // Windows ships npx as npx.cmd, which Node refuses to spawn without a shell
@@ -131,7 +150,7 @@ export function runNpxSkills(args: string[], stdio: "inherit" | "pipe" = "inheri
       console.error(`${RED}Refusing to run: argument contains shell metacharacters: ${unsafe}${RESET}`);
       return { status: 1 };
     }
-    return spawnSync("npx", ["skills", ...args].map((a) => `"${a}"`), { stdio, shell: true });
+    return spawnSync("npx", ["skills", ...args].map(quoteWindowsArg), { stdio, shell: true });
   }
   return spawnSync("npx", ["skills", ...args], {
     stdio,


### PR DESCRIPTION
An argument ending in a backslash escapes its own closing quote on the Windows `npx skills` path, so it reaches the child with a literal `"` appended and swallows the argument after it. Directory arguments end in a backslash routinely, so this is ordinary input rather than a crafted one.

---

`npx` ships as `npx.cmd`, which Node refuses to spawn without a shell (EINVAL since 18.20.2, the BatBadBut mitigation). The Windows path therefore runs through `cmd` and defends itself by rejecting arguments containing shell metacharacters, then wrapping each remaining argument in quotes.

The wrapping was a bare `` `"${arg}"` ``. Windows programs parse their command line with MSVCRT rules, where a run of backslashes immediately before a quote *escapes* it, so:

```
in "trailing\"  ->  quoted "trailing\"  ->  child argv: ["trailing\"" ...]
```

Even runs are corrupted differently — silently halved rather than unbalanced. The fix is the MSVCRT rule: double only the *final* run of backslashes, which yields the intended literal backslashes and still terminates the string. Interior backslashes are untouched, so `C:\path\to\skill` is unaffected. Verified against real child processes before and after.

**On severity — corrected from my original description.** This is argument corruption and defence-in-depth, not a working injection. Every argument still passes `WINDOWS_UNSAFE_ARG`, so no `&`, `|`, `<`, `>`, `^`, `%` or newline can reach the command line even when the quoting is unbalanced; the injected character is a `"` and nothing more. Worth fixing because `jinn skills` is invoked with LLM- and web-sourced package names, and because the even-run halving would produce baffling bug reports — but it does not reach command execution.

**Also corrected: the Windows branch was not uncovered.** `skills-windows-spawn.test.ts` has covered it since `b0783896`, the same commit that added the Windows handling, by stubbing `process.platform`. My original description was wrong about that.

**Test placement fixed.** My two new spawn assertions were gated with `it.skipIf` against the *real* platform, and CI is `ubuntu-latest`, so they never executed — the regression was unguarded by the very tests meant to guard it. They now live in `skills-windows-spawn.test.ts` alongside the existing Windows cases, where the stubbed platform means they run on Linux. The `quoteWindowsArg` unit tests are platform-independent and gained an odd run of three plus the realistic `C:\skills\mine\` directory case; previously only runs of one and two were covered.

Confirmed locally: 9 of the 10 assertions across the two files execute, the single skip being the POSIX-argv contract, which runs on CI.
