### PR TITLE
fix(windows): spawn engine binaries that are .cmd shims

### DIFF
--- a/packages/jinn/src/shared/__tests__/engine-limits.test.ts
+++ b/packages/jinn/src/shared/__tests__/engine-limits.test.ts
@@ -181,17 +181,15 @@ describe("collectEngineLimits — claude statusline snapshot", () => {
   });
 });
 
-// The stubs below are `#!/usr/bin/env node` files made executable with chmod.
-// Windows has neither a shebang nor an executable bit, so `spawn(bin, …)` never
-// starts them and all three cases fail on what the fixture cannot express rather
-// than on what they test.
+// These ran on POSIX only until #103: the stubs were `#!/usr/bin/env node` files
+// made executable with chmod, and Windows has neither a shebang nor an
+// executable bit, so `spawn(bin, …)` never started them.
 //
-// Not merely a fixture limitation: production spawns the engine binary the same
-// way, and an npm-installed `codex` on Windows is a `.cmd` shim that Node has
-// refused to spawn without a shell since 18.20.2. That is issue #103, and the
-// fix for it is what makes a `.cmd` stub — and therefore real coverage here —
-// possible. Re-enable these with that change rather than by relaxing them.
-describe.skipIf(process.platform === "win32")("collectEngineLimits — codex session rollout", () => {
+// They now run on both. writeCodexAppServerStub emits a `.cmd` on Windows —
+// the shape npm actually installs a CLI in — so these exercise the shim spawn
+// path in engine-limits rather than asserting around it, and they fail without
+// that fix.
+describe("collectEngineLimits — codex session rollout", () => {
   it("prefers a successful live app-server response over an older rollout snapshot", async () => {
     const ts = new Date(Date.now() - 5 * 60_000).toISOString();
     writeCodexRollout(ts, 72);

--- a/packages/jinn/src/shared/__tests__/engine-limits.test.ts
+++ b/packages/jinn/src/shared/__tests__/engine-limits.test.ts
@@ -82,10 +82,22 @@ function writeCodexAppServerStub(
         "});",
       ].join("\n")
     : "process.exit(1);";
-  fs.writeFileSync(
-    bin,
-    `#!/usr/bin/env node\nimport fs from "node:fs";\nfs.writeFileSync(${JSON.stringify(startedFile)}, "started");\n${behavior}\n`,
-  );
+  const body = `import fs from "node:fs";\nfs.writeFileSync(${JSON.stringify(startedFile)}, "started");\n${behavior}\n`;
+
+  // Windows has neither a shebang nor an executable bit, so the POSIX stub is
+  // inert there and these cases used to be skipped. A .cmd is not merely a
+  // workaround: it is exactly the shape npm installs a CLI in on Windows, so
+  // this now exercises the .cmd spawn path in engine-limits rather than
+  // pretending the platform cannot be tested.
+  if (process.platform === "win32") {
+    const script = `${bin}.mjs`;
+    fs.writeFileSync(script, body);
+    const shim = `${bin}.cmd`;
+    fs.writeFileSync(shim, `@echo off\r\nnode "%~dp0${path.basename(script)}" %*\r\n`);
+    return { bin: shim, startedFile };
+  }
+
+  fs.writeFileSync(bin, `#!/usr/bin/env node\n${body}`);
   fs.chmodSync(bin, 0o755);
   return { bin, startedFile };
 }

--- a/packages/jinn/src/shared/__tests__/resolve-bin.test.ts
+++ b/packages/jinn/src/shared/__tests__/resolve-bin.test.ts
@@ -70,4 +70,43 @@ describe("resolveBin", () => {
       process.env.PATH = prev;
     }
   });
+
+  it.skipIf(process.platform !== "win32")("finds a .cmd shim, which is how npm installs a CLI on Windows", () => {
+    // The bug behind #103's first half: dir + bare name matches nothing, because
+    // an npm-installed `codex` on Windows is `codex.cmd`. Resolution then fell
+    // through to the bare name, and CreateProcess cannot start that either — it
+    // tries .exe and .com but never .cmd.
+    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "resolvebin-cmd-"));
+    const shim = path.join(shimDir, "jinn-fake-shim-xyz.cmd");
+    fs.writeFileSync(shim, "@echo off\r\n");
+    const prev = process.env.PATH;
+    process.env.PATH = `${shimDir}${path.delimiter}${prev ?? ""}`;
+    try {
+      expect(resolveBin("jinn-fake-shim-xyz")).toBe(shim);
+    } finally {
+      process.env.PATH = prev;
+      fs.rmSync(shimDir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform !== "win32")("prefers PATHEXT order, so a real .exe wins over a .cmd shim", () => {
+    const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "resolvebin-order-"));
+    const base = path.join(shimDir, "jinn-fake-order-xyz");
+    fs.writeFileSync(`${base}.cmd`, "@echo off\r\n");
+    fs.writeFileSync(`${base}.exe`, "");
+    const prev = process.env.PATH;
+    const prevExt = process.env.PATHEXT;
+    process.env.PATH = `${shimDir}${path.delimiter}${prev ?? ""}`;
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    try {
+      // A native executable is spawnable directly and needs no interpreter, so
+      // it must win when both exist.
+      expect(resolveBin("jinn-fake-order-xyz")).toBe(`${base}.exe`);
+    } finally {
+      process.env.PATH = prev;
+      if (prevExt === undefined) delete process.env.PATHEXT;
+      else process.env.PATHEXT = prevExt;
+      fs.rmSync(shimDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/jinn/src/shared/__tests__/windows-spawn.test.ts
+++ b/packages/jinn/src/shared/__tests__/windows-spawn.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
-import { needsCmdShim, spawnableCommand } from "../windows-spawn.js";
+import { cmdExePath, needsCmdShim, spawnableCommand, windowsRoot } from "../windows-spawn.js";
 
 const roots: string[] = [];
 afterEach(() => {
@@ -14,6 +14,49 @@ function tempDir(): string {
   roots.push(dir);
   return dir;
 }
+
+describe("windowsRoot", () => {
+  const saved = { SystemRoot: process.env.SystemRoot, windir: process.env.windir };
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("prefers SystemRoot, then windir", () => {
+    process.env.SystemRoot = "D:\\Alt";
+    process.env.windir = "E:\\Other";
+    expect(windowsRoot()).toBe("D:\\Alt");
+    delete process.env.SystemRoot;
+    expect(windowsRoot()).toBe("E:\\Other");
+  });
+
+  it("falls back to a ROOTED default when the environment omits both", () => {
+    // Regression: one of two copies of this fallback was written "C:\Windows",
+    // where \W is not an escape sequence — JavaScript dropped the backslash and
+    // produced the drive-RELATIVE "C:Windows". taskkill.exe beneath it cannot be
+    // found, and killProcessTree's catch then silently degraded to a plain kill,
+    // leaving the grandchild it exists to reap. Reachable in a stripped service
+    // environment where neither variable is set.
+    delete process.env.SystemRoot;
+    delete process.env.windir;
+    expect(windowsRoot()).toBe("C:\\Windows");
+    expect(path.win32.isAbsolute(windowsRoot())).toBe(true);
+    // Pin the distinction the bug turned on, so the assertion above cannot be
+    // "fixed" later by matching whatever the code happens to produce.
+    expect(path.win32.isAbsolute("C:Windows")).toBe(false);
+  });
+
+  it("keeps every System32 consumer rooted, not just the one that was correct", () => {
+    delete process.env.SystemRoot;
+    delete process.env.windir;
+    // cmdExePath and killProcessTree's taskkill share this resolver now, so one
+    // assertion covers both rather than each carrying its own copy to proofread.
+    expect(path.win32.isAbsolute(cmdExePath().replace(/\//g, "\\"))).toBe(true);
+    expect(cmdExePath()).toContain("System32");
+  });
+});
 
 describe("needsCmdShim", () => {
   it.skipIf(process.platform !== "win32")("recognises the extensions Node refuses to spawn", () => {

--- a/packages/jinn/src/shared/__tests__/windows-spawn.test.ts
+++ b/packages/jinn/src/shared/__tests__/windows-spawn.test.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { needsCmdShim, spawnableCommand } from "../windows-spawn.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-winspawn-"));
+  roots.push(dir);
+  return dir;
+}
+
+describe("needsCmdShim", () => {
+  it.skipIf(process.platform !== "win32")("recognises the extensions Node refuses to spawn", () => {
+    expect(needsCmdShim("C:\\tools\\codex.cmd")).toBe(true);
+    expect(needsCmdShim("C:\\tools\\codex.BAT")).toBe(true);
+    expect(needsCmdShim("C:\\tools\\codex.exe")).toBe(false);
+    expect(needsCmdShim("codex")).toBe(false);
+  });
+
+  it.skipIf(process.platform === "win32")("never rewrites anything off Windows", () => {
+    // A POSIX file may legitimately be named `foo.cmd`; only Windows' loader
+    // treats the extension as meaningful.
+    expect(needsCmdShim("/usr/local/bin/codex.cmd")).toBe(false);
+    expect(needsCmdShim("/usr/local/bin/codex")).toBe(false);
+  });
+});
+
+describe("spawnableCommand", () => {
+  it("passes a normal binary through untouched", () => {
+    expect(spawnableCommand("/usr/local/bin/codex", ["app-server", "--stdio"])).toEqual({
+      command: "/usr/local/bin/codex",
+      args: ["app-server", "--stdio"],
+      options: {},
+    });
+  });
+
+  it.skipIf(process.platform !== "win32")("routes a shim through cmd.exe from System32", () => {
+    const { command, args, options } = spawnableCommand("C:\\tools\\codex.cmd", ["app-server", "--stdio"]);
+    expect(command.toLowerCase()).toContain("system32\\cmd.exe");
+    // Without this Node applies its own quoting on top of the line built here and
+    // cmd.exe reports the whole thing as an unrecognised command.
+    expect(options.windowsVerbatimArguments).toBe(true);
+    // /d so a registry AutoRun cannot inject work into every engine spawn.
+    expect(args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+    expect(args[3]).toBe('""C:\\tools\\codex.cmd" "app-server" "--stdio""');
+  });
+
+  it.skipIf(process.platform !== "win32")("doubles a trailing backslash run so it cannot escape the quote", () => {
+    // A directory argument ends in a backslash routinely. `C:\work\` + `"`
+    // becomes `C:\work\"`, escaping the closing quote and swallowing whatever
+    // follows — the same hazard cli/skills.ts documents for npx.
+    const { args } = spawnableCommand("C:\\tools\\codex.cmd", ["C:\\work\\", "--stdio"]);
+    expect(args[3]).toContain('"C:\\work\\\\"');
+    expect(args[3]).toContain('"--stdio"');
+  });
+});
+
+describe("spawnableCommand against a real shim", () => {
+  it.skipIf(process.platform !== "win32")("runs a .cmd that a bare spawn cannot", async () => {
+    const dir = tempDir();
+    const shim = path.join(dir, "echo-args.cmd");
+    fs.writeFileSync(shim, "@echo off\r\necho ARGS:%1,%2\r\n");
+
+    // The regression itself: Node refuses the shim without an interpreter.
+    const bare = spawnSync(shim, ["alpha", "beta"], { encoding: "utf-8" });
+    expect(bare.error).toBeTruthy();
+    expect((bare.error as NodeJS.ErrnoException).code).toBe("EINVAL");
+
+    const { command, args, options } = spawnableCommand(shim, ["alpha", "beta"]);
+    const out = execFileSync(command, args, { encoding: "utf-8", windowsHide: true, ...options });
+    expect(out).toContain("ARGS:");
+    expect(out).toContain("alpha");
+    expect(out).toContain("beta");
+  });
+});

--- a/packages/jinn/src/shared/engine-limits.ts
+++ b/packages/jinn/src/shared/engine-limits.ts
@@ -1,4 +1,5 @@
 import { spawn, execFile } from "node:child_process";
+import { killProcessTree, spawnableCommand } from "./windows-spawn.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -196,7 +197,11 @@ async function fetchClaudeOAuthUsage(): Promise<JsonRecord | undefined> {
 async function claudeAuthPlan(config: JinnConfig): Promise<string | undefined> {
   const bin = resolveBin("claude", config.engines.claude?.bin);
   return new Promise((resolve) => {
-    execFile(bin, ["auth", "status"], { timeout: 3000 }, (err, stdout) => {
+    // An npm-installed CLI on Windows is a .cmd shim, which Node refuses to
+    // spawn without a shell; without this the call fails against a working
+    // install and the plan silently reads as unknown.
+    const auth = spawnableCommand(bin, ["auth", "status"]);
+    execFile(auth.command, auth.args, { timeout: 3000, windowsHide: true, ...auth.options }, (err, stdout) => {
       if (err) return resolve(undefined);
       try {
         const parsed = JSON.parse(stdout);
@@ -352,14 +357,17 @@ async function readCodexRateLimits(config: JinnConfig): Promise<JsonRecord> {
   const request = { id: 2, method: "account/rateLimits/read", params: null };
 
   return new Promise((resolve, reject) => {
-    const child = spawn(bin, ["app-server", "--stdio"], { stdio: ["pipe", "pipe", "pipe"] });
+    // Same .cmd constraint as above. Codex usage limits were unavailable on
+    // Windows entirely because this threw EINVAL and the error was swallowed.
+    const appServer = spawnableCommand(bin, ["app-server", "--stdio"]);
+    const child = spawn(appServer.command, appServer.args, { stdio: ["pipe", "pipe", "pipe"], windowsHide: true, ...appServer.options });
     let stdout = "";
     let stderr = "";
     let settled = false;
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      child.kill("SIGTERM");
+      killProcessTree(child);
       reject(new Error(stderr.trim() || "Timed out reading Codex rate limits"));
     }, 5000);
 
@@ -367,7 +375,7 @@ async function readCodexRateLimits(config: JinnConfig): Promise<JsonRecord> {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      child.kill("SIGTERM");
+      killProcessTree(child);
       resolve(value);
     }
 

--- a/packages/jinn/src/shared/resolve-bin.ts
+++ b/packages/jinn/src/shared/resolve-bin.ts
@@ -16,11 +16,30 @@ function isExecutableFile(p: string): boolean {
   try {
     const st = fs.statSync(p);
     if (!st.isFile()) return false;
+    // Windows has no executable bit: X_OK succeeds for any readable file, so the
+    // check is meaningless there and what makes a file runnable is its extension
+    // (see windowsCandidates).
+    if (process.platform === "win32") return true;
     fs.accessSync(p, fs.constants.X_OK);
     return true;
   } catch {
     return false;
   }
+}
+
+/** Extensions Windows will actually execute, most-specific first.
+ *
+ *  A CLI installed by npm on Windows is `name.cmd`, never a bare `name`, so
+ *  joining dir + name finds nothing and resolution falls through to the bare
+ *  name — which CreateProcess then cannot start either, because it tries .exe
+ *  and .com but not .cmd. Both halves have to know about PATHEXT. */
+function windowsCandidates(name: string): string[] {
+  if (path.extname(name)) return [name]; // already explicit
+  const pathext = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((ext) => ext.trim())
+    .filter(Boolean);
+  return [...pathext.map((ext) => `${name}${ext.toLowerCase()}`), name];
 }
 
 /** Common install locations not guaranteed to be on a daemon's PATH. */
@@ -56,8 +75,11 @@ function findOnPath(name: string): string | null {
   for (const dir of [...pathDirs, ...commonBinDirs()]) {
     if (seen.has(dir)) continue;
     seen.add(dir);
-    const candidate = path.join(dir, name);
-    if (isExecutableFile(candidate)) return candidate;
+    const names = process.platform === "win32" ? windowsCandidates(name) : [name];
+    for (const candidate of names) {
+      const full = path.join(dir, candidate);
+      if (isExecutableFile(full)) return full;
+    }
   }
   return null;
 }

--- a/packages/jinn/src/shared/windows-spawn.ts
+++ b/packages/jinn/src/shared/windows-spawn.ts
@@ -32,9 +32,28 @@ function quoteForCmd(arg: string): string {
   return `"${arg.replace(/(\\+)$/, "$1$1")}"`;
 }
 
+/** The Windows installation root, from the environment or its documented default.
+ *
+ *  One resolver, deliberately. This fallback existed twice in this file and the
+ *  copies drifted: one was written `"C:\Windows"`, where `\W` is not an escape
+ *  sequence, so JavaScript dropped the backslash and produced the drive-relative
+ *  `"C:Windows"`. That directory does not exist, `taskkill.exe` beneath it cannot
+ *  be found, and `killProcessTree` then degraded into exactly the grandchild leak
+ *  it exists to prevent — silently, because its catch falls back to a plain kill.
+ *
+ *  Exported so a test pins it instead of proofreading catching it next time. */
+export function windowsRoot(): string {
+  return process.env.SystemRoot || process.env.windir || "C:\\Windows";
+}
+
+/** Absolute path to a System32 tool. Never invoke these by bare name: MSYS,
+ *  Cygwin and Git Bash ship their own and place them ahead on PATH. */
+function system32(exe: string): string {
+  return path.join(windowsRoot(), "System32", exe);
+}
+
 export function cmdExePath(): string {
-  const root = process.env.SystemRoot || process.env.windir || "C:\\Windows";
-  return path.join(root, "System32", "cmd.exe");
+  return system32("cmd.exe");
 }
 
 /**
@@ -82,8 +101,7 @@ export function killProcessTree(child: { pid?: number; kill: (signal?: NodeJS.Si
     return;
   }
   try {
-    const root = process.env.SystemRoot || process.env.windir || "C:\Windows";
-    execFileSync(path.join(root, "System32", "taskkill.exe"), ["/pid", String(child.pid), "/t", "/f"], {
+    execFileSync(system32("taskkill.exe"), ["/pid", String(child.pid), "/t", "/f"], {
       windowsHide: true,
       timeout: 5_000,
       stdio: ["ignore", "ignore", "ignore"],

--- a/packages/jinn/src/shared/windows-spawn.ts
+++ b/packages/jinn/src/shared/windows-spawn.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+/**
+ * Make a command line runnable on Windows when the binary is a `.cmd`/`.bat` shim.
+ *
+ * Node has refused to spawn `.cmd` and `.bat` without a shell since 18.20.2 (the
+ * CVE-2024-27980 fix): `spawn("codex.cmd", …)` throws EINVAL. Every CLI installed
+ * by npm on Windows is exactly such a shim, so a bare spawn fails against a
+ * perfectly working install.
+ *
+ * The fix is to invoke the interpreter explicitly — `cmd.exe /d /s /c "…"` —
+ * rather than passing `shell: true`. Both end up running cmd.exe, but doing it
+ * here keeps the quoting visible and reviewable instead of delegating it to
+ * Node's shell handling, and it resolves cmd.exe from System32 rather than PATH.
+ *
+ * Arguments are quoted for cmd.exe's parser: the whole command is wrapped in the
+ * outer quotes `/s` expects, and each argument is individually quoted with its
+ * trailing backslash run doubled, per MSVCRT rules — the same escape hazard
+ * `cli/skills.ts` documents. Callers must still not pass attacker-controlled
+ * arguments; this is for fixed argv with an operator-configured binary path.
+ */
+export function needsCmdShim(bin: string): boolean {
+  if (process.platform !== "win32") return false;
+  const ext = path.extname(bin).toLowerCase();
+  return ext === ".cmd" || ext === ".bat";
+}
+
+function quoteForCmd(arg: string): string {
+  // Double only the FINAL run of backslashes: a run immediately before the
+  // closing quote would otherwise escape it and swallow the next argument.
+  return `"${arg.replace(/(\\+)$/, "$1$1")}"`;
+}
+
+export function cmdExePath(): string {
+  const root = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  return path.join(root, "System32", "cmd.exe");
+}
+
+/**
+ * Rewrite `(bin, args)` so a Windows shim can be executed, or pass them through.
+ *
+ * Spread `options` into the `spawn`/`execFile` call. It carries
+ * `windowsVerbatimArguments` for the shim case: Node would otherwise apply its
+ * own quoting on top of the command line built here, and cmd.exe would receive
+ * escaped quotes and report the whole line as an unrecognised command. This is
+ * the same flag `shell: true` sets internally.
+ */
+export interface SpawnPlan {
+  command: string;
+  args: string[];
+  options: { windowsVerbatimArguments?: true };
+}
+
+export function spawnableCommand(bin: string, args: readonly string[]): SpawnPlan {
+  if (!needsCmdShim(bin)) return { command: bin, args: [...args], options: {} };
+  const line = [bin, ...args].map(quoteForCmd).join(" ");
+  // /d skips AutoRun commands from the registry, which could otherwise inject
+  // work into every spawn. /s with the outer quotes keeps the line intact.
+  return {
+    command: cmdExePath(),
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}
+
+/**
+ * Terminate a spawned process and anything it started.
+ *
+ * `spawnableCommand` interposes cmd.exe on Windows, so the engine runs as a
+ * GRANDCHILD. Killing the returned handle then reaps only the interpreter and
+ * leaves the engine running — for a long-lived `app-server` that is a leaked
+ * process per collection, every time the read times out.
+ *
+ * Windows has no process groups to signal, so this uses taskkill /T, which walks
+ * the child tree. Best-effort by design: the caller is already on an error path
+ * and must not be derailed by a reap that raced with a normal exit.
+ */
+export function killProcessTree(child: { pid?: number; kill: (signal?: NodeJS.Signals) => boolean }): void {
+  if (process.platform !== "win32" || !child.pid) {
+    child.kill("SIGTERM");
+    return;
+  }
+  try {
+    const root = process.env.SystemRoot || process.env.windir || "C:\Windows";
+    execFileSync(path.join(root, "System32", "taskkill.exe"), ["/pid", String(child.pid), "/t", "/f"], {
+      windowsHide: true,
+      timeout: 5_000,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+  } catch {
+    // Already gone, or taskkill unavailable. Fall back to the direct kill so the
+    // interpreter at least does not survive.
+    try { child.kill("SIGTERM"); } catch { /* already reaped */ }
+  }
+}


### PR DESCRIPTION
Fixes #103. Codex usage limits were unavailable on Windows against a perfectly working install, and silently — both call sites swallow the error and resolve `undefined`, so there is no log line and no user-visible reason. The feature simply appears never to have data.

**There were two bugs, not one.** The second is the one #103 describes; the first is why it was never even reached.

---

**Resolution never found the binary.** `findOnPath` joined `dir` + bare name, but an npm-installed CLI on Windows is `codex.cmd`, so nothing matched and `resolveBin` fell through to returning the bare name — which `CreateProcess` cannot start either, since it tries `.exe` and `.com` but never `.cmd`. Both halves had to know about `PATHEXT`.

It now walks `PATHEXT`, most-specific first, so a real `.exe` still wins over a shim when both exist (pinned by a test). `isExecutableFile` also stops consulting `X_OK` on Windows, where it succeeds for any readable file and therefore means nothing.

**Spawning then refused the shim.** Node has rejected `.cmd`/`.bat` without a shell since 18.20.2 (the CVE-2024-27980 fix), so both sites threw `EINVAL`.

They now route through `cmd.exe` **explicitly, rather than `shell: true`**. Both end up running cmd.exe, but doing it here keeps the quoting visible and reviewable instead of delegating it, resolves cmd.exe from `System32` rather than PATH, and passes `/d` so a registry AutoRun cannot inject work into every engine spawn. Arguments are quoted per MSVCRT rules with the trailing backslash run doubled — the same hazard `cli/skills.ts` documents.

`windowsVerbatimArguments` is required alongside it, and this took a moment to find: without it Node applies its own quoting on top of the line built here, and cmd.exe reports the whole thing as an unrecognised command. It is what `shell: true` sets internally.

**Interposing cmd.exe makes the engine a grandchild**, so `child.kill()` would reap only the interpreter and leave a long-lived `app-server` running — one leaked process per collection, every time the read times out. `killProcessTree` uses `taskkill /T` for that, best-effort, since the caller is already on an error path.

---

**The three codex-rollout cases now run on Windows with real coverage.** You noted in #103 that fixing the stub alone would make them pass without touching the product bug, so I did the opposite: their stub is written as a `.cmd` — the shape npm actually installs — so they exercise this spawn path rather than asserting around it. They fail without this change and pass with it, which is the coverage the issue asked for.

Also tested: `PATHEXT` resolution and its ordering, the cmd.exe rewrite and its quoting, and a real `.cmd` executed end-to-end after asserting that a bare `spawnSync` of it gives `EINVAL` — so the regression itself is pinned, not just the fix.

**Stacking:** #104 skips those three cases on Windows, since it had to make the leg green without this fix. If #104 lands first this PR should drop that skip on rebase; if this lands first, #104's skip becomes a no-op to remove. Either order works, they just both touch `engine-limits.test.ts`.

**One thing for review.** `resolveBin` now hands *every* engine a resolved `.cmd` path where it previously handed them a bare name. I do not believe that is a regression — a `.cmd`-only install could not be spawned either way — but making the PTY engines actually launch a shim is separate work with different constraints (interposing cmd.exe inside a PTY changes the process tree the CLI renders into), and I have not attempted it here. Happy to file it if you agree it is worth tracking.

Verified on Windows 11 / Node 24: `shared` + `engines` + `cli` suites pass (738 tests), typecheck clean on both packages.
