### PR TITLE
PLA-58: give cron expression and timezone one validated owner

### DIFF
--- a/packages/jinn/src/workflows/__tests__/service-validation.test.ts
+++ b/packages/jinn/src/workflows/__tests__/service-validation.test.ts
@@ -30,6 +30,8 @@ const scheduleTrigger: WorkflowNode = { id: "start", type: "trigger", name: "Sta
   config: { kind: "schedule", cron: "0 * * * *", timezone: "UTC" } };
 const eventTrigger: WorkflowNode = { id: "start", type: "trigger", name: "Start",
   config: { kind: "event", eventName: "build.finished" } };
+const poisonSchedule: WorkflowNode = { id: "start", type: "trigger", name: "Start",
+  config: { kind: "schedule", cron: "every weekday please", timezone: "UTC" } };
 const finish: WorkflowNode = { id: "finish", type: "end", name: "Finish", config: { result: "success" } };
 const employee: Employee = { name: "worker", displayName: "Worker", department: "operations", rank: "employee",
   engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work." };
@@ -199,6 +201,36 @@ describe("Workflow executable service boundaries", () => {
     }
     expect(repository.getDefinition(authored.id)).toEqual(authored);
     expect(definitionChanges).toEqual([{ workflowId: authored.id, revision: authored.revision }]);
+  });
+
+  it("refuses an unparseable Schedule cron expression on save and on enable", () => {
+    const created = service.createDefinition({ id: "poison-schedule", title: "Poison schedule" });
+    const poison = { ...created, nodes: [poisonSchedule, finish], edges: [edge("start-finish", "start", "finish")] };
+    const expected = new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.",
+      [{ code: "invalid-schedule", message: "schedule must be a valid cron expression", nodeId: "start", path: "config.cron" }]);
+    definitionChanges.length = 0;
+    let saveError: unknown;
+    let enableError: unknown;
+
+    try { service.saveDefinition(poison, created.revision); } catch (error) { saveError = error; }
+    expect(saveError).toEqual(expected);
+    expect(repository.getDefinition(created.id)).toEqual(created);
+
+    // Seeded past the gate, exactly as a row authored before it existed would be.
+    const stored = repository.saveDefinition(poison, created.revision);
+    try { service.setEnabled({ id: stored.id, enabled: true, expectedRevision: stored.revision }); }
+    catch (error) { enableError = error; }
+
+    expect(enableError).toEqual(expected);
+    expect(repository.getDefinition(stored.id)).toMatchObject({ enabled: false, revision: stored.revision });
+    expect(definitionChanges).toEqual([]);
+  });
+
+  it("cannot carry a Schedule trigger into createDefinition in the first place", () => {
+    expect(() => service.createDefinition(
+      { id: "created-with-nodes", title: "Created", nodes: [poisonSchedule] } as unknown as { id: string; title: string },
+    )).toThrow(expect.objectContaining<Partial<WorkflowRepositoryError>>({ code: "bad-input" }));
+    expect(repository.getDefinition("created-with-nodes")).toBeNull();
   });
 
   it("keeps valid enable, revision conflicts, and manual dispatch behavior unchanged", async () => {

--- a/packages/jinn/src/workflows/__tests__/validation.test.ts
+++ b/packages/jinn/src/workflows/__tests__/validation.test.ts
@@ -881,3 +881,25 @@ describe('inherited adversarial public seams', () => {
     expect(ownGraph).toEqual(snapshot);
   });
 });
