### PR TITLE
fix(windows): make the repo buildable, and narrow tests to what each platform can express

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,38 @@
+# Line endings are load-bearing in this repository.
+#
+# Shipped migration payloads under packages/jinn/template/migrations are
+# content-addressed: each manifest stores a sha256 of the payload bytes, and the
+# migration snapshot compares payloads byte-for-byte against the user's instance
+# files. A contributor with core.autocrlf=true (the Git for Windows default) got
+# CRLF working-tree copies, so every one of those hashes mismatched and the
+# migration service failed to validate its own shipped bundle.
+#
+# Normalize to LF in the repository and in the working tree on every platform.
+* text=auto eol=lf
+
+# Windows script hosts require CRLF.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Never touch binary payloads.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.webp binary
+*.ico  binary
+*.svg  text eol=lf
+*.mp4  binary
+*.webm binary
+*.mov  binary
+*.woff  binary
+*.woff2 binary
+*.ttf  binary
+*.otf  binary
+*.node binary
+*.wasm binary
+*.db   binary
+*.sqlite binary
+*.gz   binary
+*.zip  binary

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "turbo run test --concurrency=1",
     "coverage": "turbo run coverage",
     "test:e2e": "playwright test",
-    "clean": "rm -rf .turbo node_modules/.cache && turbo clean",
+    "clean": "node -e \"const fs=require('fs');for(const d of ['.turbo','node_modules/.cache'])fs.rmSync(d,{recursive:true,force:true})\" && turbo clean",
     "jinn": "node packages/jinn/dist/bin/jinn.js",
     "setup": "pnpm build && node packages/jinn/dist/bin/jinn.js setup",
     "setup:force": "pnpm build && node packages/jinn/dist/bin/jinn.js setup --force",

--- a/packages/jinn/package.json
+++ b/packages/jinn/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "postinstall": "node scripts/fix-node-pty-permissions.mjs",
-    "build": "rm -rf dist/bin dist/src && tsc -p tsconfig.build.json && mkdir -p dist/src/talk && (cp src/talk/*.md src/talk/*.py dist/src/talk/ 2>/dev/null || true)",
+    "build": "node scripts/build.mjs",
     "dev": "tsc && (tsc --watch &) && node --watch-path=dist dist/bin/jinn.js start",
     "typecheck": "tsc --noEmit",
     "test": "pnpm build && vitest run",
@@ -28,7 +28,7 @@
     "test:watch": "vitest",
     "migration:generate": "node scripts/instance-migration-bundle.mjs generate",
     "migration:check": "node scripts/instance-migration-bundle.mjs check",
