### PR TITLE
PLA-57: derive web engine vocabulary from the gateway registry

### DIFF
--- a/packages/jinn/src/gateway/server.ts
+++ b/packages/jinn/src/gateway/server.ts
@@ -11,6 +11,7 @@ import { loadConfig, normalizeClaudeEngineConfig } from "../shared/config.js";
 import {
   getModelRegistry,
   invalidateModelRegistry,
+  type PtyViewEngineName,
   refreshAntigravityModels,
   refreshClaudeModels,
   refreshCodexModels,
@@ -629,7 +630,7 @@ export async function startGateway(
 
   // PTY-capable engines, keyed by engine name — the /ws/pty handler routes by
   // session.engine so the xterm view attaches to the right engine.
-  const ptyViewEngines: Record<string, Engine & PtyViewEngine> = {
+  const ptyViewEngines: Record<PtyViewEngineName, Engine & PtyViewEngine> = {
     claude: interactiveClaudeEngine,
     codex: codexInteractiveEngine,
     antigravity: antigravityEngine,
@@ -1375,7 +1376,7 @@ export async function startGateway(
       // PTY view, and attaching the claude TUI to a codex session showed the wrong
       // engine. No view engine for this engine → refuse the upgrade (FE hides the
       // CLI toggle for codex so this only catches stragglers).
-      const ptyEngine = ptySession ? ptyViewEngines[ptySession.engine] : undefined;
+      const ptyEngine = ptySession ? ptyViewEngines[ptySession.engine as PtyViewEngineName] : undefined;
       if (!ptyEngine) { socket.destroy(); return; }
       ptyWss.handleUpgrade(req, socket, head, (ws) => {
         trackHeartbeat(ws);

--- a/packages/jinn/src/shared/__tests__/models.test.ts
+++ b/packages/jinn/src/shared/__tests__/models.test.ts
@@ -320,6 +320,12 @@ describe("featured models (registry marking)", () => {
   });
 });
 
+it("drift guard: registers 6 engines and stamps supportsPty on the 5 PTY-capable ones", () => {
+  const reg = getModelRegistry(cfg({}));
+  expect(Object.keys(reg)).toEqual(["claude", "codex", "antigravity", "grok", "pi", "hermes"]);
+  expect(Object.keys(reg).filter((n) => reg[n].supportsPty)).toEqual(["claude", "codex", "antigravity", "grok", "hermes"]);
+});
+
 describe("cache + invalidate", () => {
   it("caches across calls and refreshes only after invalidate", () => {
     const a = getModelRegistry(cfg({}));

--- a/packages/jinn/src/shared/models.ts
+++ b/packages/jinn/src/shared/models.ts
@@ -54,6 +54,8 @@ import {
 /** Engines registered in this build (mirrors server.ts engine map). */
 const ENGINE_NAMES = ["claude", "codex", "antigravity", "grok", "pi", "hermes"] as const;
 export type EngineName = (typeof ENGINE_NAMES)[number];
+export const PTY_VIEW_ENGINE_NAMES = ["claude", "codex", "antigravity", "grok", "hermes"] as const; // engines with a /ws/pty view
+export type PtyViewEngineName = (typeof PTY_VIEW_ENGINE_NAMES)[number];
 
 /** Binary name probed for each engine's availability (override via engines.<name>.bin). */
 const ENGINE_BIN: Record<EngineName, string> = {
@@ -366,7 +368,7 @@ export function buildRegistry(config: JinnConfig): ModelRegistry {
       ? fromEngineModelsConfig(name, engineBlock, available)
       : synthesized[name]; // engine omitted from the block → keep the synthesized entry
   }
-  return registry;
+  return Object.fromEntries(ENGINE_NAMES.map((n) => [n, { ...registry[n], supportsPty: (PTY_VIEW_ENGINE_NAMES as readonly string[]).includes(n) }])) as ModelRegistry;
 }
 
 /**

--- a/packages/jinn/src/shared/types.ts
+++ b/packages/jinn/src/shared/types.ts
@@ -768,6 +768,7 @@ export interface EngineRegistryEntry {
   defaultModel: string;
   effortMechanism: EffortMechanism;
   models: ModelInfo[];
+  supportsPty?: boolean; // interactive PTY/CLI view (`/ws/pty`) — stamped by buildRegistry
 }
 
 /** Resolved registry, keyed by engine name. */

--- a/packages/web/src/components/chat/chat-pane.tsx
+++ b/packages/web/src/components/chat/chat-pane.tsx
@@ -15,7 +15,7 @@ import { useLiveSession } from '@/hooks/use-live-session'
 const CliTerminal = lazy(() => import('@/components/cli-terminal').then(m => ({ default: m.CliTerminal })))
 import type { CliTerminalHandle } from '@/components/cli-terminal'
 import { buildNewSessionParams, resolveNewSessionSelector, shouldPersistNewSessionSelector } from '@/components/chat/new-chat-helpers'
-import type { Employee } from '@/lib/api'
+import type { Employee, EnginesResponse } from '@/lib/api'
 import type { Message, MediaAttachment } from '@/lib/conversations'
 
 // The live read pipeline (load/WS/reconnect/watchdog) now lives in
@@ -26,7 +26,6 @@ export { shouldRecoverStuckTurn } from '@/hooks/use-live-session'
 type Listener = (event: string, payload: unknown) => void
 
 const NEW_SESSION_SELECTOR_KEY = 'jinn-chat-new-session-selector'
-const CLI_CAPABLE_ENGINES = new Set(['claude', 'codex', 'antigravity', 'grok'])
 
 function readNewSessionSelector(): SelectorValue {
   if (typeof window === 'undefined') return {}
@@ -53,14 +52,6 @@ function writeNewSessionSelector(value: SelectorValue): void {
   }))
 }
 
-function supportsCli(engine: string | undefined): boolean {
-  return !!engine && CLI_CAPABLE_ENGINES.has(engine)
-}
-
-function supportsCliPreference(engine: string | undefined): boolean {
-  return !engine || supportsCli(engine)
-}
-
 interface ChatPaneProps {
   sessionId: string | null
   isActive: boolean
@@ -79,6 +70,7 @@ interface ChatPaneProps {
   portalName?: string
   /** Gateway subscribe function for WS events */
   subscribe: (fn: Listener) => () => void
+  engineRegistry?: EnginesResponse // supportsPty decides the CLI/xterm affordance
   /** Gateway connection seq number - triggers reload on reconnect */
   connectionSeq?: number
   /** Gateway skills version */
@@ -112,6 +104,7 @@ export function ChatPane({
   onRefresh,
   portalName = 'Jinn',
   subscribe,
+  engineRegistry,
   connectionSeq,
   skillsVersion,
   events,
@@ -358,7 +351,7 @@ export function ChatPane({
             effortLevel: selector.effortLevel,
             speech,
           })
-          if (viewMode === 'cli' && supportsCliPreference(selector.engine)) (params as Record<string, unknown>).mode = 'interactive'
+          if (viewMode === 'cli' && (!selector.engine || engineRegistry?.engines?.[selector.engine]?.supportsPty)) (params as Record<string, unknown>).mode = 'interactive'
           const session = (await api.createSession(params)) as Record<string, unknown>
           if (shouldPersistNewSessionSelector({ selectedEmployee, manuallyChanged: newSessionSelectorDirtyRef.current })) {
             writeNewSessionSelector(selector)
@@ -369,7 +362,7 @@ export function ChatPane({
         } else {
           // CLI view → route to the interactive PTY engine so the user sees the prompt
           // get injected into the live xterm + claude's streaming response.
-          const mode = viewMode === 'cli' && supportsCli(currentSession?.engine as string | undefined) ? 'interactive' : undefined
+          const mode = viewMode === 'cli' && engineRegistry?.engines?.[String(currentSession?.engine ?? '')]?.supportsPty ? 'interactive' : undefined
           await api.sendMessage(sid, { message, interrupt: interrupt || undefined, attachments: attachmentIds, mode, speech: speech || undefined })
           onRefresh?.()
         }
@@ -380,7 +373,7 @@ export function ChatPane({
     // viewMode MUST be in deps — without it, toggling chat↔CLI keeps the stale
     // closure value and routes CLI sends to the headless engine, which is
     // exactly what made "the xterm shows stale content" reproducible.
-    [sessionId, selectedEmployee, onSessionCreated, onRefresh, viewMode, selector, currentSession?.engine, beginSend, failSend]
+    [sessionId, selectedEmployee, onSessionCreated, onRefresh, viewMode, selector, currentSession?.engine, engineRegistry, beginSend, failSend]
   )
 
   const handleStatusRequest = useCallback(async () => {

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -287,6 +287,7 @@ export interface EngineRegistryEntry {
   defaultModel: string;
   effortMechanism: "claude-flag" | "codex-config" | "grok-flag" | "pi-flag" | "none";
   models: ModelInfo[];
+  supportsPty?: boolean; // interactive PTY/CLI view (`/ws/pty`)
 }
 export interface EnginesResponse {
   default: string;

--- a/packages/web/src/routes/chat/page.tsx
+++ b/packages/web/src/routes/chat/page.tsx
@@ -12,6 +12,7 @@ import {
   type ThreadOrigin,
 } from '@/components/chat/chat-route-helpers'
 import { useGateway } from '@/hooks/use-gateway'
+import { useModelRegistry } from '@/hooks/use-model-registry'
 import { PageLayout } from '@/components/page-layout'
 import { ChatSidebar, pickDeleteFallbackId, type SidebarOrder } from '@/components/chat/chat-sidebar'
 import { ChatHeaderPills } from '@/components/chat/chat-tabs'
@@ -205,6 +206,7 @@ function ChatPage() {
   const [focusTrigger, setFocusTrigger] = useState(0)
   const sessionPickerRef = useRef<HTMLDivElement>(null)
   const { events, connectionSeq, skillsVersion, subscribe } = useGateway()
+  const { data: engineRegistry } = useModelRegistry() // PTY capability per engine — drives the CLI view toggle
   const chatTabs = useChatTabs()
   const deleteSessionMutation = useDeleteSession()
   const archiveSessionMutation = useArchiveSession()
@@ -881,7 +883,7 @@ function ChatPage() {
     // instead of ChatPane, but the underlying session selection is preserved.
   }, [chatTabs.hydrated, chatTabs.activeTab, selectedId, handleSelect, navigate])
 
-  const cliModeAvailable = !sessionMeta?.engine || ['claude', 'codex', 'antigravity', 'grok'].includes(sessionMeta.engine)
+  const cliModeAvailable = !sessionMeta?.engine || engineRegistry?.engines?.[sessionMeta.engine]?.supportsPty === true
   const activeSessionTab = chatTabs.activeTab?.kind === 'session' ? chatTabs.activeTab : null
   const viewSwitchLocked = sessionMeta?.engine === 'codex' && activeSessionTab?.sessionId === selectedId && activeSessionTab.status === 'running'
   const cliTitle = viewSwitchLocked
@@ -1146,6 +1148,7 @@ function ChatPage() {
                 onRefresh={handleRefresh}
                 portalName={portalName}
                 subscribe={subscribe}
+                engineRegistry={engineRegistry}
                 connectionSeq={connectionSeq}
                 skillsVersion={skillsVersion}
                 events={events}

--- a/packages/web/src/routes/limits/page.tsx
+++ b/packages/web/src/routes/limits/page.tsx
@@ -8,7 +8,6 @@ import { useBreadcrumbs } from "@/context/breadcrumb-context"
 import { Skeleton } from "@/components/ui/skeleton"
 import { deriveFreshness, useEngineLimits, type FreshnessKind } from "./use-engine-limits"
 
-const FEATURED_ENGINES = ["claude", "codex", "grok"]
 const DANGER = 90
 
 function formatDuration(minutes?: number) {
@@ -191,8 +190,6 @@ export default function LimitsPage() {
   useBreadcrumbs([{ label: 'Limits' }])
   const { data, phase, refreshing, error, now, refresh } = useEngineLimits()
 
-  const engines = FEATURED_ENGINES.map((name) => data?.engines[name]).filter(Boolean) as EngineLimitEngineSnapshot[]
-
   return (
     <PageLayout>
       {/* Same page frame as Todos: one scrolling column, inline large-title
@@ -234,7 +231,7 @@ export default function LimitsPage() {
             </div>
           ) : (
             <div className="grid items-start gap-4 md:grid-cols-2">
-              {engines.map((engine) => (
+              {Object.values(data?.engines ?? {}).map((engine) => (
                 <EngineCard key={engine.name} engine={engine} now={now} />
               ))}
             </div>

--- a/packages/web/src/routes/settings/page.tsx
+++ b/packages/web/src/routes/settings/page.tsx
@@ -1303,7 +1303,7 @@ export default function SettingsPage() {
 
                 <FieldRow label="When Claude Hits Usage Limit">
                   <SettingsSelect
-                    value={config.sessions?.rateLimitStrategy ?? "fallback"}
+                    value={config.sessions?.rateLimitStrategy ?? "wait"}
                     onChange={(v) =>
                       updateConfig(["sessions", "rateLimitStrategy"], v)
                     }

--- a/packages/web/src/routes/settings/page.tsx
+++ b/packages/web/src/routes/settings/page.tsx
@@ -213,7 +213,7 @@ function SettingsSelect({
 }: {
   value: string
   onChange: (v: string) => void
-  options: { value: string; label: string }[]
+  options: { value: string; label: string; disabled?: boolean }[]
 }) {
   return (
     <select
@@ -222,7 +222,7 @@ function SettingsSelect({
       className={`${CONTROL_CLASS} cursor-pointer`}
     >
       {options.map((o) => (
-        <option key={o.value} value={o.value}>
+        <option key={o.value} value={o.value} disabled={o.disabled}>
           {o.label}
         </option>
       ))}
@@ -1047,11 +1047,7 @@ export default function SettingsPage() {
                   <SettingsSelect
                     value={config.engines?.default ?? "claude"}
                     onChange={(v) => updateConfig(["engines", "default"], v)}
-                    options={[
-                      { value: "claude", label: "Claude" },
-                      { value: "codex", label: "Codex" },
-                      { value: "grok", label: "Grok" },
-                    ]}
+                    options={Object.values(modelRegistry?.engines ?? {}).map((e) => ({ value: e.name, label: e.name.charAt(0).toUpperCase() + e.name.slice(1), disabled: !e.available }))}
                   />
                 </FieldRow>
               </Section>


### PR DESCRIPTION
## Selected area

The web dashboard's engine vocabulary. Four separate hardcoded engine lists in
`packages/web/src` each spelled their own answer to "which engines exist" and
"which engines can show a CLI view", while the gateway already owned that truth
in its engine registry and served it at `GET /api/engines`.

## Evidence of blended concerns

The derivation rails already existed and these four copies simply never boarded
them. `hooks/use-model-registry.ts` fetches and caches `GET /api/engines`,
`model-selector-row.tsx` already derives its engine list from it, and
`routes/settings/page.tsx` already called `useModelRegistry()` for a different
purpose. The duplicates:

1. `components/chat/chat-pane.tsx` - `CLI_CAPABLE_ENGINES`, a 4-engine set that
   omitted `hermes`. Live defect: the Hermes CLI view was unreachable even though
   the gateway routes Hermes over `/ws/pty`.
2. `routes/chat/page.tsx` - a verbatim inline duplicate of that same 4-engine array.
3. `routes/settings/page.tsx` - Default Engine options hardcoded 3 of the 6
   registered engines, so a config default such as `hermes` could not render as a
   valid selected option.
4. `routes/limits/page.tsx` - `FEATURED_ENGINES`, a third and different 3-engine
   spelling.

The underlying wire fact was never published: `gateway/server.ts` `ptyViewEngines`
(claude, codex, antigravity, grok, hermes) is what `/ws/pty` routes by, but no
endpoint ever told the client about it. Every client-side list was therefore a
guess at server state, which is why three of them disagreed and one was wrong.

A second, unrelated display defect was found in the same file and fixed in its own
commit: Settings rendered the rate-limit strategy default as `fallback` while the
gateway resolves it to `wait`.

## Fixed constraint budget

Frozen before any product-code edit:

| Field | Budget |
|---|---|
| netLineDelta | <= 0 |
| maxFilesTouched | 9 |
| maxNewFiles | 0 |
| maxFileLines | 1909 |

No new dependencies, no new config options, no single-caller abstractions, no new
files. The only new public export is the PTY-capable engine list plus its name
type, born with two real consumers.

## Measured budget output

Real output of the frozen budget command, run against base
`23df25ed62acfa162a39923638eb14dbbf1d8bea`:

```
netLineDelta=0
filesTouched=9
newFiles=0
maxFileLines=1905
```

All four measures are within budget. Per-file numbers:

```
 3	 2	packages/jinn/src/gateway/server.ts
 6	 0	packages/jinn/src/shared/__tests__/models.test.ts
 3	 1	packages/jinn/src/shared/models.ts
 1	 0	packages/jinn/src/shared/types.ts
 6	13	packages/web/src/components/chat/chat-pane.tsx
 1	 0	packages/web/src/lib/api.ts
 4	 1	packages/web/src/routes/chat/page.tsx
 1	 4	packages/web/src/routes/limits/page.tsx
 4	 8	packages/web/src/routes/settings/page.tsx
```

The three web files that were not allowed to grow all shrank.

## What was deleted or clarified

Published the capability once, then deleted every client-side guess:

- `shared/models.ts` exports one PTY-capable engine name tuple and its derived
  name type; `EngineRegistryEntry` gains `supportsPty`, stamped in `buildRegistry`
  so all served entries inherit it. `GET /api/engines` now carries it.
- `gateway/server.ts` types `ptyViewEngines` as a `Record` over that name type, so
  the PTY router and the served wire field cannot drift apart without a type error.
  Membership is unchanged: claude, codex, antigravity, grok, hermes.
- Deleted `CLI_CAPABLE_ENGINES` and its `supportsCli` / `supportsCliPreference`
  helper pair from `chat-pane.tsx`, and the inline duplicate array in
  `chat/page.tsx`. Both now read `supportsPty` from the served registry. A new chat
  with no engine chosen still behaves as before.
- Settings Default Engine options now enumerate the served registry. Unavailable
  engines render disabled rather than being omitted, so a configured default is
  always representable.
- Deleted `FEATURED_ENGINES`; the Limits page derives its cards from the served
  payload in registry order. `shared/engine-limits.ts` `LIVE_LIMIT_ENGINES` is
  untouched.
- Fixed the Settings rate-limit default display from `fallback` to `wait` in its
  own commit, so it can be reverted independently.

Net effect: the Hermes CLI view becomes reachable, the three disagreeing lists
collapse into one server-owned answer, and `grep -rn "CLI_CAPABLE_ENGINES\|FEATURED_ENGINES" packages/web/src`
now prints nothing.

A drift guard was added to the existing `shared/__tests__/models.test.ts`: registry
keys must equal the literal 6-engine list, and the `supportsPty` subset must equal
the literal 5-engine PTY list. The literals are the point, since a seventh engine
now has to consciously update them. No test was deleted.

## Test results

All three gates run fresh after the final commit, with turbo cache bypassed.

`pnpm typecheck`:

```
 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    5.108s
```

`pnpm test`:

```
 Test Files  309 passed (309)
      Tests  3829 passed | 1 skipped (3830)
   Duration  36.52s

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
```

`turbo run build --force`:

```
✓ built in 4.93s

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    5.693s
```

### Note on flaky intermediate runs

Several earlier full-suite runs on this machine failed with `waitFor` and hook
timeouts in `routes/todos/*` and `activity/performance.test.ts`. These were traced
to ambient machine load (load average peaked above 30 from Spotlight indexing and
unrelated processes), not to this change:

- The failing tests do not import any changed module. The only changed file they
  reach is `lib/api.ts`, whose edit is an optional field on an `interface` and is
  fully erased at compile time. The emitted JS for `api.ts` is byte-identical at
  base and head (verified by transpiling both revisions and comparing output).
- An interleaved base/head A/B of the affected tests passed 3/3 on both revisions
  once load subsided.
- Suite duration for identical code swung between 21s and 83s across runs, tracking
  ambient load rather than revision.

The gate output quoted above is a clean full pass at head `1fb91fc4`.