+
+describe('Schedule trigger cron and timezone', () => {
+  function scheduled(cron: string, timezone: string): WorkflowDefinition {
+    return definition(
+      [{ id: 'trigger', type: 'trigger', name: 'trigger', config: { kind: 'schedule', cron, timezone } }, end()],
+      [edge('e1', 'trigger', 'end')],
+    );
+  }
+
+  it('accepts a parseable cron expression paired with a real IANA timezone', () => {
+    expect(validateExecutableWorkflow(scheduled('0 9 * * 1-5', 'Europe/Sofia'))).toEqual({ ok: true, issues: [] });
+  });
+
+  it.each([
+    ['every weekday please', 'UTC', 'config.cron', 'schedule must be a valid cron expression'],
+    ['0 9 * * 1-5', 'Mars/Olympus', 'config.timezone', 'timezone "Mars/Olympus" is not a valid IANA timezone'],
+  ])('reports %j / %j as an invalid-schedule issue on its trigger node', (cron, timezone, path, message) => {
+    const result = validateExecutableWorkflow(scheduled(cron, timezone));
+    expect(result.ok).toBe(false);
+    expect(issue(result, 'invalid-schedule')).toEqual({ code: 'invalid-schedule', message, nodeId: 'trigger', path });
+  });
+});

--- a/packages/jinn/src/workflows/__tests__/workflow-triggers.test.ts
+++ b/packages/jinn/src/workflows/__tests__/workflow-triggers.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../shared/logger.js";
 import type { Employee, ModelRegistry, WorkflowAttemptCommand, WorkflowAttemptCompletionListener } from "../../shared/types.js";
 import type { WorkflowTodoEventClaimOutcome, WorkflowTodoEventFeed, WorkflowTodoStatusEvent } from "../../work-items/workflow-event-feed.js";
 import type { TriggerNode, WorkflowDefinition, WorkflowNode } from "../model.js";
@@ -12,9 +13,17 @@ import type { WorkflowSessionExecutor } from "../session-executor.js";
 import { WorkflowService } from "../service.js";
 
 const scheduled: Array<{ callback: () => void | Promise<void>; stop: ReturnType<typeof vi.fn> }> = [];
-vi.mock("node-cron", () => ({ default: { schedule: vi.fn((_cron, callback) => {
-  const task = { callback, stop: vi.fn() }; scheduled.push(task); return task;
-}) } }));
+// The recorder exists only to fire the callback by hand; construction still goes
+// through the real node-cron, so an invalid expression or timezone throws here
+// exactly as it does in production.
+vi.mock("node-cron", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node-cron")>();
+  return { default: { validate: actual.validate,
+    schedule: vi.fn((expression: string, callback: () => void | Promise<void>, options?: { timezone?: string }) => {
+      actual.schedule(expression, () => {}, { ...options, scheduled: false }).stop();
+      const task = { callback, stop: vi.fn() }; scheduled.push(task); return task;
+    }) } };
+});
 
 const employee: Employee = { name: "worker", displayName: "Worker", department: "operations", rank: "employee",
   engine: "test-engine", model: "test-model", effortLevel: "high", persona: "Complete work." };
