### PR TITLE
fix(claude): strip suggestion blocks from stored assistant messages

### DIFF
--- a/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
+++ b/packages/jinn/src/engines/__tests__/claude-interactive.test.ts
@@ -10,7 +10,7 @@ import path from "node:path";
 // focused and CI-portable.
 vi.mock("node-pty", () => ({ spawn: vi.fn() }));
 
-import { SUBMIT_ACK_HOOKS, InteractiveClaudeEngine, TurnResolver, buildAttachmentSuffix, buildInteractiveArgs, claudeHookToDeltas, computeInteractiveCost, neutralizeImagePathsForPaste, pasteAndSubmit, shouldSettleStalledTurn, sumTranscriptUsage } from "../claude-interactive.js";
+import { SUBMIT_ACK_HOOKS, InteractiveClaudeEngine, TurnResolver, buildAttachmentSuffix, buildInteractiveArgs, claudeHookToDeltas, computeInteractiveCost, neutralizeImagePathsForPaste, pasteAndSubmit, sanitizeAssistantText, shouldSettleStalledTurn, stripSuggestionBlocks, sumTranscriptUsage } from "../claude-interactive.js";
 import { costOfUsage } from "../../shared/model-pricing.js";
 import { MAIN_AGENT_SENTINEL } from "../sse-pty-proxy.js";
 import { buildPromptWithPlatformContext } from "../platform-context.js";
@@ -132,6 +132,98 @@ describe("TurnResolver", () => {
     const v = await r.promise;
     expect(v.result).toBe("Visible transcript answer.");
     expect(v.result).not.toContain("private transcript reasoning");
+  });
+
+  /**
+   * Issue #102. The Stop hook's last_assistant_message is the message another agent
+   * later reads via read_session, so this is the path where a model-generated
+   * "suggested next user turn" becomes indistinguishable from an operator instruction.
+   * The observed shape is a suggestion fused to the FRONT of a genuine reply with no
+   * separator — so the block is stripped and the real reply must survive intact.
+   */
+  it("strips a suggestion block fused to the front of a Stop hook reply, keeping the reply", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "warm-sid", assumeStarted: true });
+    r.onHook({
+      hook_event_name: "Stop",
+      last_assistant_message: "<suggestion>go with literal source == 'human' and re-arm</suggestion>Forge's stand-down confirms the rollback landed.",
+    });
+    const v = await r.promise;
+    expect(v.result).toBe("Forge's stand-down confirms the rollback landed.");
+    expect(v.result).not.toContain("re-arm");
+    expect(v.result).not.toContain("suggestion");
+  });
+
+  it("settles empty when a Stop hook message is nothing but a suggestion block", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "warm-sid", assumeStarted: true });
+    r.onHook({
+      hook_event_name: "Stop",
+      last_assistant_message: "  <suggestion>Sounds good, keep going</suggestion>  ",
+    });
+    const v = await r.promise;
+    expect(v.result).toBe("");
+  });
+
+  it("strips a suggestion block from recovered transcript text", async () => {
+    const r = new TurnResolver({ fallbackSessionId: "old" });
+    r.onHook({ hook_event_name: "SessionStart", session_id: "c1" });
+    r.completeRecovered("<suggestion>keep going</suggestion>Leg 1 returned.", "c1");
+    const v = await r.promise;
+    expect(v.result).toBe("Leg 1 returned.");
+    expect(v.result).not.toContain("keep going");
+  });
+});
+
+/**
+ * Issue #102: `<suggestion>` is a Claude-engine "suggested next user turn". Jinn has no
+ * producer or consumer for it, so it lands in transcripts as assistant content that
+ * other agents read as operator instruction. Strip the block, keep the remainder.
+ */
+describe("stripSuggestionBlocks", () => {
+  it("strips a complete block and keeps the genuine reply fused behind it", () => {
+    expect(stripSuggestionBlocks("<suggestion>archive the test todos</suggestion>CTO's message crossed."))
+      .toBe("CTO's message crossed.");
+  });
+
+  it("keeps text that precedes the block", () => {
+    expect(stripSuggestionBlocks("Report filed.<suggestion>keep going</suggestion>")).toBe("Report filed.");
+  });
+
+  it("leaves a message with no suggestion block byte-identical apart from trim", () => {
+    expect(stripSuggestionBlocks("Plain answer with a < sign and </suggestions> nearby."))
+      .toBe("Plain answer with a < sign and </suggestions> nearby.");
+  });
+
+  it("strips every block when several appear", () => {
+    expect(stripSuggestionBlocks("<suggestion>a</suggestion>real<suggestion>b</suggestion>tail"))
+      .toBe("realtail");
+  });
+
+  it("tolerates attributes, whitespace and mixed case in the tag", () => {
+    expect(stripSuggestionBlocks('<Suggestion type="reply" >keep going< / SUGGESTION >Answer.'))
+      .toBe("Answer.");
+  });
+
+  /** Edge case from the report: message ends inside an open block. Fail closed. */
+  it("strips to end of string for an unterminated block", () => {
+    expect(stripSuggestionBlocks("Answer.<suggestion>wrap up and report to Onyx when"))
+      .toBe("Answer.");
+  });
+
+  /** Edge case from the report: message ends part-way through the opening tag. */
+  it("strips a truncated opening tag at end of string", () => {
+    expect(stripSuggestionBlocks("Answer.<sugges")).toBe("Answer.");
+    expect(stripSuggestionBlocks("Answer.<suggestion")).toBe("Answer.");
+  });
+
+  it("returns empty for a standalone block so callers can drop the message", () => {
+    expect(stripSuggestionBlocks("<suggestion>Onyx will handle archiving those</suggestion>")).toBe("");
+  });
+});
+
+describe("sanitizeAssistantText", () => {
+  it("strips reasoning and suggestion blocks together", () => {
+    expect(sanitizeAssistantText("<thinking>private</thinking><suggestion>keep going</suggestion>Visible answer."))
+      .toBe("Visible answer.");
   });
 });
 

