### PR TITLE
fix(security): make instance files owner-only, by SID rather than by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.28.8]
+
+### 🔒 Security
+- **The instance directory is restricted to you, and says so when it is not.** `~/.jinn` holds the gateway token, connector secrets and every session transcript, and was protected with a `0600` file mode. Windows has no such mode — `chmod` there only toggles the read-only flag — so the protection was a no-op and the directory kept whatever access it inherited from the user profile; on one machine that meant every file readable by an unrelated account group. Permissions are now expressed in each platform's own model, identified by security identifier rather than by name so that a non-English Windows is handled correctly, and `jinn setup` restricts the directory once so everything written later inherits it. Local device pairing also worked again on Windows, where it had required a file mode no Windows file can report.
+
+  **Existing macOS and Linux instances are affected.** A directory created before this release is group- and world-readable (`0755`), so the gateway now tightens it to `0700` once, at startup, and logs that it did. Widen it again deliberately and the gateway reports the exposure on each start instead of overriding you. Windows is never repaired automatically: doing so means dropping inherited access an operator may have granted on purpose, such as a sandboxed engine account that needs to read configuration.
+
 ## [0.28.7] - 2026-07-27
 
 ### 🐛 Fixes

--- a/packages/jinn/src/cli/setup.ts
+++ b/packages/jinn/src/cli/setup.ts
@@ -5,6 +5,7 @@ import readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
 import yaml from "js-yaml";
 import { isInstalled, resolveBin } from "../shared/resolve-bin.js";
