### PR TITLE
fix(registry): give the SQLite contention retry a time budget

### DIFF
--- a/packages/jinn/src/sessions/registry.ts
+++ b/packages/jinn/src/sessions/registry.ts
@@ -922,7 +922,14 @@ function isTransientSqliteError(code: string): boolean {
 const SQLITE_RETRY_BUDGET_MS = process.platform === 'win32' ? 15_000 : 5_000;
 
 function runSqliteBusyRetry<T>(operation: () => T): T {
-  const deadline = Date.now() + SQLITE_RETRY_BUDGET_MS;
+  // performance.now(), not Date.now(): this runs at process start and the sleep
+  // below blocks the thread outright, so a backward wall-clock step during the
+  // wait (w32time resyncing at boot, an NTP correction, a VM snapshot restore)
+  // would extend a synchronous block by the size of the step, unbounded and
+  // unlogged — the gateway would simply appear hung. A forward step would
+  // silently truncate the budget instead. performance.now() is monotonic from
+  // process start and immune to both.
+  const deadline = performance.now() + SQLITE_RETRY_BUDGET_MS;
   let delayMs = 10;
   for (;;) {
     try {
@@ -931,7 +938,7 @@ function runSqliteBusyRetry<T>(operation: () => T): T {
       const code = error && typeof error === 'object' && 'code' in error
         ? String((error as { code?: unknown }).code)
         : '';
-      const remainingMs = deadline - Date.now();
+      const remainingMs = deadline - performance.now();
       if (!isTransientSqliteError(code) || remainingMs <= 0) throw error;
       // Jittered exponential backoff. Without the jitter, peers that collided
       // once back off by the same amount and collide again on every subsequent

--- a/packages/jinn/src/sessions/registry.ts
+++ b/packages/jinn/src/sessions/registry.ts
@@ -900,19 +900,45 @@ function isTransientSqliteError(code: string): boolean {
   return code.startsWith('SQLITE_BUSY') || code.startsWith('SQLITE_READONLY');
 }
 
+/** How long to keep retrying transient contention before giving up.
+ *
+ *  A time budget rather than an attempt count, because the thing being waited
+ *  out is a window of contention whose length has nothing to do with how many
+ *  times we have asked. The previous fixed ladder spent ~1.76s on Windows and
+ *  then threw; sixteen processes initializing one database on a CI runner held
+ *  the lock for longer than that, so the ladder ran out mid-race.
+ *
+ *  Matched to the `busy_timeout` already set on the connection: SQLite waits ten
+ *  seconds for a BUSY lock, so waiting a comparable span for the same class of
+ *  contention is consistent rather than arbitrary. Only ever reached on an error
+ *  path — a database that is genuinely read-only pays this once at boot and then
+ *  fails with the same message it would have before.
+ *
+ *  This raises a ceiling; it does not remove one. Instrumented at six times CI's
+ *  concurrency the loop still exhausts the full budget and throws, because no
+ *  bounded wait can be sufficient for unbounded contention. Serializing
+ *  initialization across processes is the fix that would not have a ceiling, and
+ *  it is a larger change than this one. */
+const SQLITE_RETRY_BUDGET_MS = process.platform === 'win32' ? 15_000 : 5_000;
+
 function runSqliteBusyRetry<T>(operation: () => T): T {
-  // Windows takes longer to release a lock than POSIX, and the race that needs
-  // this is at process start, where a few hundred extra milliseconds are free.
-  const retryDelaysMs = process.platform === 'win32' ? [10, 50, 200, 500, 1000] : [10, 50, 200];
-  for (let attempt = 0; ; attempt++) {
+  const deadline = Date.now() + SQLITE_RETRY_BUDGET_MS;
+  let delayMs = 10;
+  for (;;) {
     try {
       return operation();
     } catch (error) {
       const code = error && typeof error === 'object' && 'code' in error
         ? String((error as { code?: unknown }).code)
         : '';
-      if (!isTransientSqliteError(code) || attempt >= retryDelaysMs.length) throw error;
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, retryDelaysMs[attempt]);
+      const remainingMs = deadline - Date.now();
+      if (!isTransientSqliteError(code) || remainingMs <= 0) throw error;
+      // Jittered exponential backoff. Without the jitter, peers that collided
+      // once back off by the same amount and collide again on every subsequent
+      // attempt, which is how a ladder that looks generous still exhausts itself.
+      const jittered = delayMs * (0.5 + Math.random());
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(1, Math.min(jittered, remainingMs)));
+      delayMs = Math.min(delayMs * 2, 500);
     }
   }
 }


### PR DESCRIPTION
The Windows leg failed on #105 with `attempt to write a readonly database` from one of the 16 processes in `callback-concurrent-init`. It is **not #105's** — that PR touches engine spawning — and it is not a new flake: it is the same class #104 addressed at `journal_mode = WAL`, surfacing one frame along at the schema-init transaction.

Raising this separately so #105 is not held behind it, and so the reasoning is reviewable on its own.

## The retry was working; it ran out

Worth establishing before changing anything, since "add more retries" is the kind of fix that is easy to apply and hard to justify:

- the error code is `SQLITE_READONLY` (verified directly against better-sqlite3, not assumed), which `isTransientSqliteError` already matches;
- `runSqliteBusyRetry` is in the failing stack, so the wrapper engages;
- the ladder `[10, 50, 200, 500, 1000]` spends **1.76s**, and the worker that died had been contending for **3.5s**.

So it was giving up mid-race.

## An attempt count is the wrong unit

What is being waited out is a window of contention whose length has nothing to do with how many times we have asked. This is now a **time budget** — 15s on Windows, 5s elsewhere — matched to the `busy_timeout = 10000` already set on the connection, so the two agree about how long this class of contention is worth waiting for.

Backoff is exponential and **jittered**. Without jitter, peers that collide once back off by the same amount and collide again on every subsequent attempt, which is how a ladder that looks generous still exhausts itself.

## What I can and cannot claim

I instrumented the give-up path and ran it at six times CI's concurrency (96 processes against one database):

```
RETRY-GAVEUP elapsed=15015ms code=SQLITE_READONLY
```

The loop engages, backs off, and **exhausts the entire budget**. That is the honest result, and it cuts both ways:

- it confirms the mechanism — this is real contention outlasting a bounded wait, not a predicate that fails to match or a wrapper that never runs;
- and it confirms that **no budget is sufficient for unbounded concurrency**. This raises a ceiling from 1.76s to 15s against observed contention of 3.5s. It does not remove one.

A straight comparison against `main` at that concurrency is within noise (1/12 vs 2/12), for the same reason: at 96 processes both exhaust whatever they are given. At CI-equivalent load (16 processes) I get 0 failures in 10 local runs, but I would not lean on that either — `main` also passes locally at that load, which is precisely why this only ever showed up on the runner.

**The change that would remove the ceiling is serializing initialization across processes** — a lock file around the migration, so peers wait once rather than colliding repeatedly. That is a larger change to the boot path and deserves its own review rather than being smuggled in behind a flake fix. Happy to take it if you want it; the comment in the code says the same thing so the next reader does not mistake this for a guarantee.

## Why it matters outside CI

The gateway, the CLI and session workers all open this database. Sixteen simultaneous openers is a test construct, but two or three is an ordinary Windows session, and those were exposed to the same race with a 1.76s tolerance.