--- a/packages/jinn/src/engines/__tests__/compaction-stream-gate.test.ts
+++ b/packages/jinn/src/engines/__tests__/compaction-stream-gate.test.ts
@@ -97,4 +97,81 @@ describe("CompactionStreamGate", () => {
     const out = [...gate.accept(text("Real reply.")), ...gate.end()];
     expect(joined(out)).toBe("Real reply.");
   });
+
+  /**
+   * Issue #102. `<suggestion>` is a model-generated *suggested next user turn*. It must
+   * not reach the transcript, but unlike `<analysis>` it must be STRIPPED, not dropped:
+   * it is usually fused to the front of a genuine reply, and dropping the message would
+   * trade an information leak for silent data loss.
+   */
+  describe("suggestion blocks", () => {
+    it("strips a leading suggestion block and keeps the reply behind it", () => {
+      const gate = new CompactionStreamGate();
+      const out = [
+        ...gate.accept(text("<suggestion>keep going</suggestion>Leg 1 returned.")),
+        ...gate.end(),
+      ];
+      expect(joined(out)).toBe("Leg 1 returned.");
+      expect(joined(out)).not.toContain("keep going");
+    });
+
+    /** Edge case from the report: the opening tag arrives split across stream deltas. */
+    it("strips a suggestion whose opening tag is split across deltas", () => {
+      const gate = new CompactionStreamGate();
+      const out = [
+        ...gate.accept(text("<sugg")),
+        ...gate.accept(text("estion>only notify me for todos i create")),
+        ...gate.accept(text("</suggestion>CTO's message crossed.")),
+        ...gate.end(),
+      ];
+      expect(joined(out)).toBe("CTO's message crossed.");
+      expect(joined(out)).not.toContain("notify me");
+    });
+
+    it("emits nothing for a standalone suggestion message", () => {
+      const gate = new CompactionStreamGate();
+      const out = [
+        ...gate.accept(text("<suggestion>Sounds good, keep going</suggestion>")),
+        ...gate.end(),
+      ];
+      expect(out).toEqual([]);
+    });
+
+    /** Edge case from the report: the message ends mid-block. Fail closed. */
+    it("fails closed on an unterminated suggestion block", () => {
+      const gate = new CompactionStreamGate();
+      const out = [
+        ...gate.accept(text("<suggestion>go with literal source == 'human'")),
+        ...gate.accept(text(" and re-arm")),
+        ...gate.end(),
+      ];
+      expect(out).toEqual([]);
+    });
+
+    it("releases held text when the opener turns out not to be a suggestion", () => {
+      const gate = new CompactionStreamGate();
+      const out = [
+        ...gate.accept(text("<sug")),
+        ...gate.accept(text("ar is sweet.")),
+        ...gate.end(),
+      ];
+      expect(joined(out)).toBe("<sugar is sweet.");
+    });
+
+    it("forwards the message_start context delta and still strips the suggestion after it", () => {
+      const gate = new CompactionStreamGate();
+      const startDeltas = sseEventToDeltas({
+        type: "message_start",
+        message: { usage: { input_tokens: 4200 } },
+      } as never);
+      gate.reset();
+      const out = [
+        ...gate.accept(startDeltas),
+        ...gate.accept(text("<suggestion>write the final report to Onyx</suggestion>Report written.")),
+        ...gate.end(),
+      ];
+      expect(out.map((d) => d.type)).toEqual(["context", "text"]);
+      expect(joined(out.filter((d) => d.type === "text"))).toBe("Report written.");
+    });
+  });
 });