+import { enforceOwnerOnlyDirectory } from "../shared/owner-only.js";
 import {
   JINN_HOME,
   CONFIG_PATH,
@@ -495,6 +496,17 @@ export async function runSetup(opts?: { force?: boolean }): Promise<void> {
   const created: string[] = [];
 
   if (ensureDir(JINN_HOME)) created.push(JINN_HOME);
+
+  // Restrict the instance to this user before anything sensitive is written into
+  // it. Done once on the directory, with inheritance, so every file created later
+  // is covered: on Windows there are no mode bits to set per file, and a home
+  // that inherits a broad ACE from the profile would expose the gateway token,
+  // connector secrets and the whole session database to those principals.
+  if (enforceOwnerOnlyDirectory(JINN_HOME)) {
+    ok(`Restricted ${JINN_HOME} to ${process.platform === "win32" ? "your account" : "owner-only (0700)"}`);
+  } else {
+    warn(`Could not restrict permissions on ${JINN_HOME}; check who can read it before adding credentials`);
+  }
 
   // Copy or create config files.
   // DEFAULT_CONFIG (above) is the canonical default. `template/config.yaml` is an

--- a/packages/jinn/src/gateway/__tests__/auth-ux-api.test.ts
+++ b/packages/jinn/src/gateway/__tests__/auth-ux-api.test.ts
@@ -6,6 +6,7 @@ import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { handleApiRequest, type ApiContext } from "../api.js";
 import { requestPairingCode } from "../../cli/pair.js";
+import { enforceOwnerOnlyDirectory } from "../../shared/owner-only.js";
 import {
   createAuthSession,
   issueLocalBootstrapGrant,
@@ -69,7 +70,16 @@ function makeRes() {
   };
 }
 
-function ctx(jinnHome = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-auth-api-"))): ApiContext {
+/** The loopback pairing proof requires a home only this account can reach.
+ *  mkdtemp gives that on POSIX (0700) but not on Windows, where a temp
+ *  directory inherits whatever %TEMP% grants. Establish it either way. */
+function ownerOnlyTempHome(prefix: string): string {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  enforceOwnerOnlyDirectory(home);
+  return home;
+}
+
+function ctx(jinnHome = ownerOnlyTempHome("jinn-auth-api-")): ApiContext {
   return {
     gatewayAuthToken: "gateway-token",
     jinnHome,

--- a/packages/jinn/src/gateway/__tests__/pairing-challenge.test.ts
+++ b/packages/jinn/src/gateway/__tests__/pairing-challenge.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
+import { enforceOwnerOnlyDirectory } from "../../shared/owner-only.js";
 import {
   consumePairingChallenge,
   issuePairingChallenge,
@@ -10,7 +13,14 @@ import {
 } from "../pairing-challenge.js";
 
 function tempHome(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "jinn-pair-challenge-"));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-pair-challenge-"));
+  // The proof is only meaningful in a home nobody else can reach, and these
+  // cases assume that premise. mkdtemp gives it for free on POSIX (0700), but
+  // not on Windows, where a temp directory inherits whatever %TEMP% grants —
+  // often several groups with Modify. Establish it explicitly so the fixture
+  // matches the precondition on both platforms.
+  enforceOwnerOnlyDirectory(home);
+  return home;
 }
 
 function issue(home: string, store: PairingChallengeStore, now = 1_000) {
@@ -36,7 +46,7 @@ describe("pairing filesystem challenges", () => {
     fs.chmodSync(challenge.path, 0o600);
 
     expect(fs.statSync(challenge.path).uid).toBe(fs.statSync(home).uid);
-    expect(fs.statSync(challenge.path).mode & 0o777).toBe(0o600);
+    expectPosixMode(fs.statSync(challenge.path), 0o600);
     expect(consumePairingChallenge(home, challenge.challengeId, store, 1_001)).toBe(true);
     expect(fs.existsSync(challenge.path)).toBe(false);
     expect(consumePairingChallenge(home, challenge.challengeId, store, 1_002)).toBe(false);
@@ -70,9 +80,19 @@ describe("pairing filesystem challenges", () => {
     const store: PairingChallengeStore = new Map();
     const broad = issue(home, store);
     fs.writeFileSync(broad.path, broad.nonce, { mode: 0o644 });
-    fs.chmodSync(broad.path, 0o644);
+    if (process.platform === "win32") {
+      // chmod cannot widen anything on Windows. Grant the Everyone SID instead -
+      // by SID, because the name is localized - which is what "readable by more
+      // than the owner" actually means on this platform.
+      execFileSync("icacls", [broad.path, "/grant", "*S-1-1-0:(R)"], { windowsHide: true });
+    } else {
+      fs.chmodSync(broad.path, 0o644);
+    }
     expect(consumePairingChallenge(home, broad.challengeId, store, 1_001)).toBe(false);
 
+    // A forged uid is a POSIX-only notion: the Windows check reads the ACL, and
+    // ownership cannot be reassigned to another account from inside a test.
+    if (process.platform !== "win32") {
     const foreign = issuePairingChallenge(
       home,
       store,
@@ -91,6 +111,7 @@ describe("pairing filesystem challenges", () => {
     }) as typeof fs.lstatSync);
     expect(consumePairingChallenge(home, foreign.challengeId, store, 2_001)).toBe(false);
     vi.restoreAllMocks();
+    }
 
     const symlink = issuePairingChallenge(
       home,

--- a/packages/jinn/src/gateway/__tests__/pairing-challenge.test.ts
+++ b/packages/jinn/src/gateway/__tests__/pairing-challenge.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expectPosixMode } from "../../shared/test-support/posix-mode.js";
-import { enforceOwnerOnlyDirectory } from "../../shared/owner-only.js";
+import { currentWindowsSid, enforceOwnerOnlyDirectory, parseSddlTrustees, pathIsOwnerOnly } from "../../shared/owner-only.js";
 import {
   consumePairingChallenge,
   issuePairingChallenge,
@@ -20,6 +20,34 @@ function icacls(): string {
   return path.join(root, "System32", "icacls.exe");
 }
 
+/** What the owner-only check actually sees, for failure messages.
+ *
+ *  A bare "expected false to be true" from these cases is close to undiagnosable
+ *  on a machine you cannot log into: it could be identity resolution, the ACL
+ *  edit, or inheritance onto the proof file. Naming the state costs one icacls
+ *  call on the failure path only. */
+function ownerOnlyDiagnosis(target: string): string {
+  if (process.platform !== "win32") {
+    const stat = fs.statSync(target, { throwIfNoEntry: false });
+    return stat ? `mode=0o${(stat.mode & 0o777).toString(8)} uid=${stat.uid}` : "missing";
+  }
+  const dump = path.join(os.tmpdir(), `pair-diag-${process.pid}-${Math.abs(hashPath(target))}.sddl`);
+  try {
+    execFileSync(icacls(), [target, "/save", dump, "/Q"], { windowsHide: true, stdio: ["ignore", "pipe", "ignore"] });
+    return `sid=${currentWindowsSid() ?? "UNRESOLVED"} trustees=[${parseSddlTrustees(fs.readFileSync(dump, "utf16le")).join(", ")}]`;
+  } catch (error) {
+    return `sid=${currentWindowsSid() ?? "UNRESOLVED"} icacls-save-failed: ${(error as Error).message.slice(0, 120)}`;
+  } finally {
+    try { fs.unlinkSync(dump); } catch { /* nothing written */ }
+  }
+}
+
+function hashPath(value: string): number {
+  let h = 0;
+  for (let i = 0; i < value.length; i += 1) h = (h * 31 + value.charCodeAt(i)) | 0;
+  return h;
+}
+
 function tempHome(): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-pair-challenge-"));
   // The proof is only meaningful in a home nobody else can reach, and these
@@ -27,7 +55,11 @@ function tempHome(): string {
   // not on Windows, where a temp directory inherits whatever %TEMP% grants —
   // often several groups with Modify. Establish it explicitly so the fixture
   // matches the precondition on both platforms.
-  enforceOwnerOnlyDirectory(home);
+  //
+  // Asserted rather than assumed: if this fails, every acceptance case below
+  // fails with "expected false to be true" and the real cause is invisible.
+  const applied = enforceOwnerOnlyDirectory(home);
+  expect(applied, `could not establish an owner-only home at ${home} — ${ownerOnlyDiagnosis(home)}`).toBe(true);
   return home;
 }
 
@@ -55,6 +87,10 @@ describe("pairing filesystem challenges", () => {
 
     expect(fs.statSync(challenge.path).uid).toBe(fs.statSync(home).uid);
     expectPosixMode(fs.statSync(challenge.path), 0o600);
+    // The proof inherits the home's restriction rather than setting its own on
+    // Windows, so check that separately: it is the half a mode-only assertion
+    // cannot see, and the half that fails if inheritance did not apply.
+    expect(pathIsOwnerOnly(challenge.path), `proof file is not owner-only — ${ownerOnlyDiagnosis(challenge.path)}`).toBe(true);
     expect(consumePairingChallenge(home, challenge.challengeId, store, 1_001)).toBe(true);
     expect(fs.existsSync(challenge.path)).toBe(false);
     expect(consumePairingChallenge(home, challenge.challengeId, store, 1_002)).toBe(false);

--- a/packages/jinn/src/gateway/__tests__/pairing-challenge.test.ts
+++ b/packages/jinn/src/gateway/__tests__/pairing-challenge.test.ts
@@ -12,6 +12,14 @@ import {
   type PairingChallengeStore,
 } from "../pairing-challenge.js";
 
+/** Resolve icacls from System32, never PATH. MSYS/Cygwin/Git Bash ship their own
+ *  utilities ahead of Windows', and a bare name gets whichever comes first — the
+ *  hazard `owner-only.ts` documents and this fixture must not reintroduce. */
+function icacls(): string {
+  const root = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  return path.join(root, "System32", "icacls.exe");
+}
+
 function tempHome(): string {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-pair-challenge-"));
   // The proof is only meaningful in a home nobody else can reach, and these
@@ -84,7 +92,7 @@ describe("pairing filesystem challenges", () => {
       // chmod cannot widen anything on Windows. Grant the Everyone SID instead -
       // by SID, because the name is localized - which is what "readable by more
       // than the owner" actually means on this platform.
-      execFileSync("icacls", [broad.path, "/grant", "*S-1-1-0:(R)"], { windowsHide: true });
+      execFileSync(icacls(), [broad.path, "/grant", "*S-1-1-0:(R)"], { windowsHide: true });
     } else {
       fs.chmodSync(broad.path, 0o644);
     }
@@ -93,24 +101,24 @@ describe("pairing filesystem challenges", () => {
     // A forged uid is a POSIX-only notion: the Windows check reads the ACL, and
     // ownership cannot be reassigned to another account from inside a test.
     if (process.platform !== "win32") {
-    const foreign = issuePairingChallenge(
-      home,
-      store,
-      2_000,
-      () => "challenge-id-foreign0001",
-      () => "nonce-value-foreign0001",
-    );
-    fs.writeFileSync(foreign.path, foreign.nonce, { mode: 0o600 });
-    const realLstat = fs.lstatSync.bind(fs);
-    vi.spyOn(fs, "lstatSync").mockImplementation(((file: fs.PathLike) => {
-      const stat = realLstat(file);
-      if (path.resolve(String(file)) !== path.resolve(foreign.path)) return stat;
-      const forged = Object.create(stat) as fs.Stats;
-      Object.defineProperty(forged, "uid", { value: stat.uid + 1 });
-      return forged;
-    }) as typeof fs.lstatSync);
-    expect(consumePairingChallenge(home, foreign.challengeId, store, 2_001)).toBe(false);
-    vi.restoreAllMocks();
+      const foreign = issuePairingChallenge(
+        home,
+        store,
+        2_000,
+        () => "challenge-id-foreign0001",
+        () => "nonce-value-foreign0001",
+      );
+      fs.writeFileSync(foreign.path, foreign.nonce, { mode: 0o600 });
+      const realLstat = fs.lstatSync.bind(fs);
+      vi.spyOn(fs, "lstatSync").mockImplementation(((file: fs.PathLike) => {
+        const stat = realLstat(file);
+        if (path.resolve(String(file)) !== path.resolve(foreign.path)) return stat;
+        const forged = Object.create(stat) as fs.Stats;
+        Object.defineProperty(forged, "uid", { value: stat.uid + 1 });
+        return forged;
+      }) as typeof fs.lstatSync);
+      expect(consumePairingChallenge(home, foreign.challengeId, store, 2_001)).toBe(false);
+      vi.restoreAllMocks();
     }
 
     const symlink = issuePairingChallenge(

--- a/packages/jinn/src/gateway/pairing-challenge.ts
+++ b/packages/jinn/src/gateway/pairing-challenge.ts
@@ -49,7 +49,13 @@ function unlinkProof(file: string): void {
  *  process. Windows has neither concept — every uid is 0 and mode is synthetic —
  *  so the 0o600 test could never pass there and local pairing was impossible.
  *  Ask the ACL instead, which is what actually governs access on that platform.
- *  Both paths fail closed. */
+ *  Both paths fail closed.
+ *
+ *  The checks are not symmetric: POSIX also pins the uid triple, while Windows
+ *  verifies the DACL only, because `icacls /save` emits the DACL and not the
+ *  owner. Planting a proof file still requires write access to a home that this
+ *  same call asserts is owner-only, so the gap is not reachable on its own — but
+ *  it is a gap, and an owner check belongs here if one becomes available. */
 function proofOwnershipIsExclusive(jinnHome: string, file: string, proofStat: fs.Stats): boolean {
   if (process.platform === "win32") {
     return pathIsOwnerOnly(file) && pathIsOwnerOnly(jinnHome);

--- a/packages/jinn/src/gateway/pairing-challenge.ts
+++ b/packages/jinn/src/gateway/pairing-challenge.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { pathIsOwnerOnly } from "../shared/owner-only.js";
 
 export const PAIRING_CHALLENGE_TTL_MS = 10_000;
 export const PAIRING_CHALLENGE_FILE_PREFIX = "pair-challenge-";
@@ -42,14 +43,29 @@ function unlinkProof(file: string): void {
   }
 }
 
+/** The proof file must be reachable only by the operator running the gateway.
+ *
+ *  POSIX states that as mode 0o600 plus a uid matching both JINN_HOME and this
+ *  process. Windows has neither concept — every uid is 0 and mode is synthetic —
+ *  so the 0o600 test could never pass there and local pairing was impossible.
+ *  Ask the ACL instead, which is what actually governs access on that platform.
+ *  Both paths fail closed. */
+function proofOwnershipIsExclusive(jinnHome: string, file: string, proofStat: fs.Stats): boolean {
+  if (process.platform === "win32") {
+    return pathIsOwnerOnly(file) && pathIsOwnerOnly(jinnHome);
+  }
+  const homeStat = fs.statSync(jinnHome);
+  if ((proofStat.mode & 0o777) !== 0o600) return false;
+  if (proofStat.uid !== homeStat.uid) return false;
+  if (typeof process.getuid === "function" && homeStat.uid !== process.getuid()) return false;
+  return true;
+}
+
 function proofMatches(jinnHome: string, file: string, nonce: string): boolean {
   try {
-    const homeStat = fs.statSync(jinnHome);
     const proofStat = fs.lstatSync(file);
     if (!proofStat.isFile() || proofStat.isSymbolicLink()) return false;
-    if ((proofStat.mode & 0o777) !== 0o600) return false;
-    if (proofStat.uid !== homeStat.uid) return false;
-    if (typeof process.getuid === "function" && homeStat.uid !== process.getuid()) return false;
+    if (!proofOwnershipIsExclusive(jinnHome, file, proofStat)) return false;
 
     const expected = Buffer.from(nonce, "utf-8");
     if (proofStat.size !== expected.length) return false;

--- a/packages/jinn/src/gateway/server.ts
+++ b/packages/jinn/src/gateway/server.ts
@@ -42,10 +42,6 @@ import { setTodoStatusChangeListener } from "../work-items/transitions.js";
 import { seedTrust, cleanupSessionSettings } from "../shared/claude-settings.js";
 import { GATEWAY_INFO_FILE, HOOK_RELAY_SCRIPT, JINN_HOME, CLAUDE_SETTINGS_DIR } from "../shared/paths.js";
 import { enforceOwnerOnlyDirectory, pathIsOwnerOnly } from "../shared/owner-only.js";
-
-/** Records that boot already tightened JINN_HOME once, so an operator who
- *  deliberately re-widens it afterwards is warned rather than silently overridden. */
-const OWNER_ONLY_HEAL_MARKER = path.join(JINN_HOME, ".owner-only-healed");
 import { handleApiRequest, isSameOriginBrowserRequest, resumePendingWebQueueItems, type ApiContext } from "./api.js";
 import { resolveCallerIdentity, sessionCommGuards, LATERAL_MAX_HOPS, type CallerIdentityOptions } from "./session-comm-guards.js";
 import { UNIDENTIFIED_TOOL_CALL_ERROR, verifySessionCapability } from "../mcp/identity.js";
@@ -104,6 +100,10 @@ import { scanOrg } from "./org.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+/** Records that boot already tightened JINN_HOME once, so an operator who
+ *  deliberately re-widens it afterwards is warned rather than silently overridden. */
+const OWNER_ONLY_HEAL_MARKER = path.join(JINN_HOME, ".owner-only-healed");
 
 type UpgradeRejectionSocket = {
   write(chunk: string): unknown;
@@ -364,21 +364,6 @@ export async function startGateway(
   const host = config.gateway.host || "127.0.0.1";
   const exposure = validateGatewayExposure(config);
   if (!exposure.ok) throw new Error(exposure.error);
-  const gatewayAuthToken = ensureGatewayAuthToken(JINN_HOME);
-  if (shouldRequireGatewayAuth(config)) logger.info("Gateway auth enabled for privileged API and WebSocket routes");
-
-  // Expose the auth token + base URL to spawned sessions. Every engine builds its
-  // child PTY env by spreading `process.env`, so an in-session agent inherits these
-  // and can dispatch/poll child sessions in one curl instead of hunting for the
-  // token. Same trust boundary as the 0600 gateway.json it already came from.
-  // gatewayBaseUrl maps a wildcard bind (0.0.0.0) to 127.0.0.1 and keeps a specific
-  // host as-is, so the URL is always reachable from the child.
-  process.env.JINN_GATEWAY_TOKEN = gatewayAuthToken;
-  process.env.JINN_GATEWAY_URL = gatewayBaseUrl({ port, host });
-
-  // Normalize claude engine config (idempotent — loadConfig already normalized it)
-  const claudeCfg = normalizeClaudeEngineConfig(config.engines.claude);
-
   // The instance holds the gateway token, connector secrets and every session
   // transcript. Report when something else can read it — a broad ACE inherited
   // from the profile on Windows, or group/other bits on POSIX.
@@ -395,6 +380,10 @@ export async function startGateway(
   //
   // Once, not every boot: a marker records the attempt, so an operator who
   // deliberately re-widens the directory is told rather than overridden.
+  //
+  // Deliberately BEFORE ensureGatewayAuthToken below: on a pre-existing 0755 home
+  // the other order materializes the token while the directory is still
+  // group-readable, then tightens it.
   if (!pathIsOwnerOnly(JINN_HOME)) {
     const healed = process.platform !== "win32" && !fs.existsSync(OWNER_ONLY_HEAL_MARKER)
       && enforceOwnerOnlyDirectory(JINN_HOME);
@@ -415,6 +404,21 @@ export async function startGateway(
       );
     }
   }
+
+  const gatewayAuthToken = ensureGatewayAuthToken(JINN_HOME);
+  if (shouldRequireGatewayAuth(config)) logger.info("Gateway auth enabled for privileged API and WebSocket routes");
+
+  // Expose the auth token + base URL to spawned sessions. Every engine builds its
+  // child PTY env by spreading `process.env`, so an in-session agent inherits these
+  // and can dispatch/poll child sessions in one curl instead of hunting for the
+  // token. Same trust boundary as the 0600 gateway.json it already came from.
+  // gatewayBaseUrl maps a wildcard bind (0.0.0.0) to 127.0.0.1 and keeps a specific
+  // host as-is, so the URL is always reachable from the child.
+  process.env.JINN_GATEWAY_TOKEN = gatewayAuthToken;
+  process.env.JINN_GATEWAY_URL = gatewayBaseUrl({ port, host });
+
+  // Normalize claude engine config (idempotent — loadConfig already normalized it)
+  const claudeCfg = normalizeClaudeEngineConfig(config.engines.claude);
 
   // Reap any orphaned PTYs from a prior crashed run before writing the fresh gateway.json.
   const oldInfo = readGatewayInfo(GATEWAY_INFO_FILE);

--- a/packages/jinn/src/gateway/server.ts
+++ b/packages/jinn/src/gateway/server.ts
@@ -41,6 +41,7 @@ import { setTodoLiveEmitter } from "../work-items/live-events.js";
 import { setTodoStatusChangeListener } from "../work-items/transitions.js";
 import { seedTrust, cleanupSessionSettings } from "../shared/claude-settings.js";
 import { GATEWAY_INFO_FILE, HOOK_RELAY_SCRIPT, JINN_HOME, CLAUDE_SETTINGS_DIR } from "../shared/paths.js";
+import { pathIsOwnerOnly } from "../shared/owner-only.js";
 import { handleApiRequest, isSameOriginBrowserRequest, resumePendingWebQueueItems, type ApiContext } from "./api.js";
 import { resolveCallerIdentity, sessionCommGuards, LATERAL_MAX_HOPS, type CallerIdentityOptions } from "./session-comm-guards.js";
 import { UNIDENTIFIED_TOOL_CALL_ERROR, verifySessionCapability } from "../mcp/identity.js";
@@ -373,6 +374,24 @@ export async function startGateway(
 
   // Normalize claude engine config (idempotent — loadConfig already normalized it)
   const claudeCfg = normalizeClaudeEngineConfig(config.engines.claude);
+
+  // The instance holds the gateway token, connector secrets and every session
+  // transcript. Report when something else can read it — a broad ACE inherited
+  // from the profile on Windows, or group/other bits on POSIX.
+  //
+  // Deliberately a warning, not a repair: an operator may have granted that
+  // access on purpose (a sandboxed engine account needing to read config), and
+  // silently rewriting ACLs under a running install could break it. `jinn setup`
+  // restricts the home; boot only tells you when it is no longer restricted.
+  if (!pathIsOwnerOnly(JINN_HOME)) {
+    logger.warn(
+      `Instance directory ${JINN_HOME} is readable beyond your account — the gateway token, `
+      + `connector secrets and session history are exposed to those principals. `
+      + `Restrict it with ${process.platform === "win32"
+        ? `icacls "${JINN_HOME}" /inheritance:r /grant:r "%USERNAME%:(OI)(CI)(F)"`
+        : `chmod 700 "${JINN_HOME}"`}`,
+    );
+  }
 
   // Reap any orphaned PTYs from a prior crashed run before writing the fresh gateway.json.
   const oldInfo = readGatewayInfo(GATEWAY_INFO_FILE);

--- a/packages/jinn/src/gateway/server.ts
+++ b/packages/jinn/src/gateway/server.ts
@@ -41,7 +41,11 @@ import { setTodoLiveEmitter } from "../work-items/live-events.js";
 import { setTodoStatusChangeListener } from "../work-items/transitions.js";
 import { seedTrust, cleanupSessionSettings } from "../shared/claude-settings.js";
 import { GATEWAY_INFO_FILE, HOOK_RELAY_SCRIPT, JINN_HOME, CLAUDE_SETTINGS_DIR } from "../shared/paths.js";
-import { pathIsOwnerOnly } from "../shared/owner-only.js";
+import { enforceOwnerOnlyDirectory, pathIsOwnerOnly } from "../shared/owner-only.js";
+
+/** Records that boot already tightened JINN_HOME once, so an operator who
+ *  deliberately re-widens it afterwards is warned rather than silently overridden. */
+const OWNER_ONLY_HEAL_MARKER = path.join(JINN_HOME, ".owner-only-healed");
 import { handleApiRequest, isSameOriginBrowserRequest, resumePendingWebQueueItems, type ApiContext } from "./api.js";
 import { resolveCallerIdentity, sessionCommGuards, LATERAL_MAX_HOPS, type CallerIdentityOptions } from "./session-comm-guards.js";
 import { UNIDENTIFIED_TOOL_CALL_ERROR, verifySessionCapability } from "../mcp/identity.js";
@@ -379,18 +383,37 @@ export async function startGateway(
   // transcript. Report when something else can read it — a broad ACE inherited
   // from the profile on Windows, or group/other bits on POSIX.
   //
-  // Deliberately a warning, not a repair: an operator may have granted that
-  // access on purpose (a sandboxed engine account needing to read config), and
-  // silently rewriting ACLs under a running install could break it. `jinn setup`
-  // restricts the home; boot only tells you when it is no longer restricted.
+  // On POSIX this self-heals ONCE. `jinn setup` now restricts the home, but every
+  // instance created before that ran is 0755 (mkdir under a 022 umask), so without
+  // a heal those operators would get this warning on every boot forever. chmod 700
+  // on a directory we own is cheap, reversible, and exactly what setup does.
+  //
+  // Windows is warn-only, and the asymmetry is deliberate: repairing there means
+  // /inheritance:r, which strips ACEs an operator may have granted on purpose (a
+  // sandboxed engine account that needs to read config), and doing that silently
+  // under a running install could break it.
+  //
+  // Once, not every boot: a marker records the attempt, so an operator who
+  // deliberately re-widens the directory is told rather than overridden.
   if (!pathIsOwnerOnly(JINN_HOME)) {
-    logger.warn(
-      `Instance directory ${JINN_HOME} is readable beyond your account — the gateway token, `
-      + `connector secrets and session history are exposed to those principals. `
-      + `Restrict it with ${process.platform === "win32"
-        ? `icacls "${JINN_HOME}" /inheritance:r /grant:r "%USERNAME%:(OI)(CI)(F)"`
-        : `chmod 700 "${JINN_HOME}"`}`,
-    );
+    const healed = process.platform !== "win32" && !fs.existsSync(OWNER_ONLY_HEAL_MARKER)
+      && enforceOwnerOnlyDirectory(JINN_HOME);
+    if (healed) {
+      try { fs.writeFileSync(OWNER_ONLY_HEAL_MARKER, new Date().toISOString(), { mode: 0o600 }); } catch { /* best effort */ }
+      logger.info(
+        `Restricted ${JINN_HOME} to owner-only (0700). It held the gateway token, connector `
+        + `secrets and session history while group/other-readable. Done once; re-widen it and `
+        + `this becomes a warning rather than a repair.`,
+      );
+    } else {
+      logger.warn(
+        `Instance directory ${JINN_HOME} is readable beyond your account — the gateway token, `
+        + `connector secrets and session history are exposed to those principals. `
+        + `Restrict it with ${process.platform === "win32"
+          ? `icacls "${JINN_HOME}" /inheritance:r /grant:r "%USERNAME%:(OI)(CI)(F)"`
+          : `chmod 700 "${JINN_HOME}"`}`,
+      );
+    }
   }
 
   // Reap any orphaned PTYs from a prior crashed run before writing the fresh gateway.json.

--- a/packages/jinn/src/shared/__tests__/owner-only.test.ts
+++ b/packages/jinn/src/shared/__tests__/owner-only.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseSddlTrustees, pathIsOwnerOnly } from "../owner-only.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-owner-only-"));
+  roots.push(dir);
+  return dir;
+}
+
+/**
+ * Real `icacls /save` output. SDDL is the locale-independent form: trustees are
+ * two-letter well-known aliases or raw SIDs, never names resolved into the system
+ * locale. Matching on names meant a German Windows saw every path as shared.
+ */
+const OWNER_ONLY = String.raw`jinn
+D:AI(A;OICIID;FA;;;S-1-5-21-111-222-333-1001)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)`;
+
+const SHARED_WITH_GROUP = String.raw`jinn
+D:AI(A;OICI;0x1200a9;;;S-1-5-21-999-888-777-1005)(A;OICIID;FA;;;S-1-5-21-111-222-333-1001)(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)`;
+
+describe("parseSddlTrustees", () => {
+  it("extracts every granted trustee from the DACL", () => {
+    expect(parseSddlTrustees(OWNER_ONLY)).toEqual([
+      "S-1-5-21-111-222-333-1001",
+      "SY",
+      "BA",
+    ]);
+  });
+
+  it("sees a group that an owner-only check must reject", () => {
+    expect(parseSddlTrustees(SHARED_WITH_GROUP)).toContain("S-1-5-21-999-888-777-1005");
+  });
+
+  it("ignores Deny ACEs, which cannot make a path reachable", () => {
+    const sddl = String.raw`x
+D:(D;;FA;;;S-1-5-21-4-4-4-4)(A;;FA;;;SY)`;
+    expect(parseSddlTrustees(sddl)).toEqual(["SY"]);
+  });
+
+  it("returns nothing when there is no DACL, so callers fail closed", () => {
+    expect(parseSddlTrustees("Access is denied.")).toEqual([]);
+    expect(parseSddlTrustees("")).toEqual([]);
+  });
+
+  it("skips malformed ACEs rather than guessing a trustee", () => {
+    expect(parseSddlTrustees("x\nD:(A;;FA)(A;;FA;;;SY)")).toEqual(["SY"]);
+  });
+});
+
+describe("pathIsOwnerOnly", () => {
+  it.skipIf(process.platform === "win32")("reads POSIX bits: 0700 is owner-only, 0755 is not", () => {
+    const dir = tempDir();
+    fs.chmodSync(dir, 0o700);
+    expect(pathIsOwnerOnly(dir)).toBe(true);
+    fs.chmodSync(dir, 0o755);
+    expect(pathIsOwnerOnly(dir)).toBe(false);
+    fs.chmodSync(dir, 0o750);
+    expect(pathIsOwnerOnly(dir)).toBe(false); // group read still counts as shared
+  });
+
+  it("fails closed for a path that does not exist", () => {
+    // Must not throw: the gateway calls this unguarded at boot on every platform,
+    // so a missing path has to answer "not owner only" rather than crash.
+    expect(pathIsOwnerOnly(path.join(tempDir(), "definitely-absent"))).toBe(false);
+  });
+
+  it("answers for a real path on this platform without throwing", () => {
+    expect(typeof pathIsOwnerOnly(tempDir())).toBe("boolean");
+  });
+});

--- a/packages/jinn/src/shared/__tests__/owner-only.test.ts
+++ b/packages/jinn/src/shared/__tests__/owner-only.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { parseSddlTrustees, pathIsOwnerOnly } from "../owner-only.js";
+import { enforceOwnerOnlyDirectory, parseSddlTrustees, pathIsOwnerOnly } from "../owner-only.js";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -73,5 +73,33 @@ describe("pathIsOwnerOnly", () => {
 
   it("answers for a real path on this platform without throwing", () => {
     expect(typeof pathIsOwnerOnly(tempDir())).toBe("boolean");
+  });
+});
+
+describe("enforceOwnerOnlyDirectory", () => {
+  it("reports the verified state, never a bare exit code", () => {
+    // The caller prints this as an assurance ("Restricted ~/.jinn to your
+    // account"), so the return value has to mean the directory IS owner-only
+    // afterwards. On Windows /grant:r replaces permissions only for the trustees
+    // it names, so a pre-existing explicit ACE for an unrelated group can survive
+    // a successful invocation — returning true on exit code alone would be the
+    // same "reports success, silently does nothing" bug this module removes.
+    const dir = tempDir();
+    const applied = enforceOwnerOnlyDirectory(dir);
+    expect(applied).toBe(pathIsOwnerOnly(dir));
+    if (applied) expect(pathIsOwnerOnly(dir)).toBe(true);
+  });
+
+  it("fails closed for a path that does not exist, without throwing", () => {
+    // A hardening failure must not stop the gateway from starting.
+    expect(enforceOwnerOnlyDirectory(path.join(tempDir(), "definitely-absent"))).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("tightens a group-readable directory", () => {
+    const dir = tempDir();
+    fs.chmodSync(dir, 0o755);
+    expect(pathIsOwnerOnly(dir)).toBe(false);
+    expect(enforceOwnerOnlyDirectory(dir)).toBe(true);
+    expect(pathIsOwnerOnly(dir)).toBe(true);
   });
 });

--- a/packages/jinn/src/shared/__tests__/owner-only.test.ts
+++ b/packages/jinn/src/shared/__tests__/owner-only.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { enforceOwnerOnlyDirectory, parseSddlTrustees, pathIsOwnerOnly } from "../owner-only.js";
+import { enforceOwnerOnlyDirectory, parseSddlTrustees, pathIsOwnerOnly, trusteesAreOwnerOnly } from "../owner-only.js";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -51,6 +51,47 @@ D:(D;;FA;;;S-1-5-21-4-4-4-4)(A;;FA;;;SY)`;
 
   it("skips malformed ACEs rather than guessing a trustee", () => {
     expect(parseSddlTrustees("x\nD:(A;;FA)(A;;FA;;;SY)")).toEqual(["SY"]);
+  });
+});
+
+describe("trusteesAreOwnerOnly", () => {
+  const ME = "S-1-5-21-111-222-333-1001";
+
+  it("accepts the user plus the unavoidable privileged trustees", () => {
+    expect(trusteesAreOwnerOnly([ME, "SY", "BA"], ME)).toBe(true);
+    expect(trusteesAreOwnerOnly([ME, "S-1-5-18", "S-1-5-32-544", "CO", "OW"], ME)).toBe(true);
+  });
+
+  it("rejects any other principal", () => {
+    expect(trusteesAreOwnerOnly([ME, "SY", "S-1-5-21-999-888-777-1005"], ME)).toBe(false);
+    // Everyone / Authenticated Users / Users, the aliases that actually show up.
+    for (const alias of ["WD", "AU", "BU"]) {
+      expect(trusteesAreOwnerOnly([ME, alias], ME)).toBe(false);
+    }
+  });
+
+  it("accepts the SDDL alias for the current account, not just its raw SID", () => {
+    // GitHub's windows-latest runs as the built-in Administrator (RID 500), and
+    // icacls /save writes that SID back as `LA` even though /grant was given the
+    // raw form. Matching the SID alone read the user's own grant as a stranger's
+    // and reported a correctly restricted directory as shared — the exact ACL
+    // below is what the runner produced.
+    const admin = "S-1-5-21-1742564184-1656218818-310408600-500";
+    expect(trusteesAreOwnerOnly(["BA", "SY", "LA"], admin)).toBe(true);
+    expect(trusteesAreOwnerOnly(["BA", "SY", admin], admin)).toBe(true);
+    expect(trusteesAreOwnerOnly(["BA", "SY", "LG"], "S-1-5-21-1-2-3-501")).toBe(true);
+  });
+
+  it("does not accept another account's alias as the current user", () => {
+    // LA is THIS machine's Administrator. For anyone who is not that account it
+    // is a different principal with access, so it must still read as shared.
+    expect(trusteesAreOwnerOnly(["BA", "SY", "LA"], ME)).toBe(false);
+    expect(trusteesAreOwnerOnly(["BA", "SY", "LG"], ME)).toBe(false);
+    expect(trusteesAreOwnerOnly(["BA", "SY", "LA"], "S-1-5-21-1-2-3-501")).toBe(false);
+  });
+
+  it("treats an unparsed descriptor as not owner-only", () => {
+    expect(trusteesAreOwnerOnly([], ME)).toBe(false);
   });
 });
 

--- a/packages/jinn/src/shared/owner-only.ts
+++ b/packages/jinn/src/shared/owner-only.ts
@@ -140,17 +140,32 @@ export function pathIsOwnerOnly(target: string, stats?: fs.Stats): boolean {
  * is why this is a directory operation rather than a per-file chmod: on Windows
  * inheritance is the only way to get the property without touching each file.
  *
- * Returns true when the restriction was applied. Never throws: a hardening
- * failure must not stop the gateway from starting, and the caller logs it.
+ * Returns true only when the directory is owner-only AFTERWARDS — the result is
+ * verified, never assumed, because the caller prints it as an assurance. Never
+ * throws: a hardening failure must not stop the gateway from starting, and the
+ * caller logs it.
  */
 export function enforceOwnerOnlyDirectory(directory: string): boolean {
   try {
     if (process.platform !== "win32") {
       fs.chmodSync(directory, 0o700);
-      return true;
+      return pathIsOwnerOnly(directory);
     }
     const mySid = currentWindowsSid();
     if (!mySid) return false;
+    // /reset first: /inheritance:r below drops only INHERITED ACEs, so without
+    // this a pre-existing EXPLICIT ACE for an unrelated group survives the whole
+    // operation. /reset drops explicit ACEs and leaves inherited ones for
+    // /inheritance:r to remove.
+    execFileSync(system32("icacls.exe"), [directory, "/reset", "/Q"], {
+      encoding: "utf-8",
+      windowsHide: true,
+      timeout: 10_000,
+      // icacls writes its own progress and errors to the console; without this
+      // they print raw over `jinn setup`'s formatted output. The read path above
+      // already does the same.
+      stdio: ["ignore", "pipe", "ignore"],
+    });
     // /inheritance:r drops ACEs inherited from the profile — the mechanism by
     // which an unrelated group can otherwise reach the whole instance.
     // /grant:r replaces rather than adds, so re-running is idempotent.
@@ -165,8 +180,13 @@ export function enforceOwnerOnlyDirectory(directory: string): boolean {
       "/grant:r", "*S-1-5-18:(OI)(CI)(F)",      // NT AUTHORITY\SYSTEM
       "/grant:r", "*S-1-5-32-544:(OI)(CI)(F)",  // BUILTIN\Administrators
       "/Q",
-    ], { encoding: "utf-8", windowsHide: true, timeout: 10_000 });
-    return true;
+    ], { encoding: "utf-8", windowsHide: true, timeout: 10_000, stdio: ["ignore", "pipe", "ignore"] });
+    // Verify rather than assume. /grant:r replaces permissions only for the
+    // trustees it names, so this cannot report success on the strength of an
+    // exit code alone — that is the same "reports success, silently does
+    // nothing" failure this module exists to remove. `undefined` means the ACL
+    // could not be read, which is a failure here, not a pass.
+    return windowsPathIsOwnerOnly(directory) === true;
   } catch {
     return false;
   }

--- a/packages/jinn/src/shared/owner-only.ts
+++ b/packages/jinn/src/shared/owner-only.ts
@@ -1,0 +1,173 @@
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Owner-only file protection, on both permission models.
+ *
+ * POSIX expresses this with mode bits and uid. Windows has neither: fs.chmod
+ * only toggles the read-only attribute there, so a file written 0o600 reports
+ * 0o666 and every uid is 0. Access on Windows is the ACL, so that is what this
+ * module reads and writes.
+ *
+ * Everything here fails closed. An unparseable ACL is treated as "not owner
+ * only", never as "probably fine".
+ */
+
+/** Trustees that may hold access without the path counting as shared. SYSTEM and
+ *  Administrators can take ownership of anything on Windows, so excluding them
+ *  would make every path "shared" and the check meaningless.
+ *
+ *  Identified by SID, never by name. `icacls` prints names resolved into the
+ *  system locale — German Windows says VORDEFINIERT\Administratoren — so an
+ *  English allowlist reports every path as shared there, which is both a
+ *  permanent boot warning and a silent failure of the check itself. SDDL uses
+ *  well-known two-letter aliases plus raw SIDs and is locale-independent. */
+const ALWAYS_PRIVILEGED_TRUSTEES = new Set([
+  "SY", "S-1-5-18",        // NT AUTHORITY\SYSTEM
+  "BA", "S-1-5-32-544",    // BUILTIN\Administrators
+  "CO", "S-1-3-0",         // CREATOR OWNER
+  "OW", "S-1-3-4",         // OWNER RIGHTS
+]);
+
+/** Absolute path to a System32 tool.
+ *
+ *  Never invoke these by bare name: MSYS, Cygwin and Git Bash ship their own
+ *  `whoami` and put it ahead of Windows' on PATH, so a bare call gets the Unix
+ *  one, fails to parse, and this module silently degrades to "cannot tell" — a
+ *  permanent boot warning and a hardening call that quietly does nothing. */
+function system32(exe: string): string {
+  const root = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  return path.join(root, "System32", exe);
+}
+
+/** This process's user SID. The SID is the only locale-independent identity Node
+ *  can obtain without a native binding; %USERNAME% gives a name that still has to
+ *  be resolved, and resolution is exactly what localisation breaks. */
+export function currentWindowsSid(): string | undefined {
+  try {
+    // "DOMAIN\user","S-1-5-21-..." — no header, no shell.
+    const out = execFileSync(system32("whoami.exe"), ["/user", "/fo", "csv", "/nh"], {
+      encoding: "utf-8",
+      windowsHide: true,
+      timeout: 5_000,
+    }).trim();
+    const sid = out.split(",").pop()?.replace(/"/g, "").trim();
+    return sid && /^S-1-[\d-]+$/.test(sid) ? sid.toUpperCase() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Trustees granted access by an SDDL security descriptor, upper-cased.
+ *
+ *  SDDL DACL shape: `D:AI(A;OICIID;FA;;;SY)(A;;FA;;;S-1-5-21-…)`. The trustee is
+ *  the sixth semicolon-separated field of each ACE — either a two-letter
+ *  well-known alias or a raw SID, neither of which is localised.
+ *
+ *  `icacls /save` emits the DACL only (no `O:`/`G:` prefix), which is what this
+ *  reads; an owner/group prefix is not handled because it never appears here, and
+ *  `G:BAD:AI(…)` is genuinely ambiguous to parse.
+ *
+ *  Exported for tests: this parser decides whether a path counts as shared. */
+export function parseSddlTrustees(sddl: string): string[] {
+  const dacl = /(?:^|[\s\0])D:([^\s\0]*)/.exec(sddl)?.[1];
+  if (!dacl) return [];
+  const trustees: string[] = [];
+  for (const ace of dacl.matchAll(/\(([^)]*)\)/g)) {
+    const fields = ace[1].split(";");
+    if (fields.length < 6) continue;
+    // Only Allow ACEs grant reach; a Deny ACE cannot make a path shared.
+    if (!/^A/i.test(fields[0].trim())) continue;
+    const trustee = fields[5].trim().toUpperCase();
+    if (trustee) trustees.push(trustee);
+  }
+  return trustees;
+}
+
+/** True when only the current user (plus the unavoidable privileged trustees)
+ *  can reach `target`. Windows only; undefined when it cannot tell.
+ *
+ *  Reads the descriptor as SDDL rather than parsing `icacls`'s human output,
+ *  because that output is localised and this comparison must not be. */
+export function windowsPathIsOwnerOnly(target: string): boolean | undefined {
+  const mySid = currentWindowsSid();
+  if (!mySid) return undefined;
+  const dump = path.join(os.tmpdir(), `jinn-acl-${process.pid}-${crypto.randomUUID()}.sddl`);
+  try {
+    // icacls cannot print SDDL to stdout; /save writes it as UTF-16LE.
+    execFileSync(system32("icacls.exe"), [target, "/save", dump, "/Q"], {
+      encoding: "utf-8",
+      windowsHide: true,
+      timeout: 5_000,
+      // Discard icacls' own stderr: a missing path is an expected answer here
+      // ("not owner only"), not something to print over the caller's output.
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const sddl = fs.readFileSync(dump, "utf16le");
+    const trustees = parseSddlTrustees(sddl);
+    if (trustees.length === 0) return undefined; // parsed nothing — do not guess
+    return trustees.every((t) => t === mySid || ALWAYS_PRIVILEGED_TRUSTEES.has(t));
+  } catch {
+    return undefined;
+  } finally {
+    try { fs.unlinkSync(dump); } catch { /* nothing written */ }
+  }
+}
+
+/**
+ * True when `target` is readable only by its owner.
+ *
+ * POSIX callers pass the already-taken Stats to avoid a second syscall.
+ */
+export function pathIsOwnerOnly(target: string, stats?: fs.Stats): boolean {
+  if (process.platform === "win32") return windowsPathIsOwnerOnly(target) === true;
+  // throwIfNoEntry: false, because this must fail closed rather than throw. The
+  // gateway calls it unguarded at boot on every platform, so a plain statSync
+  // turned a missing path into a crash instead of a "not owner only" answer —
+  // contradicting this module's own contract and its own test.
+  const stat = stats ?? fs.statSync(target, { throwIfNoEntry: false });
+  if (!stat) return false;
+  return (stat.mode & 0o077) === 0;
+}
+
+/**
+ * Restrict `directory` to the current user, and make new children inherit that.
+ *
+ * One call at setup/boot covers every file the instance will ever write, which
+ * is why this is a directory operation rather than a per-file chmod: on Windows
+ * inheritance is the only way to get the property without touching each file.
+ *
+ * Returns true when the restriction was applied. Never throws: a hardening
+ * failure must not stop the gateway from starting, and the caller logs it.
+ */
+export function enforceOwnerOnlyDirectory(directory: string): boolean {
+  try {
+    if (process.platform !== "win32") {
+      fs.chmodSync(directory, 0o700);
+      return true;
+    }
+    const mySid = currentWindowsSid();
+    if (!mySid) return false;
+    // /inheritance:r drops ACEs inherited from the profile — the mechanism by
+    // which an unrelated group can otherwise reach the whole instance.
+    // /grant:r replaces rather than adds, so re-running is idempotent.
+    //
+    // Grant by SID (the *S-… form), not by name: the literals would have to be
+    // the localised ones on a non-English Windows, where "BUILTIN\Administrators"
+    // does not resolve and the whole call fails.
+    execFileSync(system32("icacls.exe"), [
+      directory,
+      "/inheritance:r",
+      "/grant:r", `*${mySid}:(OI)(CI)(F)`,
+      "/grant:r", "*S-1-5-18:(OI)(CI)(F)",      // NT AUTHORITY\SYSTEM
+      "/grant:r", "*S-1-5-32-544:(OI)(CI)(F)",  // BUILTIN\Administrators
+      "/Q",
+    ], { encoding: "utf-8", windowsHide: true, timeout: 10_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/jinn/src/shared/owner-only.ts
+++ b/packages/jinn/src/shared/owner-only.ts
@@ -87,6 +87,41 @@ export function parseSddlTrustees(sddl: string): string[] {
   return trustees;
 }
 
+/** Every SDDL spelling of one specific account SID.
+ *
+ *  SDDL serializes some well-known SIDs as two-letter aliases, so an ACE granting
+ *  exactly this user can come back as `LA` rather than `S-1-5-21-…-500` — the
+ *  form `icacls /grant` was given. Comparing the raw SID alone then reads the
+ *  user's own grant as a stranger's and reports a correctly restricted directory
+ *  as shared. Observed on GitHub's windows-latest runner, which runs as the
+ *  built-in Administrator.
+ *
+ *  Derived from the RID rather than accepted unconditionally: `LA` denotes THIS
+ *  machine's Administrator account, so it is the current user only when the
+ *  current user is that account. For anyone else it is a different principal and
+ *  must still count as shared. */
+function sddlSpellingsOf(sid: string): Set<string> {
+  const spellings = new Set([sid.toUpperCase()]);
+  // Local account RIDs: 500 = Administrator, 501 = Guest. Domain accounts start
+  // at 1000 and have no alias.
+  if (/-500$/.test(sid)) spellings.add("LA");
+  if (/-501$/.test(sid)) spellings.add("LG");
+  return spellings;
+}
+
+/** Whether a DACL's trustees mean "only this user can reach it".
+ *
+ *  Exported for tests: with {@link parseSddlTrustees} this is the whole verdict,
+ *  and it must be checkable without a Windows box to read an ACL from.
+ *
+ *  Empty is not a pass — no parsed trustee means the descriptor was not
+ *  understood, and guessing there would report an unreadable ACL as safe. */
+export function trusteesAreOwnerOnly(trustees: readonly string[], mySid: string): boolean {
+  if (trustees.length === 0) return false;
+  const mine = sddlSpellingsOf(mySid);
+  return trustees.every((t) => mine.has(t.toUpperCase()) || ALWAYS_PRIVILEGED_TRUSTEES.has(t.toUpperCase()));
+}
+
 /** True when only the current user (plus the unavoidable privileged trustees)
  *  can reach `target`. Windows only; undefined when it cannot tell.
  *
@@ -109,7 +144,7 @@ export function windowsPathIsOwnerOnly(target: string): boolean | undefined {
     const sddl = fs.readFileSync(dump, "utf16le");
     const trustees = parseSddlTrustees(sddl);
     if (trustees.length === 0) return undefined; // parsed nothing — do not guess
-    return trustees.every((t) => t === mySid || ALWAYS_PRIVILEGED_TRUSTEES.has(t));
+    return trusteesAreOwnerOnly(trustees, mySid);
   } catch {
     return undefined;
   } finally {


### PR DESCRIPTION
The instance holds the gateway token, connector secrets and every session transcript, protected with mode `0o600`. Windows has no POSIX mode bits — `chmod` there only toggles the read-only attribute — so that call is a no-op and the home keeps whatever ACL it inherits from the profile. A group granted access on the profile reads the entire instance. This also subsumes **#99**, the `mode === 0o600` equality that no NTFS file can satisfy.

> Split out of #97 as ③, per review — this is the one to argue about. **Stacked on #97**, because it needs the `expectPosixMode` helper introduced there; review or merge that first. All four of your points are addressed below, including the POSIX behaviour change you were right to call undisclosed.

Found on a real instance: every file under `~/.jinn` readable by a sandbox account group, including `gateway.json`, `secrets/` and `sessions/registry.db`.

---

**1. Fails closed instead of throwing.** `fs.statSync` raises ENOENT, and `server.ts` calls `pathIsOwnerOnly(JINN_HOME)` unguarded at boot **on every platform** — a live crash path that contradicted both the module's stated contract and its own test. Now `fs.statSync(target, { throwIfNoEntry: false })` with a null check, and the test asserts it.

**2. SIDs throughout, not English names.** You were right that this was the same bug class I had just fixed in netstat, in my own code. Fixed on both sides:

- **Reading** no longer parses `icacls`'s human output at all. It reads the descriptor as SDDL via `icacls /save`, whose trustees are well-known two-letter aliases (`SY`, `BA`) and raw SIDs — locale-independent by construction. `parseIcaclsPrincipals` is gone, replaced by `parseSddlTrustees`.
- **Granting** passes the `*S-…` form: `*S-1-5-18`, `*S-1-5-32-544`, plus the caller's own SID. The literals would have had to be the localised ones on a non-English Windows, where `BUILTIN\Administrators` does not resolve and the whole call fails.
- Identity comes from the SID via `whoami /user`, not `%USERNAME%`/`%USERDOMAIN%` — addressing your fourth point too, since a name still has to be resolved and resolution is exactly what localisation breaks.

One thing that fell out of testing this: `whoami` and `icacls` are now resolved from `%SystemRoot%\System32` rather than `PATH`. MSYS, Cygwin and Git Bash ship their own `whoami` ahead of Windows' one, and a bare call gets the Unix binary, fails to parse, and silently degrades the check to "cannot tell" — a permanent boot warning plus a hardening call that quietly does nothing. I hit exactly that while verifying.

Verified end-to-end on real paths: the SID resolves, a temp directory inheriting a shared `%TEMP%` ACL reads as *not* owner-only, `enforceOwnerOnlyDirectory` makes it owner-only, a newly created child inherits that, and a missing path returns false without throwing.

**3. The POSIX behaviour change, now disclosed.** `enforceOwnerOnlyDirectory` chmods `0o700` on POSIX and `jinn setup` calls it. The default `~/.jinn` is `0755` under a 022 umask, so on merge **every existing macOS and Linux instance logs the boot warning** until setup is re-run or the directory is tightened by hand. It is the correct posture for a directory holding a gateway token, but it is user-visible and shipped under a Windows-titled PR — so it is now stated in the commit message as a `BEHAVIOUR CHANGE ON POSIX` and wants a changelog entry. Boot only warns and never repairs, deliberately: an operator may have granted that access on purpose, and rewriting ACLs under a running install could break it.

Per your comment, the one-shot self-heal is now in: on POSIX only, boot tightens an over-permissive `JINN_HOME` to `0700` once, writes a `.owner-only-healed` marker so it never fights an operator who deliberately widens it again, and logs what it did. Windows still only warns — rewriting ACLs under a running install is not something to do unasked, and the audit that started this found a group grant that may well be intentional. The user-visible `0755 → 0700` change is recorded in the changelog under Security.

**Also here:** the pairing proof required mode `0o600` unconditionally, which no Windows file can report, so local pairing was impossible there (#99). It now reads the ACL on Windows and the mode/uid triple on POSIX. Both pairing fixtures establish an owner-only home explicitly, since `mkdtemp` gives that for free on POSIX but not on Windows, where a temp directory inherits whatever `%TEMP%` grants — often several groups with Modify.

Tests cover the SDDL parser directly (it decides whether a path counts as shared): trustee extraction, a group that must be rejected, Deny ACEs ignored, malformed ACEs skipped, and empty output failing closed. Those are platform-independent and run on CI.