-    "clean": "rm -rf dist"
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\""
   },
   "dependencies": {
     "@slack/bolt": "^4.7.3",

--- a/packages/jinn/scripts/build.mjs
+++ b/packages/jinn/scripts/build.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform build for jinn-cli.
+ *
+ * This was a shell one-liner (`rm -rf … && tsc && mkdir -p … && cp …`). npm and
+ * pnpm run package scripts through the platform shell, which on Windows is cmd —
+ * where none of those commands exist, so `pnpm build` failed with "The syntax of
+ * the command is incorrect" and the repo could not be built there at all. Node's
+ * own fs APIs do the same work on every platform.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const dist = path.join(packageRoot, "dist");
+const require = createRequire(import.meta.url);
+
+/** Run TypeScript's own entry with the current Node. Resolving the JS entry
+ *  instead of the `tsc` shim keeps this shell-free, which avoids both the
+ *  Windows .CMD resolution problem and shell argument concatenation. */
+function runTsc(args) {
+  const tsc = require.resolve("typescript/bin/tsc");
+  const result = spawnSync(process.execPath, [tsc, ...args], { cwd: packageRoot, stdio: "inherit" });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+// 1. Clear only the compiled output. dist/web is produced separately by
+//    scripts/sync-web-dist.mjs and must survive a package rebuild.
+for (const dir of ["bin", "src"]) {
+  fs.rmSync(path.join(dist, dir), { recursive: true, force: true });
+}
+
+// 2. Compile.
+runTsc(["-p", "tsconfig.build.json"]);
+
+// 3. Copy the Talk assets tsc does not emit (Markdown + Python live beside the
+//    TypeScript). Missing files are not an error: they are optional extras.
+const talkSource = path.join(packageRoot, "src", "talk");
+const talkTarget = path.join(dist, "src", "talk");
+fs.mkdirSync(talkTarget, { recursive: true });
+let copied = 0;
+try {
+  for (const entry of fs.readdirSync(talkSource)) {
+    if (!/\.(md|py)$/i.test(entry)) continue;
+    fs.copyFileSync(path.join(talkSource, entry), path.join(talkTarget, entry));
+    copied += 1;
+  }
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+console.log(`build: compiled to dist/, copied ${copied} talk asset(s)`);

--- a/packages/jinn/src/cli/__tests__/instance-migration-bundle.test.ts
+++ b/packages/jinn/src/cli/__tests__/instance-migration-bundle.test.ts
@@ -24,6 +24,12 @@ function fixture(): string {
   git(root, "init", "-q")
   git(root, "config", "user.name", "Test Operator")
   git(root, "config", "user.email", "test@example.invalid")
+  // A throwaway fixture must not inherit the developer's line-ending config.
+  // With core.autocrlf=true (the Git for Windows default) git prints "LF will be
+  // replaced by CRLF" advisories to stderr, and one case below asserts stderr is
+  // empty — so the suite failed on Windows for a property it never meant to test.
+  git(root, "config", "core.autocrlf", "false")
+  git(root, "config", "core.eol", "lf")
   write(root, "CLAUDE.md", "base doctrine\n")
   write(root, "skills/old/SKILL.md", "renamed body\n")
   write(root, "removed.txt", "remove me\n")

--- a/packages/jinn/src/cli/__tests__/pair.test.ts
+++ b/packages/jinn/src/cli/__tests__/pair.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 import {
   formatPairedDevices,
   formatPairingInstructions,
@@ -35,7 +36,7 @@ describe("pair CLI helpers", () => {
       expect(url).toBe("http://127.0.0.1:7777/api/auth/pairing-codes");
       expect(JSON.parse(String(init?.body))).toEqual({ challengeId });
       expect(fs.readFileSync(challengePath, "utf-8")).toBe(nonce);
-      expect(fs.statSync(challengePath).mode & 0o777).toBe(0o600);
+      expectPosixMode(fs.statSync(challengePath), 0o600);
       return new Response(JSON.stringify({
         status: "ok",
         code: "ABCD-EFGH-JKLM",

--- a/packages/jinn/src/engines/__tests__/codex-mcp-args.test.ts
+++ b/packages/jinn/src/engines/__tests__/codex-mcp-args.test.ts
@@ -12,6 +12,7 @@ import {
   realCodexHome,
 } from "../codex.js";
 import type { ResolvedMcpConfig, EngineRunOpts } from "../../shared/types.js";
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 
 const CAPABILITY = "cap-SUPER-SECRET-do-not-leak-123";
 
@@ -185,12 +186,11 @@ describe("prepareCodexSessionHome", () => {
     // Deterministic path — same session id → same dir every turn.
     expect(home!.home).toBe(path.join(baseDir, "sess-1"));
 
-    const dirMode = fs.statSync(home!.home).mode & 0o777;
-    expect(dirMode).toBe(0o700);
+    expectPosixMode(home!.home, 0o700);
 
     const cfgPath = path.join(home!.home, "config.toml");
     expect(fs.existsSync(cfgPath)).toBe(true);
-    expect(fs.statSync(cfgPath).mode & 0o777).toBe(0o600);
+    expectPosixMode(fs.statSync(cfgPath), 0o600);
 
     const cfg = fs.readFileSync(cfgPath, "utf8");
     // Operator base settings preserved…

--- a/packages/jinn/src/engines/__tests__/codex.test.ts
+++ b/packages/jinn/src/engines/__tests__/codex.test.ts
@@ -82,6 +82,7 @@ vi.mock("node:child_process", () => ({
 
 import { CodexEngine, type CodexEngineOpts } from "../codex.js";
 import type { StreamDelta, EngineResult } from "../../shared/types.js";
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 
 const flush = () => new Promise((r) => setTimeout(r, 0));
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -387,7 +388,7 @@ describe("CodexEngine — systemPrompt / developer_instructions injection", () =
 
       // config.toml is 0600, carries the capability, and merged the operator base.
       const cfgPath = path.join(expectedHome, "config.toml");
-      expect(fs.statSync(cfgPath).mode & 0o777).toBe(0o600);
+      expectPosixMode(fs.statSync(cfgPath), 0o600);
       const cfg = fs.readFileSync(cfgPath, "utf-8");
       expect(cfg).toContain(`JINN_SESSION_CAPABILITY = ${JSON.stringify(capability)}`);
       expect(cfg).toContain('approval_policy = "never"'); // operator base preserved

--- a/packages/jinn/src/engines/grok-interactive.ts
+++ b/packages/jinn/src/engines/grok-interactive.ts
@@ -57,23 +57,29 @@ function walkFiles(dir: string, out: string[] = []): string[] {
   let entries: fs.Dirent[];
   try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return out; }
   for (const entry of entries) {
-    const p = `${dir}/${entry.name}`;
+    // path.join, not `${dir}/${name}`: the latter produced mixed separators on
+    // Windows ("C:\...\root/session-x/updates.jsonl"). Windows opens such a path
+    // fine, so reads worked, but the string never equalled a path.join-built one
+    // — so equality checks, dedupe by path, and path.relative all misbehaved.
+    const p = path.join(dir, entry.name);
     if (entry.isDirectory()) walkFiles(p, out);
     else if (entry.isFile()) out.push(p);
   }
   return out;
 }
 
+/** Transcript file names Grok writes, most authoritative first. Matched on the
+ *  basename so the separator never enters the comparison. */
+const GROK_TRANSCRIPT_NAMES = ["updates.jsonl", "chat_history.jsonl", "events.jsonl"];
+
 function isGrokTranscriptFile(file: string): boolean {
-  return file.endsWith("/updates.jsonl") || file.endsWith("/chat_history.jsonl") || file.endsWith("/events.jsonl");
+  return GROK_TRANSCRIPT_NAMES.includes(path.basename(file));
 }
 
 function sortGrokTranscriptFiles(files: string[]): string[] {
   const rank = (file: string) => {
-    if (file.endsWith("/updates.jsonl")) return 0;
-    if (file.endsWith("/chat_history.jsonl")) return 1;
-    if (file.endsWith("/events.jsonl")) return 2;
-    return 3;
+    const index = GROK_TRANSCRIPT_NAMES.indexOf(path.basename(file));
+    return index === -1 ? GROK_TRANSCRIPT_NAMES.length : index;
   };
   return files.filter(isGrokTranscriptFile).sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
 }

--- a/packages/jinn/src/gateway/__tests__/auth-security.test.ts
+++ b/packages/jinn/src/gateway/__tests__/auth-security.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 import {
   authCookieHeaders,
   authCookieName,
@@ -42,8 +43,7 @@ describe("gateway auth", () => {
     expect(first.length).toBeGreaterThanOrEqual(32);
 
     const tokenFile = path.join(home, "gateway.json");
-    const mode = fs.statSync(tokenFile).mode & 0o777;
-    expect(mode).toBe(0o600);
+    expectPosixMode(tokenFile, 0o600);
     expect(JSON.parse(fs.readFileSync(tokenFile, "utf-8")).token).toBe(first);
   });
 

--- a/packages/jinn/src/instances/create.test.ts
+++ b/packages/jinn/src/instances/create.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadInstances, saveInstances } from "./directory.js";
+import { expectPosixMode } from "../shared/test-support/posix-mode.js";
 import {
   createInstance,
   normalizeWorkspaceName,
@@ -38,9 +39,13 @@ describe("workspace naming", () => {
 
   it("resolves legacy and prefixed selectors through registered homes", () => {
     const instances = [{ id: "id", name: "jinn-john", displayName: "John", port: 7788, home: "/custom/john", createdAt: "now" }];
+    // A registered home is returned verbatim, so it stays exactly as stored.
     expect(resolveInstanceHome("john", instances, "/home/operator")).toBe("/custom/john");
     expect(resolveInstanceHome("jinn-john", instances, "/home/operator")).toBe("/custom/john");
-    expect(resolveInstanceHome("newco", [], "/home/operator")).toBe("/home/operator/.jinn-newco");
+    // An unregistered selector is derived with path.join, which correctly yields
+    // native separators — backslashes on Windows. Build the expectation the same
+    // way rather than hard-coding a POSIX path.
+    expect(resolveInstanceHome("newco", [], "/home/operator")).toBe(path.join("/home/operator", ".jinn-newco"));
   });
 });
 
@@ -100,7 +105,7 @@ describe("workspace creation", () => {
     const gatewayPath = path.join(root, ".jinn-john", "gateway.json");
     const gateway = JSON.parse(fs.readFileSync(gatewayPath, "utf8")) as { token?: string };
     expect(gateway.token?.length).toBeGreaterThanOrEqual(32);
-    expect(fs.statSync(gatewayPath).mode & 0o777).toBe(0o600);
+    expectPosixMode(fs.statSync(gatewayPath), 0o600);
     expect(loadInstances({ registryPath, legacyRegistryPath })).toHaveLength(1);
   });
 

--- a/packages/jinn/src/mcp/__tests__/attachment.test.ts
+++ b/packages/jinn/src/mcp/__tests__/attachment.test.ts
@@ -293,9 +293,18 @@ describe("readGatewayJsonToken", () => {
     fs.writeFileSync(path.join(instanceHome, "gateway.json"), JSON.stringify({ token: instanceToken }));
     fs.writeFileSync(path.join(wrongHome, "gateway.json"), JSON.stringify({ token: wrongToken }));
 
-    const envBackup = { HOME: process.env.HOME, JINN_HOME: process.env.JINN_HOME, JINN_INSTANCE: process.env.JINN_INSTANCE };
+    const envBackup = {
+      HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
+      JINN_HOME: process.env.JINN_HOME,
+      JINN_INSTANCE: process.env.JINN_INSTANCE,
+    };
     try {
-      process.env.HOME = fakeHomeRoot; // os.homedir() follows $HOME on POSIX
+      // os.homedir() reads $HOME on POSIX and %USERPROFILE% on Windows. Setting
+      // only HOME left the real home in play on Windows, so the probe read the
+      // operator's actual ~/.jinn instead of the fixture. Redirect both.
+      process.env.HOME = fakeHomeRoot;
+      process.env.USERPROFILE = fakeHomeRoot;
       delete process.env.JINN_HOME;
       process.env.JINN_INSTANCE = "qafoo";
       vi.resetModules();

--- a/packages/jinn/src/mcp/__tests__/engine-wiring.test.ts
+++ b/packages/jinn/src/mcp/__tests__/engine-wiring.test.ts
@@ -40,6 +40,7 @@ import {
   ANTIGRAVITY_JINN_MCP_MARKER,
 } from "../../engines/antigravity-mcp.js";
 import type { McpGlobalConfig } from "../../shared/types.js";
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 
 const GATEWAY_URL = "http://127.0.0.1:56789";
 const TOKEN = "wiring-test-secret-token";
@@ -74,7 +75,7 @@ describe("per-engine jinn-server wiring (GRS-018 seam for GRS-017 default-on)", 
     const resolved = resolveMcpServers(ON, undefined);
     const p = writeMcpConfigFile(resolved, "wiring-claude");
     try {
-      expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+      expectPosixMode(fs.statSync(p), 0o600);
       const onDisk = JSON.parse(fs.readFileSync(p, "utf-8"));
       expect(onDisk.mcpServers.jinn.command).toBeTruthy();
       // GRS-018 unified builtin env: URL + JINN_HOME (token-fallback hint) —
@@ -143,7 +144,7 @@ describe("per-engine jinn-server wiring (GRS-018 seam for GRS-017 default-on)", 
       const capability = capabilityOf(resolved);
       const p = writeMcpConfigFile(resolved, "wiring-claude-sid");
       try {
-        expect(fs.statSync(p).mode & 0o777).toBe(0o600);
+        expectPosixMode(fs.statSync(p), 0o600);
         expect(path.basename(path.dirname(p))).toBe("wiring-claude-sid");
         const onDisk = JSON.parse(fs.readFileSync(p, "utf-8"));
         expect(onDisk.mcpServers.jinn.env.JINN_SESSION_ID).toBe(SID);
@@ -196,7 +197,7 @@ describe("per-engine jinn-server wiring (GRS-018 seam for GRS-017 default-on)", 
       expect(home).toBeDefined();
       try {
         const cfgPath = path.join(home!.home, "config.toml");
-        expect(fs.statSync(cfgPath).mode & 0o777).toBe(0o600);
+        expectPosixMode(fs.statSync(cfgPath), 0o600);
         const toml = fs.readFileSync(cfgPath, "utf-8");
         expect(toml).toContain(`JINN_GATEWAY_URL = ${JSON.stringify(GATEWAY_URL)}`);
         expect(toml).toContain(`JINN_SESSION_ID = ${JSON.stringify(SID)}`);
@@ -271,7 +272,7 @@ describe("per-engine jinn-server wiring (GRS-018 seam for GRS-017 default-on)", 
       expect(handle.attached).toBe(true);
       try {
         if (!handle.attached) throw new Error("expected pi MCP extension to attach");
-        expect(fs.statSync(handle.extensionPath).mode & 0o777).toBe(0o600);
+        expectPosixMode(fs.statSync(handle.extensionPath), 0o600);
         const source = fs.readFileSync(handle.extensionPath, "utf-8");
         expect(source).toContain("registerTool");
         expect(source).toContain("buildTools");

--- a/packages/jinn/src/mcp/__tests__/identity-restart.test.ts
+++ b/packages/jinn/src/mcp/__tests__/identity-restart.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 
 const KEY_RELATIVE_PATH = path.join("secrets", "mcp-session-capability.key");
 
@@ -96,7 +97,7 @@ describe("restart-stable MCP session capability authority", () => {
     expect(capability).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(capability).not.toContain(sessionId);
 
-    expect(fs.statSync(keyFile).mode & 0o777).toBe(0o600);
+    expectPosixMode(fs.statSync(keyFile), 0o600);
 
     const otherHome = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-mcp-capability-other-"));
     try {

--- a/packages/jinn/src/migrations/__tests__/snapshot.test.ts
+++ b/packages/jinn/src/migrations/__tests__/snapshot.test.ts
@@ -5,6 +5,7 @@ import path from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 import { createMigrationSnapshot, verifyMigrationSnapshot } from "../snapshot.js"
 import { migrationMaterializationInputsSha256, type MigrationMaterializationPlan } from "../service.js"
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 
 const roots: string[] = []
 const hash = (value: Buffer | string) => crypto.createHash("sha256").update(value).digest("hex")
@@ -97,7 +98,7 @@ describe("migration snapshots", () => {
     expect(fs.readFileSync(target, "utf8")).toBe("# My Mixed CASE Portal\nRun my-mixed-case-portal now.\nUnknown {{futureValue}}.\n")
     expect(fs.readFileSync(json, "utf8")).toBe(genericJson)
     expect(fs.readFileSync(path.join(snapshot.path, "materialized/legacy/0.9.0/MIGRATION.md"), "utf8")).toBe("# Legacy My Mixed CASE Portal\n")
-    expect(fs.statSync(base).mode & 0o777).toBe(0o444)
+    expectPosixMode(fs.statSync(base), 0o444)
     expect(fs.readFileSync(path.join(snapshot.path, "docs/overview.md"), "utf8")).toBe("# My Mixed CASE Portal\nGenuine user edit.\n")
     expect(fs.readFileSync(path.join(sources, "base/docs/overview.md"), "utf8")).toBe(genericBase)
     const audit = JSON.parse(fs.readFileSync(path.join(snapshot.path, "materialization.json"), "utf8"))
@@ -133,7 +134,7 @@ describe("migration snapshots", () => {
     expect(verifyMigrationSnapshot(options)).toBe(true)
     expect(fs.readFileSync(path.join(first.path, "skills/stock/SKILL.md"), "utf8")).toBe("custom skill\n")
     expect(fs.lstatSync(path.join(first.path, "AGENTS.md")).isSymbolicLink()).toBe(true)
-    expect(fs.statSync(path.join(first.path, "CLAUDE.md")).mode & 0o777).toBe(0o640)
+    expectPosixMode(fs.statSync(path.join(first.path, "CLAUDE.md")), 0o640)
     expect(fs.existsSync(path.join(first.path, "secrets"))).toBe(false)
     expect(JSON.parse(fs.readFileSync(path.join(first.path, "snapshot.json"), "utf8"))).toMatchObject({
       migrationKey: options.migrationKey,

--- a/packages/jinn/src/shared/test-support/posix-mode.ts
+++ b/packages/jinn/src/shared/test-support/posix-mode.ts
@@ -1,0 +1,23 @@
+import fs from "node:fs";
+import { expect } from "vitest";
+
+/** Windows has no POSIX permission bits. fs.chmod there only toggles the
+ *  read-only attribute, so a file written with mode 0o600 reports 0o666 and a
+ *  directory reports 0o777 — every owner-only assertion fails for a reason the
+ *  code cannot fix.
+ *
+ *  IMPORTANT: this is a gap in the platform, not only in the tests. Files Jinn
+ *  intends to be owner-only (gateway tokens, pairing challenges, per-session MCP
+ *  configs carrying capabilities, instance keys) are NOT restricted on Windows;
+ *  achieving that needs ACLs, which Jinn does not set today. Skipping the
+ *  assertion keeps the suite honest on Windows without implying the property
+ *  holds there. */
+export const POSIX_MODES_SUPPORTED = process.platform !== "win32";
+
+/** Assert permission bits, where the platform can express them. Accepts a path
+ *  or an already-taken Stats, so call sites read the way they did before. */
+export function expectPosixMode(target: string | fs.Stats, expected: number): void {
+  if (!POSIX_MODES_SUPPORTED) return;
+  const stats = typeof target === "string" ? fs.statSync(target) : target;
+  expect(stats.mode & 0o777).toBe(expected);
+}

--- a/packages/jinn/src/workflows/__tests__/recovery-gate.test.ts
+++ b/packages/jinn/src/workflows/__tests__/recovery-gate.test.ts
@@ -1,3 +1,4 @@
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 import {
   chmodSync,
   existsSync,
@@ -127,9 +128,9 @@ describe('workflow recovery gate', () => {
       db = migrations.openWorkflowDatabase(paths.WORKFLOWS_DB_PATH);
       for (const file of [paths.WORKFLOWS_DB_PATH, `${paths.WORKFLOWS_DB_PATH}-wal`, `${paths.WORKFLOWS_DB_PATH}-shm`]) {
         expect(existsSync(file)).toBe(true);
-        expect(statSync(file).mode & 0o777).toBe(0o600);
+        expectPosixMode(statSync(file), 0o600);
       }
-      expect(statSync(paths.WORKFLOWS_DIR).mode & 0o777).toBe(0o700);
+      expectPosixMode(statSync(paths.WORKFLOWS_DIR), 0o700);
     } finally {
       db?.close();
       process.umask(previousUmask);
@@ -149,7 +150,7 @@ describe('workflow recovery gate', () => {
 
     expectDefaultOpenToFailClosed();
 
-    expect(statSync(target).mode & 0o777).toBe(0o755);
+    expectPosixMode(statSync(target), 0o755);
     expect(readFileSync(sentinel)).toEqual(before);
   });
 
@@ -165,7 +166,7 @@ describe('workflow recovery gate', () => {
 
     expectDefaultOpenToFailClosed();
 
-    expect(statSync(target).mode & 0o777).toBe(0o644);
+    expectPosixMode(statSync(target), 0o644);
     expect(readFileSync(target)).toEqual(before);
   });
 
@@ -186,7 +187,7 @@ describe('workflow recovery gate', () => {
     expectDefaultOpenToFailClosed();
 
     expect(readFileSync(paths.WORKFLOWS_DB_PATH)).toEqual(databaseBefore);
-    expect(statSync(target).mode & 0o777).toBe(0o644);
+    expectPosixMode(statSync(target), 0o644);
     expect(readFileSync(target)).toEqual(targetBefore);
   });
 });

--- a/packages/jinn/src/workflows/__tests__/repository-migrations.test.ts
+++ b/packages/jinn/src/workflows/__tests__/repository-migrations.test.ts
@@ -1,3 +1,4 @@
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
 import { createHash } from 'node:crypto';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -304,8 +305,8 @@ describe('workflow database paths and connection', () => {
     }
     withWorkflowDatabase(target, (db) => expect(db.open).toBe(true));
     if (process.platform !== 'win32') {
-      expect(statSync(ownerParent).mode & 0o777).toBe(0o755);
-      expect(statSync(target).mode & 0o777).toBe(0o640);
+      expectPosixMode(statSync(ownerParent), 0o755);
+      expectPosixMode(statSync(target), 0o640);
     }
   });
 

--- a/packages/jinn/tsconfig.build.json
+++ b/packages/jinn/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["**/__tests__/**", "**/*.test.ts"]
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/test-support/**"]
 }

--- a/packages/jinn/vitest.config.ts
+++ b/packages/jinn/vitest.config.ts
@@ -13,6 +13,18 @@ import { defineConfig } from 'vitest/config'
 // Local runs keep full parallelism and the snappy default timeouts.
 const isCI = !!process.env.CI
 
+// Windows needs the same headroom, for a different reason: it has no fork(), so
+// every pool worker is a full process spawn that re-resolves the module graph
+// from scratch, over NTFS, with realtime AV scanning each file. Suites whose
+// beforeAll does `await import("../api.js")` — a 350KB module pulling in most of
+// the gateway — routinely pass 10s under full local parallelism.
+//
+// This matters more than a slow test: vitest reports a timed-out hook by marking
+// the file's tests SKIPPED, not failed. Around twenty suites (~180 tests,
+// including the work-item and privileged-read guards) were dropping out of local
+// Windows runs while the run still reported green.
+const isWindows = process.platform === 'win32'
+
 export default defineConfig({
   test: {
     globals: true,
@@ -31,8 +43,8 @@ export default defineConfig({
     ...(isCI ? { minWorkers: 1, maxWorkers: 2 } : {}),
     // Give slow, resource-starved CI runners enough headroom to boot real
     // servers/workers/PTYs without tripping spurious timeouts.
-    testTimeout: isCI ? 30000 : 5000,
-    hookTimeout: isCI ? 30000 : 10000,
+    testTimeout: isCI || isWindows ? 30000 : 5000,
+    hookTimeout: isCI || isWindows ? 30000 : 10000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/web/src/components/chat/__tests__/comms-v2.test.tsx
+++ b/packages/web/src/components/chat/__tests__/comms-v2.test.tsx
@@ -682,7 +682,11 @@ describe('rendered copy carries no em or en dashes', () => {
   function strippedLines(file: string): Array<{ line: number; text: string }> {
     let source = fs.readFileSync(file, 'utf-8')
     source = source.replace(/\/\*[\s\S]*?\*\//g, '')
-    return source.split('\n')
+    // Split on CRLF too. A trailing \r survives a split on '\n', and `.` never
+    // matches \r, so the comment-stripping `.*$` below cannot reach the end of
+    // the line and strips nothing — on a CRLF checkout every commented dash in
+    // the codebase reports as rendered copy.
+    return source.split(/\r?\n/)
       .map((text, index) => ({ line: index + 1, text: text.replace(/(^|[^:])\/\/.*$/, '$1') }))
       // Regex literals legitimately MATCH dashes (e.g. tab-title parsing) —
       // they parse them, they don't render them.


### PR DESCRIPTION
`pnpm build` fails on Windows, so the package cannot be compiled from source there at all, and the test suite silently drops about 180 tests while still reporting green.

> **Split, as requested.** This PR is now ① only. ② is #100 (port detection) and ③ is #101 (owner-only ACLs), both separate. Your `tsconfig.build.json` nit is fixed here — `test-support` was emitting into `dist/` and shipping in the tarball; `**/test-support/**` is now excluded and I verified `dist/src/shared/test-support` is gone after a build.

---

**The build.** The `jinn-cli` build script chained `rm -rf`, `mkdir -p` and `cp`. Package managers run scripts through the platform shell — `cmd` on Windows — where none of those exist, so it died with "The syntax of the command is incorrect". `scripts/build.mjs` does the same work with Node's `fs`, resolving TypeScript's own entry rather than the `tsc` shim so no shell is involved at all. Both `clean` scripts had the same flaw.

**Line endings.** Shipped migration payloads are content-addressed, and there was no `.gitattributes`, so with `core.autocrlf=true` every payload checked out CRLF while its manifest hash covers LF — the migration service failing to validate its own bundle. The blobs were always LF; only the checkout was wrong, so this needs no content change.

This one bit for real while the PR was open, which is worth recording: after pulling v0.28.6, my local `0.28.5`/`0.28.6` bundles were CRLF and the CLI and gateway computed *different migration keys* for the same upgrade. Re-checking those files out with the attributes in place made them byte-identical to the published package. Note the limitation that implies — `.gitattributes` fixes fresh clones, but files arriving later via `git fetch` onto a branch that does not carry it still land CRLF, so an existing checkout needs one renormalisation pass.

**Grok transcript paths.** `walkFiles` joined with a literal `/`, returning mixed separators on Windows. Reads still worked, so it stayed invisible — but the string never equalled a `path.join`-built one, and `listTranscriptFiles` keys its mtime map by exactly that string, so one transcript could be tracked under two spellings. Transcript files are now matched on basename rather than an `endsWith("/name.jsonl")` suffix, because that suffix test only worked *while* the paths were wrongly built; fixing one without the other would have silently stopped recognising every transcript on Windows.

**Tests narrowed to what each platform can express.** Twelve owner-only mode assertions route through `expectPosixMode`, which checks the bits on POSIX and skips where the platform cannot express them. This narrows the tests to what is true; it does not make the property hold, and the helper's doc-comment says so at the point anyone will read it. Five `stop`/`stopAndWait` cases that attribute a bare spawned listener via its environment skip on Windows with the reason recorded, and still run on POSIX.

Two fixtures were wrong rather than the code: `resolveInstanceHome` correctly returns native separators, and `os.homedir()` follows `%USERPROFILE%` on Windows, so the instance-aware test was reading the operator's real `~/.jinn` instead of its fixture. And the migration-bundle fixture inherited the developer's `core.autocrlf`, which put git's "LF will be replaced by CRLF" advisory into a `stderr === ""` assertion — a throwaway repo should pin its own line-ending config.

**The suite was under-reporting.** Windows has no `fork()`, so each vitest pool worker is a full process spawn re-resolving the module graph over NTFS with realtime AV scanning. Suites whose `beforeAll` awaits an import of `api.ts` — 350KB pulling in most of the gateway — routinely passed the 10s hook timeout. Vitest reports a timed-out hook by marking that file's tests **skipped, not failed**, so roughly twenty suites (~180 tests, including the work-item and privileged-read guards) were dropping out of local Windows runs while the run still reported green. The config already grants this headroom on CI for the same underlying reason.

**On Windows CI:** agreed it is the highest-leverage thing here, and I have the one blocker fixed (the migration-bundle fixture above was the last non-flake Windows failure). I have not opened that PR yet — it needs to stack on this one, since `pnpm build` cannot pass on a Windows runner without it.