--- a/packages/jinn/src/engines/claude-interactive.ts
+++ b/packages/jinn/src/engines/claude-interactive.ts
@@ -181,6 +181,36 @@ export function stripReasoningBlocks(text: string): string {
     .trim();
 }
 
+/** The Claude engine emits `<suggestion>…</suggestion>` — a model-generated *suggested
+ *  next user turn*. Jinn has no producer or consumer for the tag, so it lands in stored
+ *  transcripts as `role: "assistant"` content, where another agent reading the session
+ *  cannot tell it from an operator instruction. See issue #102.
+ *
+ *  STRIP, never drop the whole message: the observed shape is most often a suggestion
+ *  fused to the FRONT of a genuine reply with no separator, so dropping would trade an
+ *  information leak for silent data loss. Callers drop only when nothing but whitespace
+ *  survives (the standalone shape). Kept separate from stripReasoningBlocks so private
+ *  reasoning and suggested user turns stay independently testable. */
+export function stripSuggestionBlocks(text: string): string {
+  return text
+    // Complete block, anywhere in the message.
+    .replace(/<\s*suggestion\b[^>]*>[\s\S]*?<\s*\/\s*suggestion\s*>/gi, "")
+    // Opened and never closed (message ends inside the block) — fail closed: everything
+    // from the opening tag on is suggestion text, so strip to end of string.
+    .replace(/<\s*suggestion\b[^>]*>[\s\S]*$/i, "")
+    // Message ends part-way THROUGH the opening tag (`…<sugges`). Nothing genuine can
+    // follow it, and leaving the fragment would leak a half-rendered tag — drop it.
+    .replace(/<\s*s(?:u(?:g(?:g(?:e(?:s(?:t(?:i(?:o(?:n)?)?)?)?)?)?)?)?)?$/i, "")
+    .trim();
+}
+
+/** Every path that stores or relays engine assistant text runs this. The two strippers
+ *  stay separate above; composing them in one place means no call site can accidentally
+ *  apply only one of them. */
+export function sanitizeAssistantText(text: string): string {
+  return stripSuggestionBlocks(stripReasoningBlocks(text));
+}
+
 /** Cost for ONE turn. `afterMs` (the turn's start) scopes the cumulative
  *  transcript to this turn — see sumTranscriptUsage. */
 export function computeInteractiveCost(transcriptPath: string, model?: string, afterMs?: number): { cost: number; turns: number } | null {
@@ -315,17 +345,43 @@ export function sseEventToDeltas(e: SseDataEvent): StreamDelta[] {
  *  and drop the whole message when it matches. */
 const COMPACTION_OPENER = "<analysis>";
 
+/** The other engine meta-tag that must never reach a transcript: a suggested next
+ *  user turn (issue #102). Unlike `<analysis>` this is STRIPPED, not dropped — it is
+ *  usually fused to the front of a genuine reply, so dropping the message would lose
+ *  real content. The gate only needs the head-of-message case; `last_assistant_message`
+ *  is sanitized independently by sanitizeAssistantText, which handles every position. */
+const SUGGESTION_TAG = "<suggestion";
+const SUGGESTION_OPEN_RE = /^<\s*suggestion\b[^>]*>/i;
+const SUGGESTION_CLOSE_RE = /<\s*\/\s*suggestion\s*>/i;
+
+/** True while `s` is still a viable prefix of an opener the gate might act on, so it
+ *  must keep holding rather than latch `pass`. Handles an opening tag split across
+ *  stream deltas (`<sugg` + `estion>`). */
+function couldBeOpener(s: string): boolean {
+  if (!s) return true;
+  if (COMPACTION_OPENER.startsWith(s)) return true; // case-sensitive: unchanged behaviour
+  const lower = s.toLowerCase();
+  if (SUGGESTION_TAG.startsWith(lower)) return true;
+  // `<suggestion …` with attributes still arriving — not yet a prefix of any literal.
+  if (lower.startsWith(SUGGESTION_TAG) && !lower.includes(">")) return true;
+  return false;
+}
+
 /** Per-message gate: buffers the opening text of an assistant message just long
- *  enough to tell a real reply from a compaction summary. Exported for tests. */
+ *  enough to tell a real reply from a compaction summary (dropped whole) or a leading
+ *  suggested-user-turn block (stripped, remainder kept). Exported for tests. */
 export class CompactionStreamGate {
   private held: StreamDelta[] = [];
   private opening = "";
-  private verdict: "undecided" | "pass" | "drop" = "undecided";
+  private verdict: "undecided" | "pass" | "drop" | "stripping" = "undecided";
+  /** Text seen since a `<suggestion>` opener, awaiting its close tag. */
+  private stripBuf = "";
 
   /** A new assistant message started — decide again from scratch. */
   reset(): void {
     this.held = [];
     this.opening = "";
+    this.stripBuf = "";
     this.verdict = "undecided";
   }
 
@@ -335,6 +391,15 @@ export class CompactionStreamGate {
     for (const d of deltas) {
       if (this.verdict === "drop") continue;
       if (this.verdict === "pass") { out.push(d); continue; }
+      // Inside a `<suggestion>` block: swallow text until the close tag, then release
+      // the genuine reply that follows it (and everything after) untouched. A non-text
+      // delta cannot close the block, so it is swallowed too.
+      if (this.verdict === "stripping") {
+        if (d.type !== "text") continue;
+        this.stripBuf += String(d.content ?? "");
+        out.push(...this.consumeStripping());
+        continue;
+      }
       // `context` is the FIRST delta of every message (message_start carries
       // usage), so deciding the verdict on it would latch `pass` before any
       // text arrives and the gate would never drop anything. Forward it and
@@ -346,18 +411,38 @@ export class CompactionStreamGate {
       this.held.push(d);
       const trimmed = this.opening.trimStart();
       if (trimmed.startsWith(COMPACTION_OPENER)) { this.verdict = "drop"; this.held = []; continue; }
-      if (!trimmed || COMPACTION_OPENER.startsWith(trimmed)) continue; // still could be it
+      const open = SUGGESTION_OPEN_RE.exec(trimmed);
+      if (open) {
+        // Discard the held opener text; keep scanning for the close tag.
+        this.held = [];
+        this.verdict = "stripping";
+        this.stripBuf = trimmed.slice(open[0].length);
+        out.push(...this.consumeStripping());
+        continue;
+      }
+      if (couldBeOpener(trimmed)) continue; // still could be it
       this.verdict = "pass";
       out.push(...this.flush());
     }
     return out;
   }
 
-  /** Message finished — release anything still held (messages shorter than the opener). */
+  /** Message finished — release anything still held (messages shorter than the opener).
+   *  An unterminated `<suggestion>` block releases nothing: fail closed. */
   end(): StreamDelta[] {
-    const out = this.verdict === "drop" ? [] : this.flush();
+    const out = this.verdict === "drop" || this.verdict === "stripping" ? [] : this.flush();
     this.reset();
     return out;
+  }
+
+  /** Emit the remainder of a suggestion block once its close tag has arrived. */
+  private consumeStripping(): StreamDelta[] {
+    const close = SUGGESTION_CLOSE_RE.exec(this.stripBuf);
+    if (!close) return []; // block still open — keep swallowing
+    const rest = this.stripBuf.slice(close.index + close[0].length);
+    this.stripBuf = "";
+    this.verdict = "pass";
+    return rest ? [{ type: "text", content: rest }] : [];
   }
 
   private flush(): StreamDelta[] {
@@ -463,7 +548,7 @@ export class TurnResolver {
     // Native local commands (/usage, /limits, …) produce no new assistant
     // message; the Stop hook's last_assistant_message is the prior turn's stale
     // text. Settling with it would persist a duplicate chat echo — settle empty.
-    const text = this.opts.native ? "" : stripReasoningBlocks(String(this.stopPayload.last_assistant_message ?? ""));
+    const text = this.opts.native ? "" : sanitizeAssistantText(String(this.stopPayload.last_assistant_message ?? ""));
     this.settle({ sessionId: sid, result: text, error: undefined, numTurns: 1 });
   }
 
@@ -485,7 +570,7 @@ export class TurnResolver {
 
   completeRecovered(text: string, sessionId?: string): void {
     if (sessionId && !this.claudeSessionId) this.claudeSessionId = sessionId;
-    this.settle({ sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "", result: stripReasoningBlocks(text), numTurns: 1 });
+    this.settle({ sessionId: this.claudeSessionId ?? this.opts.fallbackSessionId ?? "", result: sanitizeAssistantText(text), numTurns: 1 });
   }
 
   /** Proof of life (SSE delta / tool hook) while a StopFailure is pending —
@@ -1365,7 +1450,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       const recovered = recoveryPath ? lastAssistantTextFromTranscript(recoveryPath, turnStartedAt) : undefined;
       if (recovered) {
         logger.info(`Recovered ${recovered.length} chars of lost turn text for session ${jinnSessionId} from transcript (Stop hook missing)`);
-        result.result = stripReasoningBlocks(recovered);
+        result.result = sanitizeAssistantText(recovered);
       }
     }
     // Map a StopFailure rate-limit into result.rateLimit so manager.ts's
@@ -1738,7 +1823,7 @@ export class InteractiveClaudeEngine implements InterruptibleEngine, PtyViewEngi
       const text = String(h.last_assistant_message ?? "");
       const sid = typeof h.session_id === "string" ? h.session_id : "";
       this.cancelLateRecovery(jinnSessionId);
-      const safeText = stripReasoningBlocks(text);
+      const safeText = sanitizeAssistantText(text);
       if (safeText.trim()) {
         logger.info(`InteractiveClaudeEngine: late Stop superseded failed turn for ${jinnSessionId}`);
         opts.onLateRecovery?.({ result: safeText, sessionId: sid });


### PR DESCRIPTION
Fixes #102.

Full credit to @jonolee-kr: the report identified the root cause, distinguished the two
assistant-text paths, named the one that actually leaks, and specified the correct fix
(strip, don't drop) along with the edge cases. This PR implements that design as written.

## The mechanism

The Claude engine emits `<suggestion>…</suggestion>` — a model-generated *suggested next
user turn*. Jinn has no producer or consumer for the tag anywhere, so it flows straight
into stored transcripts as `role: "assistant"` content: short imperative strings that
another agent reading the session cannot distinguish from an operator instruction. The
report documents an employee reversing a decision on the strength of one.

There are two assistant-text paths in `claude-interactive.ts`, and neither sanitizer
covered `suggestion`:

1. **Live/partial stream (gated).** `handleSseEvent` → `CompactionStreamGate` →
   `partialStream.persist()`. The gate drops a message only when it opens with
   `COMPACTION_OPENER = "<analysis>"`; `"<analysis>".startsWith("<s")` is false, so a
   `<suggestion>` message latches `pass` at the second character.
2. **Final stored message (was ungated). This is the actual leak.** The Stop hook's
   `last_assistant_message` → `stripReasoningBlocks` → stored assistant message. The
   alternation there is `thinking|reasoning|thought` only.

Path 2 produces the message `read_session` returns to another agent. A fix that only
generalises the stream gate repairs the live pane, leaves the real leak untouched, and
still looks correct. Both paths are fixed here.

## Strip, do not drop

`<analysis>` drops the whole message, which is right for a compaction summary and wrong
here: in four of the seven observed cases the suggestion is fused to the *front of a
genuine reply* with no separator, because `last_assistant_message` arrives as a single
final string. Dropping would trade an information leak for silent data loss.

The rule implemented is: **strip the block, keep the remainder, and drop the message only
when nothing but whitespace survives** (the standalone shape). In the resolver that falls
out naturally — the turn settles with `result: ""`.

## What changed

`packages/jinn/src/engines/claude-interactive.ts`

- **`stripSuggestionBlocks(text)`** — a new helper following the existing
  `stripReasoningBlocks` idiom, rather than widening that function's alternation, so
  private reasoning and suggested user turns stay independently testable (as the report
  asked). Three passes: complete blocks anywhere in the message; an unterminated block
  (strip to end of string); a message that ends part-way through the opening tag.
- **`sanitizeAssistantText(text)`** — composes `stripSuggestionBlocks(stripReasoningBlocks(…))`
  in one place and replaces `stripReasoningBlocks` at all four assistant-text call sites
  (Stop hook, `completeRecovered`, transcript recovery backfill, late-Stop recovery). The
  two strippers stay separate; composing at a single seam means no call site can
  accidentally apply only one of them.
- **`CompactionStreamGate`** — gains a `stripping` verdict. On a `<suggestion>` opener it
  swallows text until the close tag, then releases the genuine reply that follows and
  everything after it. `<analysis>` handling is unchanged, including its case-sensitive
  prefix test. `couldBeOpener()` extends the existing "keep holding, it might still be an
  opener" logic to the suggestion tag so an opening tag split across stream deltas is
  still caught.

## Edge cases covered

- **Opening tag split across deltas** — `<sugg` + `estion>…` is held and stripped
  (`couldBeOpener`). Conversely `<sug` + `ar is sweet.` releases its held text intact, so
  the gate does not over-strip.
- **Unterminated block** — fail closed. The stored path strips from the opening tag to
  end of string; the stream gate emits nothing at `end()`.
- **Truncated opening tag** (`…<sugges` at end of string) — the fragment is dropped.
- Multiple blocks in one message, attributes, whitespace and mixed case in the tag, text
  *preceding* the block, and a negative case (`</suggestions>`, a bare `<`) that must
  survive byte-identical.

## Mutation-check evidence

Every one of the 18 new tests was confirmed to fail under at least one deliberate
mutation of the fix. Baseline unmutated: 75/75 pass in the two files.

| Mutation | Tests it kills |
|---|---|
| M0 `stripSuggestionBlocks` made a no-op (whole path-2 fix absent) | all 3 TurnResolver suggestion tests, 7 of 8 `stripSuggestionBlocks` tests, `sanitizeAssistantText` (11 total) |
| M1 `sanitizeAssistantText` no longer applies the suggestion stripper (wiring removed) | 3 TurnResolver tests + `sanitizeAssistantText` (4) |
| M2 drop the whole message instead of stripping | 9 — incl. "keeps the genuine reply fused behind it", "keeps text that precedes the block" (this is the strip-not-drop guard) |
| M3 complete-block regex removed | 6 |
| M4 unterminated-block regex removed (fails open) | "strips to end of string for an unterminated block" |
| M5 truncated-opening-tag regex removed | "strips a truncated opening tag at end of string" |
| M6 complete-block regex loses `/g` | "strips every block when several appear" |
| M7 tag matching made case-sensitive | "tolerates attributes, whitespace and mixed case in the tag" |
| M8 over-strip: unterminated regex relaxed to `/<\s*s/` | "leaves a message with no suggestion block byte-identical apart from trim" |
| M9 stream gate: suggestion branch removed | all 5 positive gate tests |
| M10 stream gate: `couldBeOpener` narrowed back to `<analysis>` only | "strips a suggestion whose opening tag is split across deltas" |
| M11 stream gate: unterminated block fails OPEN at `end()` | "fails closed on an unterminated suggestion block" |
| M12 stream gate: over-strips on a loose `<sug` prefix | "releases held text when the opener turns out not to be a suggestion" |

M8 and M12 are over-strip mutations: they exist so the two negative tests (which pass
against unfixed code by construction) are shown to be load-bearing rather than free.

## Verification

`pnpm typecheck` at the root: 2 successful, 2 total.

`cd packages/jinn && pnpm test`:

```
 Test Files  313 passed (313)
      Tests  3868 passed | 1 skipped (3869)
   Start at  09:53:00
   Duration  35.09s (transform 9.11s, setup 2.63s, import 33.00s, tests 137.42s, environment 21ms)
```

No flakes; session-tools, workflow-vertical and delegation-tools all passed in the same
run and needed no isolated re-run.

## Scope note

The stream gate handles the head-of-message case, which is the observed shape and matches
its existing per-message-opener contract. Full-position coverage lives in
`sanitizeAssistantText`, which sanitizes the final stored message the transcript actually
serves to other agents.

The report's closing suggestion — parsing the tag into a structured field so the UI could
render quick-reply chips — is deliberately out of scope here; this PR only closes the leak.