@@ -102,6 +111,27 @@ describe("Workflow trigger adapters", () => {
     now = "2026-07-21T13:00:00.000Z"; await scheduled[0]!.callback();
     expect(service.listRuns(definition.id, {}).items).toHaveLength(1);
     service.dispose(); service = buildService(); expect(scheduled).toHaveLength(1);
+  });
+
+  it("skips an already-enabled Schedule whose cron expression is invalid instead of failing to build", () => {
+    const warnings: string[] = [];
+    const warn = vi.spyOn(logger, "warn").mockImplementation((message: string) => { warnings.push(message); });
+    const trigger: WorkflowNode = { id: "start", type: "trigger", name: "Schedule",
+      config: { kind: "schedule", cron: "every weekday please", timezone: "UTC" } };
+    const work: WorkflowNode = { id: "work", type: "employee", name: "Work", config: {
+      employee: { source: "fixed", value: "worker" }, prompt: "Do work." } };
+    const finish: WorkflowNode = { id: "finish", type: "end", name: "Finish", config: { result: "success" } };
+    const draft = service.createDefinition({ id: "poison-schedule", title: "poison-schedule" });
+    // Seeded past the service gate, as a row authored before it existed would be.
+    const stored = repository.saveDefinition({ ...draft, nodes: [trigger, work, finish],
+      edges: [edge("trigger-work", "start", "work"), edge("work-end", "work", "finish")] }, draft.revision);
+    repository.setEnabled(stored.id, true, stored.revision);
+
+    service.dispose(); service = buildService();
+
+    expect(scheduled).toHaveLength(0);
+    expect(warnings).toEqual([expect.stringContaining("poison-schedule")]);
+    warn.mockRestore();
   });
 
   it("claims the existing Todo feed against its enabled in-memory index without duplicate fires", async () => {

--- a/packages/jinn/src/workflows/service.ts
+++ b/packages/jinn/src/workflows/service.ts
@@ -16,7 +16,7 @@ import type { WorkflowError, WorkflowRunDetail } from "./runtime.js";
 import { WorkflowRunner, type WorkflowTodoApprovalMirror, type WorkflowTodoLifecycle, type WorkflowTodoSessionLink } from "./runner.js";
 import type { WorkflowSessionExecutor } from "./session-executor.js";
 import { WorkflowTriggerService, type FireWorkflowEventInput } from "./trigger-service.js";
-import { validateExecutableWorkflow, type WorkflowValidationIssue } from "./validation.js";
+import { scheduleTriggerIssues, validateExecutableWorkflow, type WorkflowValidationIssue } from "./validation.js";
 
 export { WorkflowRepositoryError };
 export type { FireWorkflowEventInput };
@@ -220,6 +220,10 @@ export class WorkflowService {
     const value = this.options.repository.createDefinition(input); this.definitionChanged(value); return value;
   }
   saveDefinition(definition: WorkflowDefinition, expectedRevision: number): WorkflowDefinition {
+    // Saving a revision of an already-enabled Workflow bypasses the enable gate,
+    // so an unarmable schedule is refused here before it can become durable.
+    const issues = scheduleTriggerIssues(definition);
+    if (issues.length > 0) throw new WorkflowServiceError("invalid-definition", "Workflow definition is invalid.", issues);
     const value = this.options.repository.saveDefinition(definition, expectedRevision); this.definitionChanged(value); return value;
   }
   duplicateDefinition(sourceId: WorkflowId, input: { id: WorkflowId; title: string }): WorkflowDefinition {

--- a/packages/jinn/src/workflows/trigger-service.ts
+++ b/packages/jinn/src/workflows/trigger-service.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import cron, { type ScheduledTask } from "node-cron";
+import { validateCronSchedule } from "../cron/validation.js";
 import { logger } from "../shared/logger.js";
 import { normalizeLabelName } from "../work-items/labels.js";
 import { createWorkflowTodoEventFeed, type WorkflowTodoEventClaimOutcome,
@@ -101,6 +102,14 @@ export class WorkflowTriggerService {
 
   private addSchedule(definition: WorkflowDefinition, schedule: TriggerNode): void {
     if (schedule.config.kind !== "schedule") return;
+    // A row stored before the authoring gate existed can still be unarmable;
+    // skip-and-log it exactly as the Cron scheduler does, rather than throwing
+    // out of rebuild() and taking the whole gateway down at boot.
+    const errors = validateCronSchedule({ schedule: schedule.config.cron, timezone: schedule.config.timezone });
+    if (errors.length > 0) {
+      logger.warn(`Skipping invalid Workflow schedule "${definition.id}": ${errors.map((error) => error.message).join("; ")}`);
+      return;
+    }
     const revision = definition.revision;
     const task = cron.schedule(schedule.config.cron, () => { void this.fireSchedule(definition.id, revision); },
       { timezone: schedule.config.timezone });

--- a/packages/jinn/src/workflows/validation.ts
+++ b/packages/jinn/src/workflows/validation.ts
@@ -8,6 +8,7 @@ import {
   type WorkflowNode,
 } from './model.js';
 import { validateBindingPath } from './bindings.js';
+import { validateCronSchedule } from '../cron/validation.js';
 import type { WorkflowValidationIssue } from './issues.js';
 
 export type { WorkflowValidationIssue } from './issues.js';
@@ -339,6 +340,21 @@ function finalizeIssues(issues: WorkflowValidationIssue[], nodes: WorkflowNode[]
   });
 }
 
+/** A Schedule trigger declares the same two strings a Cron job does, so Cron's
+ *  validator owns them here too — otherwise `z.string()` lets an unparseable
+ *  expression become a durable enabled row that only fails when it is armed. */
+export function scheduleTriggerIssues(definition: WorkflowDefinition): WorkflowValidationIssue[] {
+  const issues: WorkflowValidationIssue[] = [];
+  for (const node of safeDefinition(definition)?.nodes ?? []) {
+    if (node.type !== 'trigger' || node.config.kind !== 'schedule') continue;
+    for (const error of validateCronSchedule({ schedule: node.config.cron, timezone: node.config.timezone })) {
+      issues.push({ code: 'invalid-schedule', message: error.message, nodeId: node.id,
+        path: error.field === 'schedule' ? 'config.cron' : 'config.timezone' });
+    }
+  }
+  return issues;
+}
+
 export function validateExecutableWorkflow(definition: WorkflowDefinition): { ok: boolean; issues: WorkflowValidationIssue[] } {
   const safe = safeDefinition(definition);
   if (!safe) return {
@@ -356,6 +372,7 @@ export function validateExecutableWorkflow(definition: WorkflowDefinition): { ok
   addCycleIssues(nodes, graph, add);
   addCardinalityIssues(nodes, graph, add);
   addReachabilityIssues(nodes, graph, add);
+  for (const item of scheduleTriggerIssues(safe)) add(item);
   const issues = finalizeIssues(collected, nodes, edges);
   return { ok: issues.length === 0, issues };
 }


### PR DESCRIPTION
## Selected area

Cron expression + timezone validation, which had **two independent declarations** across the gateway: the Cron subsystem (`cron/validation.ts`, backed by `node-cron`) and the Workflow schedule trigger (`workflows/model.ts`, backed by a bare `z.string()`).

## Evidence of blended concerns

A Workflow schedule trigger declares exactly the same two strings a Cron job does (`cron`, `timezone`), but nothing validated them:

- `validateExecutableWorkflow` checked graph shape only — it never looked at the two schedule strings, so `enable` accepted an unparseable expression.
- `saveDefinition` had no schedule check at all. Saving a new revision of an **already-enabled** Workflow skips the enable gate entirely, so a poison expression could be written straight to durable storage.
- The only place the string was ever actually parsed was `WorkflowTriggerService.addSchedule`, calling `cron.schedule(...)` unguarded. `node-cron` throws on a bad expression, that throw escapes `rebuild()`, and `rebuild()` runs at construction — so a single bad stored row **crashes the gateway at boot**, with no path to fix it from the UI.

Meanwhile the Cron subsystem already had the right answer for the identical problem: validate first, and skip-and-log a bad job rather than throw. The duplication here was not a second copy of a parser to delete — it was a second, *unvalidated* declaration of the same concept. Closing it is therefore additive by nature.

## Fixed constraint budget

Frozen in `PLAN.md` before implementation:

| Field | Budget |
| --- | --- |
| `netLineDelta` | ≤ +160 (product code ≤ +35 of that) |
| `filesTouched` | ≤ 6 |
| `newFiles` | 0 |
| `maxFileLines` | ≤ 950 |
| New dependencies / config options / package-boundary exports | none |

## Measured budget (actual output)

Command run from the worktree root against base `2c00eb58d39cb060047aba28ff2d3de18a1b86fb`:

```
netLineDelta=114
filesTouched=6
newFiles=0
maxFileLines=     905
```

Product-code net is **+30** of the 114 (≤ 35); the remaining +84 is the three mandated regression tests. Every field is inside budget.

## What was deleted or clarified

`cron/validation.ts` is now the single owner of both strings. Three product files, +30 net lines:

1. **`workflows/validation.ts`** — new `scheduleTriggerIssues(definition)` maps each `validateCronSchedule` error onto the existing `WorkflowValidationIssue` shape (`code: 'invalid-schedule'`, with the offending `nodeId` and a `config.cron` / `config.timezone` path). Wired into `validateExecutableWorkflow` alongside the existing passes, which gates enable, manual start, workflow-call, and the runner's own recheck in one place.
2. **`workflows/service.ts`** — `saveDefinition` runs the same check before the repository write and throws the same `WorkflowServiceError("invalid-definition", …)` shape `assertExecutableWorkflow` already throws, so existing HTTP/MCP/CLI issue rendering works unchanged. This closes the durable-poison path.
3. **`workflows/trigger-service.ts`** — `addSchedule` validates before `cron.schedule`, and on error logs and returns instead of arming. This mirrors `cron/scheduler.ts` exactly, and it is what stops a legacy poison row from bricking boot.

No new abstraction, no validation framework, no new dependency, and no new package-boundary export. The one new module export, `scheduleTriggerIssues`, has two real callers. `cron/validation.ts`, `cron/scheduler.ts`, and `gateway/api.ts` are **byte-identical to base** — Cron's own semantics are untouched.

Ownership assertions on the merged tree:

```
cron.validate( hits in workflows/: 0
validateCronSchedule referenced only in:
  packages/jinn/src/workflows/validation.ts
  packages/jinn/src/workflows/trigger-service.ts
cron/ + gateway/api.ts files changed: 0
```

## Test results

Four new cases across three **existing** test files (no new files):

- `validation.test.ts` — an invalid expression and a non-IANA timezone each produce an `invalid-schedule` issue carrying the trigger's `nodeId`; a valid pair produces none.
- `service-validation.test.ts` — `setEnabled` and `saveDefinition` refuse a poison schedule trigger with structured issues, and no enabled row is persisted.
- `workflow-triggers.test.ts` — with a poison row seeded directly into the repository (bypassing the gate, as a legacy row would), constructing `WorkflowTriggerService` does not throw, the schedule is skipped, and the skip is logged.

All four were reproduced **red on base** in a throwaway worktree: the trigger-service case crashes inside real `node-cron` construction, which is the boot-brick this change fixes. All 94 pre-existing tests in those files stayed green.

Gates, run uncached after the final commit:

```
pnpm typecheck  →  Tasks: 2 successful, 2 total   (Cached: 0 cached, 2 total)
pnpm test       →  Test Files 310 passed (310)
                   Tests 3841 passed | 1 skipped (3842)
pnpm build      →  Tasks: 2 successful, 2 total
                   synced packages/web/out -> packages/jinn/dist/web
```

## Known deviations and follow-ups

- **The `cron` → `schedule` field rename is deliberately not here.** The field is persisted inside stored definitions under `z.strictObject`, so renaming it needs a repository migration plus editor and web changes. That is a separate, larger change and no acceptance criterion required it. Proposed as a follow-up Todo rather than smuggled into this diff.
- `createDefinition` refuses a poison definition via a repository `bad-input` error rather than `WorkflowServiceError` — `CreateWorkflowInput` structurally cannot carry nodes, so the poison cannot reach that path in the shape the plan assumed. The substance (no row persisted) is proven; the error type differs.
- `pnpm lint` is a repo-wide no-op today: the turbo task exists but no package defines a `lint` script, so that gate passes vacuously. Pre-existing, unrelated to this change, flagged for visibility.
- `PLAN.md` on `main` still holds a stale plan from an earlier ticket. Replaced on this branch per convention; the copy on `main` is an adjacent problem, reported not fixed.
