### PR TITLE
fix(install): build native addons on Homebrew installs

### DIFF
--- a/Formula/jinn.rb
+++ b/Formula/jinn.rb
@@ -14,7 +14,21 @@ class Jinn < Formula
   depends_on "python" => :build
 
   def install
-    system "npm", "install", *std_npm_args
+    # ignore_scripts: false is load-bearing, not cosmetic. Homebrew's
+    # npm_install_security_args defaults ignore_scripts: true, which suppresses
+    # every lifecycle script in the tree. Two of them matter here:
+    #
+    #   * better-sqlite3's `install` (prebuild-install || node-gyp rebuild).
+    #     Without it no compiled addon is produced at all and the gateway dies
+    #     at boot with "Could not locate the bindings file".
+    #   * node-pty's `install`, which under the --build-from-source that
+    #     std_npm_args already passes compiles build/Release/{pty.node,
+    #     spawn-helper} with correct modes. Without it node-pty falls back to
+    #     the checked-in prebuilds, whose spawn-helper ships mode 0644, and
+    #     every session dies with "posix_spawnp failed.".
+    #
+    # depends_on "python" => :build exists to serve that compile step.
+    system "npm", "install", *std_npm_args(ignore_scripts: false)
     bin.install_symlink libexec.glob("bin/*")
   end
 
@@ -35,8 +49,19 @@ class Jinn < Formula
     assert_match "Usage", shell_output("#{bin}/jinn --help")
 
     cd libexec/"lib/node_modules/jinn-cli" do
-      system "node", "-e", "require('better-sqlite3')"
-      system "node", "-e", "require('classic-level')"
+      # Must OPEN a database, not just require the module. better-sqlite3
+      # resolves its binding lazily inside the Database constructor, so a bare
+      # require('better-sqlite3') passes even when no compiled addon exists
+      # anywhere on disk -- which is exactly how a binding-less install shipped
+      # undetected.
+      system "node", "-e", "new (require('better-sqlite3'))(':memory:').close()"
+
+      # Likewise require('node-pty') passes while spawn-helper is mode 0644.
+      # Only a real spawn posix_spawns the helper binary.
+      system "node", "-e", <<~JS
+        const pty = require('node-pty');
+        pty.spawn('/bin/echo', ['ok'], {}).kill();
+      JS
     end
   end
 end

--- a/packages/jinn/bin/jinn.ts
+++ b/packages/jinn/bin/jinn.ts
@@ -4,7 +4,7 @@ import { realpathSync } from "node:fs";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import pkg from "../package.json" with { type: "json" };
-import { assertNativeRuntime } from "../src/shared/runtime-guard.js";
+import { assertNativeRuntime, repairNodePtySpawnHelper } from "../src/shared/runtime-guard.js";
 import { loadInstances } from "../src/instances/directory.js";
 import { resolveInstanceHome } from "../src/instances/create.js";
 
@@ -21,6 +21,9 @@ program.hook("preAction", (thisCommand) => {
   // better-sqlite3, so an ABI mismatch prints one clear instruction instead of a
   // cryptic boot crash. Runs for real commands only (not --version/--help).
   assertNativeRuntime();
+  // Restore node-pty's spawn-helper exec bit if an --ignore-scripts install
+  // (Homebrew's default) left it at 0644. No-op on a healthy install.
+  repairNodePtySpawnHelper();
   const opts = thisCommand.opts();
   if (opts.instance) {
     process.env.JINN_INSTANCE = opts.instance;

--- a/packages/jinn/scripts/fix-node-pty-permissions.mjs
+++ b/packages/jinn/scripts/fix-node-pty-permissions.mjs
@@ -1,44 +1,90 @@
-import { chmod, readdir } from "node:fs/promises";
+// Restore the executable bit on node-pty's spawn-helper at install time.
+//
+// On macOS/Linux node-pty does not merely load `pty.node`; it `posix_spawn`s a
+// sibling binary called `spawn-helper`. node-pty 1.x ships that helper inside
+// its published tarball WITHOUT the executable bit, so without this repair every
+// pty spawn dies with `posix_spawnp failed.` — a message that names neither the
+// file nor the permission problem.
+//
+// LAYOUTS. node-pty resolves its native artifacts from `build/Release`, then
+// `build/Debug`, then `prebuilds/<platform>-<arch>` (its lib/utils.js), and
+// `spawn-helper` sits next to whichever `pty.node` was loaded. Which layout
+// exists depends on how the package was installed:
+//
+//   * plain `npm install`   → prebuilds/ only, spawn-helper at mode 0644
+//   * `--build-from-source` → node-pty compiles and DELETES prebuilds/, leaving
+//                             build/Release with correct modes already
+//
+// Homebrew always passes --build-from-source, so the earlier version of this
+// script — which assumed prebuilds/ existed and threw otherwise — failed the
+// whole `brew install` with ENOENT. Every known layout is checked here, and a
+// layout without a spawn-helper is not an error.
+//
+// NEVER FATAL. A permission fix-up must not be able to fail an install. When it
+// cannot do its job it warns, and `repairNodePtySpawnHelper()` in
+// src/shared/runtime-guard.ts repairs the same file at startup — which is also
+// the only layer that helps an install where this script never ran at all.
+import { chmod, stat } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
-if (process.platform !== "darwin") {
-  process.exit(0);
-}
+if (process.platform === "win32") process.exit(0); // no exec bit, no spawn-helper
 
 const require = createRequire(import.meta.url);
+
 let nodePtyRoot;
 try {
   nodePtyRoot = dirname(require.resolve("node-pty/package.json"));
-} catch (error) {
-  throw new Error("jinn-cli postinstall could not resolve node-pty/package.json", { cause: error });
-}
-
-async function fixPrebuilds(nodePtyRoot) {
-  let platforms;
-  try {
-    platforms = await readdir(join(nodePtyRoot, "prebuilds"), {
-      withFileTypes: true,
-    });
-  } catch (error) {
-    throw new Error(`jinn-cli postinstall could not read node-pty prebuilds at ${nodePtyRoot}`, { cause: error });
-  }
-
-  const darwinPrebuilds = platforms.filter(
-    (platform) => platform.isDirectory() && platform.name.startsWith("darwin-"),
+} catch {
+  process.stderr.write(
+    "jinn-cli postinstall: node-pty not resolvable, skipping spawn-helper repair\n",
   );
-  if (darwinPrebuilds.length === 0) {
-    throw new Error(`jinn-cli postinstall found no Darwin node-pty prebuilds at ${nodePtyRoot}`);
-  }
-
-  await Promise.all(darwinPrebuilds.map(async (platform) => {
-    const helper = join(nodePtyRoot, "prebuilds", platform.name, "spawn-helper");
-    try {
-      await chmod(helper, 0o755);
-    } catch (error) {
-      throw new Error(`jinn-cli postinstall could not chmod node-pty helper ${helper}`, { cause: error });
-    }
-  }));
+  process.exit(0);
 }
 
-await fixPrebuilds(nodePtyRoot);
+// Kept in sync with spawnHelperCandidates() in src/shared/runtime-guard.ts.
+// Both darwin arches are listed because a workspace can be installed on one
+// machine and mounted on another.
+const candidates = [
+  join(nodePtyRoot, "build", "Release", "spawn-helper"),
+  join(nodePtyRoot, "build", "Debug", "spawn-helper"),
+  join(nodePtyRoot, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
+  join(nodePtyRoot, "prebuilds", "darwin-arm64", "spawn-helper"),
+  join(nodePtyRoot, "prebuilds", "darwin-x64", "spawn-helper"),
+];
+
+let seen = 0;
+let repaired = 0;
+
+for (const helper of new Set(candidates)) {
+  let mode;
+  try {
+    mode = (await stat(helper)).mode;
+  } catch {
+    continue; // not this layout
+  }
+  seen += 1;
+  if ((mode & 0o111) === 0o111) continue; // already executable
+  try {
+    await chmod(helper, (mode & 0o7777) | 0o755);
+    repaired += 1;
+  } catch (error) {
+    process.stderr.write(
+      `jinn-cli postinstall: could not chmod ${helper} (${error?.message ?? error}); ` +
+        "jinn will retry this at startup\n",
+    );
+  }
+}
+
+if (seen === 0) {
+  process.stderr.write(
+    `jinn-cli postinstall: no node-pty spawn-helper found under ${nodePtyRoot}; ` +
+      "jinn will retry this at startup\n",
+  );
+}
+
+if (process.env.npm_config_loglevel === "verbose") {
+  process.stdout.write(
+    `jinn-cli postinstall: ${repaired} spawn-helper(s) repaired of ${seen} found\n`,
+  );
+}

--- a/packages/jinn/src/gateway/daemon-entry.ts
+++ b/packages/jinn/src/gateway/daemon-entry.ts
@@ -2,7 +2,7 @@
  * Entry point for the daemon child process.
  * Spawned by lifecycle.ts startDaemon().
  */
-import { assertNativeRuntime } from "../shared/runtime-guard.js";
+import { assertNativeRuntime, repairNodePtySpawnHelper } from "../shared/runtime-guard.js";
 
 // Verify the native DB addon loads under this Node BEFORE the imports below pull
 // in better-sqlite3 (via lifecycle → server → registry). An ABI mismatch here
@@ -10,6 +10,11 @@ import { assertNativeRuntime } from "../shared/runtime-guard.js";
 // daemon mode). The static imports are therefore deferred to dynamic imports
 // that run only after the guard passes.
 assertNativeRuntime();
+
+// Every engine spawn goes through node-pty. If an --ignore-scripts install left
+// its spawn-helper non-executable, every session would die with an opaque
+// `posix_spawnp failed.` — repair it here, before any session can start.
+repairNodePtySpawnHelper();
 
 const { loadConfig } = await import("../shared/config.js");
 const { startForeground } = await import("./lifecycle.js");

--- a/packages/jinn/src/shared/__tests__/homebrew-formula.test.ts
+++ b/packages/jinn/src/shared/__tests__/homebrew-formula.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// packages/jinn
+const PKG = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+// repo root — the tap and the source repo are the same repository, so the
+// Homebrew formula is version-controlled here and is ours to keep correct.
+const FORMULA = join(PKG, "..", "..", "Formula", "jinn.rb");
+
+const formula = () => readFileSync(FORMULA, "utf-8");
+
+describe("Homebrew formula", () => {
+  it("is present in this repo", () => {
+    expect(existsSync(FORMULA)).toBe(true);
+  });
+
+  // Issues #108 and #109 both trace to this one call. Homebrew's
+  // npm_install_security_args defaults ignore_scripts: true, so a bare
+  // *std_npm_args installs with --ignore-scripts: better-sqlite3's addon is
+  // never built and node-pty's spawn-helper never regains its exec bit.
+  it("opts out of --ignore-scripts so native addons are actually built", () => {
+    const src = formula();
+    expect(src).toMatch(/std_npm_args\(ignore_scripts:\s*false\)/);
+    // No bare *std_npm_args left anywhere — that is the broken form.
+    expect(src).not.toMatch(/\*std_npm_args(?!\()/);
+  });
+
+  it("keeps the build toolchain the source compile needs", () => {
+    const src = formula();
+    expect(src).toMatch(/depends_on "python" => :build/);
+  });
+
+  describe("test block", () => {
+    // A bare require('better-sqlite3') SUCCEEDS on a binding-less install,
+    // because the binding is resolved lazily in the Database constructor. The
+    // old assertion was therefore a false negative and could never have caught
+    // #108. Only opening a database exercises the addon.
+    it("opens a database instead of only requiring better-sqlite3", () => {
+      const src = formula();
+      expect(src).toMatch(/new \(require\('better-sqlite3'\)\)\(':memory:'\)/);
+      expect(src).not.toMatch(/"require\('better-sqlite3'\)"/);
+    });
+
+    // Likewise require('node-pty') passes while spawn-helper is mode 0644;
+    // only a real spawn posix_spawns the helper (#109).
+    it("really spawns through node-pty instead of only requiring it", () => {
+      const src = formula();
+      expect(src).toMatch(/require\('node-pty'\)/);
+      expect(src).toMatch(/pty\.spawn\(/);
+    });
+
+    // The block previously asserted require('classic-level'), which is a root
+    // workspace dependency and is not published inside jinn-cli — so the
+    // assertion could only ever fail once someone actually ran `brew test`.
+    it("only requires modules the published package actually depends on", () => {
+      const pkg = JSON.parse(readFileSync(join(PKG, "package.json"), "utf-8")) as {
+        dependencies?: Record<string, string>;
+      };
+      const declared = new Set(Object.keys(pkg.dependencies ?? {}));
+
+      const required = [...formula().matchAll(/require\('([^']+)'\)/g)].map((m) => m[1]);
+      expect(required.length).toBeGreaterThan(0);
+      for (const name of required) {
+        expect(declared, `formula requires "${name}"`).toContain(name);
+      }
+    });
+  });
+});

--- a/packages/jinn/src/shared/__tests__/postinstall-node-pty.test.ts
+++ b/packages/jinn/src/shared/__tests__/postinstall-node-pty.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// packages/jinn
+const PKG = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const SCRIPT = join(PKG, "scripts", "fix-node-pty-permissions.mjs");
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length) rmSync(created.pop()!, { recursive: true, force: true });
+});
+
+/**
+ * Build a throwaway package that looks like an installed jinn-cli: the real
+ * postinstall script under scripts/, and a fake node-pty next door in
+ * node_modules/ so the script's require.resolve finds it by walking up.
+ */
+function stagePackage(helperLayouts: Array<{ dir: string; mode: number }>): {
+  root: string;
+  script: string;
+  helpers: string[];
+} {
+  const root = mkdtempSync(join(tmpdir(), "jinn-postinstall-"));
+  created.push(root);
+
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  const script = join(root, "scripts", "fix-node-pty-permissions.mjs");
+  copyFileSync(SCRIPT, script);
+
+  const nodePty = join(root, "node_modules", "node-pty");
+  mkdirSync(nodePty, { recursive: true });
+  writeFileSync(join(nodePty, "package.json"), JSON.stringify({ name: "node-pty", version: "1.1.0" }));
+
+  const helpers: string[] = [];
+  for (const { dir, mode } of helperLayouts) {
+    const target = join(nodePty, dir);
+    mkdirSync(target, { recursive: true });
+    const helper = join(target, "spawn-helper");
+    writeFileSync(helper, "#!/bin/sh\nexit 0\n");
+    chmodSync(helper, mode);
+    helpers.push(helper);
+  }
+
+  return { root, script, helpers };
+}
+
+/** Runs the postinstall exactly as npm would. Throws if it exits non-zero. */
+function runPostinstall(script: string): string {
+  return execFileSync(process.execPath, [script], { encoding: "utf-8", stdio: "pipe" });
+}
+
+const modeOf = (path: string) => statSync(path).mode & 0o777;
+
+describe.skipIf(process.platform === "win32")("jinn-cli postinstall: node-pty permissions", () => {
+  it("repairs a shipped prebuild left at 0644", () => {
+    const { script, helpers } = stagePackage([
+      { dir: `prebuilds/${process.platform}-${process.arch}`, mode: 0o644 },
+    ]);
+
+    runPostinstall(script);
+
+    expect(modeOf(helpers[0]!)).toBe(0o755);
+  });
+
+  // Homebrew's std_npm_args always passes --build-from-source. node-pty then
+  // COMPILES and deletes prebuilds/ entirely, leaving only build/Release. The
+  // previous script did readdir("prebuilds") and threw ENOENT on exactly this
+  // layout, which failed `npm install` and would have broken `brew install`
+  // outright the moment lifecycle scripts were re-enabled.
+  it("succeeds on a source-built layout that has no prebuilds/ directory", () => {
+    const { script, helpers } = stagePackage([{ dir: "build/Release", mode: 0o755 }]);
+
+    expect(() => runPostinstall(script)).not.toThrow();
+    expect(modeOf(helpers[0]!)).toBe(0o755);
+  });
+
+  it("repairs a source-built helper that lost its exec bit", () => {
+    const { script, helpers } = stagePackage([{ dir: "build/Release", mode: 0o644 }]);
+
+    runPostinstall(script);
+
+    expect(modeOf(helpers[0]!)).toBe(0o755);
+  });
+
+  // A permission fix-up must never be able to fail an install; the runtime
+  // guard repairs the same file at startup.
+  it("never fails the install when there is nothing to repair", () => {
+    const { script } = stagePackage([]);
+
+    expect(() => runPostinstall(script)).not.toThrow();
+  });
+
+  it("never fails the install when node-pty is not resolvable", () => {
+    const root = mkdtempSync(join(tmpdir(), "jinn-postinstall-bare-"));
+    created.push(root);
+    mkdirSync(join(root, "scripts"), { recursive: true });
+    // An empty node_modules stops require.resolve from escaping to a real
+    // node-pty higher up the tree.
+    mkdirSync(join(root, "node_modules"), { recursive: true });
+    const script = join(root, "scripts", "fix-node-pty-permissions.mjs");
+    copyFileSync(SCRIPT, script);
+
+    expect(() => runPostinstall(script)).not.toThrow();
+  });
+});

--- a/packages/jinn/src/shared/__tests__/runtime-guard.test.ts
+++ b/packages/jinn/src/shared/__tests__/runtime-guard.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyNativeDbFailure,
+  nativeDbFailureReport,
+  repairNodePtySpawnHelper,
+} from "../runtime-guard.js";
+
+const created: string[] = [];
+
+function fakeNodePty(layout: string, mode: number): { root: string; helper: string } {
+  const root = mkdtempSync(join(tmpdir(), "jinn-node-pty-"));
+  created.push(root);
+  const dir = join(root, layout);
+  mkdirSync(dir, { recursive: true });
+  const helper = join(dir, "spawn-helper");
+  writeFileSync(helper, "#!/bin/sh\nexit 0\n");
+  chmodSync(helper, mode);
+  return { root, helper };
+}
+
+const modeOf = (path: string) => statSync(path).mode & 0o777;
+
+afterEach(() => {
+  while (created.length) rmSync(created.pop()!, { recursive: true, force: true });
+});
+
+// The exact message a Homebrew install produces (issue #108). node-pty and
+// better-sqlite3 both fail *after* a successful require, which is why a
+// require-only guard let this reach users.
+const BINDINGS_MISSING =
+  "Could not locate the bindings file. Tried:\n → .../better-sqlite3/build/better_sqlite3.node";
+
+const ABI_MISMATCH =
+  "The module was compiled against a different Node.js version using NODE_MODULE_VERSION 127.";
+
+describe("classifyNativeDbFailure", () => {
+  it("recognises a binding that was never built", () => {
+    expect(classifyNativeDbFailure(BINDINGS_MISSING)).toBe("binding-missing");
+    expect(classifyNativeDbFailure("Cannot find module './build/Release/better_sqlite3.node'")).toBe(
+      "binding-missing",
+    );
+  });
+
+  it("still recognises an ABI mismatch", () => {
+    expect(classifyNativeDbFailure(ABI_MISMATCH)).toBe("abi-mismatch");
+    expect(classifyNativeDbFailure("ERR_DLOPEN_FAILED")).toBe("abi-mismatch");
+  });
+
+  it("does not claim unrelated failures", () => {
+    expect(classifyNativeDbFailure("SQLITE_CANTOPEN: unable to open database file")).toBe("unknown");
+  });
+});
+
+describe("nativeDbFailureReport", () => {
+  it("tells a binding-less install to reinstall rather than to switch Node", () => {
+    const report = nativeDbFailureReport("binding-missing", BINDINGS_MISSING);
+    expect(report).toContain("never built");
+    expect(report).toContain("brew reinstall jinn");
+    expect(report).toContain("npm rebuild better-sqlite3");
+    // The old message blamed the Node version, which is wrong here and sent
+    // users to `nvm use` for a problem no Node switch can fix.
+    expect(report).not.toContain("nvm use");
+  });
+
+  it("keeps the Node-version instruction for a real ABI mismatch", () => {
+    const report = nativeDbFailureReport("abi-mismatch", ABI_MISMATCH);
+    expect(report).toContain("different Node.js version");
+    expect(report).toContain("nvm use");
+  });
+});
+
+describe.skipIf(process.platform === "win32")("repairNodePtySpawnHelper", () => {
+  it("restores the exec bit on a prebuilt spawn-helper left at 0644", () => {
+    const { root, helper } = fakeNodePty(`prebuilds/${process.platform}-${process.arch}`, 0o644);
+    expect(modeOf(helper)).toBe(0o644);
+
+    expect(repairNodePtySpawnHelper(root)).toEqual([helper]);
+    expect(modeOf(helper)).toBe(0o755);
+  });
+
+  it("also repairs a source-built build/Release layout", () => {
+    const { root, helper } = fakeNodePty("build/Release", 0o644);
+
+    expect(repairNodePtySpawnHelper(root)).toEqual([helper]);
+    expect(modeOf(helper)).toBe(0o755);
+  });
+
+  it("is a no-op on a healthy install", () => {
+    const { root, helper } = fakeNodePty(`prebuilds/${process.platform}-${process.arch}`, 0o755);
+
+    expect(repairNodePtySpawnHelper(root)).toEqual([]);
+    expect(modeOf(helper)).toBe(0o755);
+  });
+
+  it("never throws when there is no spawn-helper to repair", () => {
+    const root = mkdtempSync(join(tmpdir(), "jinn-node-pty-empty-"));
+    created.push(root);
+
+    expect(repairNodePtySpawnHelper(root)).toEqual([]);
+  });
+});

--- a/packages/jinn/src/shared/runtime-guard.ts
+++ b/packages/jinn/src/shared/runtime-guard.ts
@@ -1,49 +1,178 @@
+import { chmodSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 
 const require = createRequire(import.meta.url);
 
+export type NativeDbFailure = "abi-mismatch" | "binding-missing" | "unknown";
+
+/**
+ * Classify why the native database addon could not be used.
+ *
+ * Two failure modes look nothing alike and need different instructions:
+ *
+ *  - `abi-mismatch`    — the addon exists but was compiled for a different Node
+ *                        ABI (an nvm switch, or a Homebrew node shadowing nvm).
+ *  - `binding-missing` — the addon was never produced at all. This is what an
+ *                        install with lifecycle scripts disabled leaves behind:
+ *                        better-sqlite3's `install` script
+ *                        (`prebuild-install || node-gyp rebuild`) never ran, so
+ *                        there is no `build/` directory to load from.
+ */
+export function classifyNativeDbFailure(message: string): NativeDbFailure {
+  if (/Could not locate the bindings file|Cannot find module .*better_sqlite3\.node/i.test(message)) {
+    return "binding-missing";
+  }
+  if (
+    /NODE_MODULE_VERSION|different Node\.js version|ERR_DLOPEN_FAILED|was compiled against|dlopen|invalid ELF header|Symbol not found/i.test(
+      message,
+    )
+  ) {
+    return "abi-mismatch";
+  }
+  return "unknown";
+}
+
+/** Directory of the installed better-sqlite3 package, or null if unresolvable. */
+function betterSqlite3Root(): string | null {
+  try {
+    return dirname(require.resolve("better-sqlite3/package.json"));
+  } catch {
+    return null;
+  }
+}
+
+/** The stderr report shown for a native-database failure. */
+export function nativeDbFailureReport(kind: NativeDbFailure, message: string): string {
+  if (kind === "binding-missing") {
+    const root = betterSqlite3Root();
+    return [
+      "",
+      "✗ jinn cannot start: its native database module (better-sqlite3) was never built.",
+      "",
+      "  The compiled addon is missing entirely — this is not a version mismatch. It happens",
+      "  when the install ran with lifecycle scripts disabled (`--ignore-scripts`), so",
+      "  better-sqlite3's own install step never compiled or downloaded the binary.",
+      "",
+      "  Fix:",
+      "    • Homebrew:  brew update && brew reinstall jinn",
+      root
+        ? `    • Otherwise: npm rebuild better-sqlite3 --prefix ${root}`
+        : "    • Otherwise: npm rebuild better-sqlite3",
+      "",
+      `  Underlying error: ${message}`,
+      "",
+    ].join("\n");
+  }
+
+  return [
+    "",
+    "✗ jinn cannot start: its native database module (better-sqlite3) was built for a",
+    "  different Node.js version than the one you're running.",
+    "",
+    `  Running:  Node ${process.version} (native ABI ${process.versions.modules})`,
+    "",
+    "  Fix (either one):",
+    "    • Switch to the Node version you installed jinn with, e.g.  nvm use 24",
+    "    • Or rebuild the addon for this Node:  npm rebuild better-sqlite3",
+    "",
+    `  Underlying error: ${message}`,
+    "",
+  ].join("\n");
+}
+
 /**
  * Fail fast with a clear, actionable message when the native database module
- * (better-sqlite3) cannot load under the current Node runtime.
+ * (better-sqlite3) cannot be used under the current Node runtime.
  *
- * better-sqlite3 is a native addon compiled for one specific Node ABI
- * (NODE_MODULE_VERSION). If jinn is installed under one Node major and later run
- * under a different one (an nvm switch, or a Homebrew node shadowing the nvm node),
- * the addon throws a cryptic `ERR_DLOPEN_FAILED` deep inside the gateway boot and
- * the process dies before any logging — the exact "gateway won't start after
- * upgrade" failure this guards against. Turning that into one plain instruction
- * is the whole point.
+ * IMPORTANT: this must actually *open* a database, not merely `require` the
+ * module. better-sqlite3 resolves its binding lazily inside the `Database`
+ * constructor, so `require("better-sqlite3")` succeeds even when no compiled
+ * addon exists anywhere on disk. A require-only check is a false negative for
+ * the most common broken install there is, and lets the raw `bindings` stack
+ * trace escape from deep inside gateway boot instead.
  *
  * Call this at every process entry that will load the session database (the CLI
  * dispatcher and the daemon entry), BEFORE anything imports better-sqlite3.
  */
 export function assertNativeRuntime(): void {
   try {
-    require("better-sqlite3");
+    const Database = require("better-sqlite3") as new (path: string) => { close(): void };
+    // Constructing forces the binding to resolve; ":memory:" touches no disk.
+    new Database(":memory:").close();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const abiMismatch =
-      /NODE_MODULE_VERSION|different Node\.js version|ERR_DLOPEN_FAILED|was compiled against|dlopen|invalid ELF header|Symbol not found/i.test(
-        message,
-      );
-    if (!abiMismatch) throw err; // unrelated failure — don't mask it
+    const kind = classifyNativeDbFailure(message);
+    if (kind === "unknown") throw err; // unrelated failure — don't mask it
 
-    process.stderr.write(
-      [
-        "",
-        "✗ jinn cannot start: its native database module (better-sqlite3) was built for a",
-        "  different Node.js version than the one you're running.",
-        "",
-        `  Running:  Node ${process.version} (native ABI ${process.versions.modules})`,
-        "",
-        "  Fix (either one):",
-        "    • Switch to the Node version you installed jinn with, e.g.  nvm use 24",
-        "    • Or rebuild the addon for this Node:  npm rebuild better-sqlite3",
-        "",
-        `  Underlying error: ${message}`,
-        "",
-      ].join("\n"),
-    );
+    process.stderr.write(nativeDbFailureReport(kind, message));
     process.exit(1);
   }
+}
+
+/**
+ * node-pty's own resolution order for its native artifacts
+ * (`node_modules/node-pty/lib/utils.js`). `spawn-helper` is a sibling of
+ * whichever directory `pty.node` was loaded from, so both the source-built
+ * (`build/…`) and the shipped-prebuild layouts have to be covered.
+ *
+ * Kept in sync with `scripts/fix-node-pty-permissions.mjs`, which does the same
+ * repair at install time when lifecycle scripts are allowed to run.
+ */
+function spawnHelperCandidates(nodePtyRoot: string): string[] {
+  return [
+    join(nodePtyRoot, "build", "Release", "spawn-helper"),
+    join(nodePtyRoot, "build", "Debug", "spawn-helper"),
+    join(nodePtyRoot, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
+  ];
+}
+
+/**
+ * Restore the executable bit on node-pty's `spawn-helper`.
+ *
+ * On macOS/Linux node-pty does not merely load `pty.node`; it `posix_spawn`s a
+ * sibling binary called `spawn-helper`. node-pty 1.x ships that helper in its
+ * published tarball WITHOUT the executable bit and relies on an install-time
+ * script to restore it. Any install that skips lifecycle scripts leaves the
+ * helper at mode 0644, and then every pty spawn dies with `posix_spawnp
+ * failed.` — a message that names neither the file nor the permission problem,
+ * so it reads as if the spawned CLI were missing.
+ *
+ * `jinn-cli`'s postinstall already fixes this, but postinstall is precisely what
+ * such installs skip (Homebrew's `std_npm_args` passes `--ignore-scripts` by
+ * default). Repairing at startup is therefore the only layer that holds for an
+ * install we never got to run scripts in — including one already on disk, where
+ * no packaging change helps retroactively.
+ *
+ * Best-effort by design: a missing helper or a read-only install is not a reason
+ * to refuse to boot, and on a healthy install this is a no-op.
+ *
+ * @param nodePtyRoot Override for tests. Defaults to the resolved node-pty.
+ * @returns paths whose mode this call actually changed.
+ */
+export function repairNodePtySpawnHelper(nodePtyRoot?: string): string[] {
+  if (process.platform === "win32") return []; // no exec bit, no spawn-helper
+
+  let root = nodePtyRoot;
+  if (!root) {
+    try {
+      root = dirname(require.resolve("node-pty/package.json"));
+    } catch {
+      return []; // node-pty not installed (e.g. a trimmed environment)
+    }
+  }
+
+  const repaired: string[] = [];
+  for (const helper of spawnHelperCandidates(root)) {
+    try {
+      const mode = statSync(helper).mode;
+      if ((mode & 0o111) === 0o111) continue; // already executable
+      chmodSync(helper, (mode & 0o7777) | 0o755);
+      repaired.push(helper);
+    } catch {
+      // Absent for this build layout, or the install is read-only. Neither is
+      // fatal: if the helper we actually need is broken, node-pty will say so.
+    }
+  }
+  return repaired;
 }


### PR DESCRIPTION
Thanks to @yoobi for both reports — they were precise, correctly identified the shared cause in the formula, and correctly called out that #109 was masked by #108. Diagnosis confirmed on a reproduction of the published 0.29.0 tarball.

## Root causes

Both issues come from one line. Homebrew's `std_npm_args` folds in `Language::Node.npm_install_security_args`, whose `ignore_scripts:` parameter defaults to `true`, so the formula installed the whole tree with `--ignore-scripts`.

**#108 — better-sqlite3 binding never built.** better-sqlite3 declares `"install": "prebuild-install || node-gyp rebuild --release"`. With scripts suppressed it never runs, and the package has no `build/` directory at all. The gateway dies at `initDb` with `Could not locate the bindings file`.

**#109 — node-pty `spawn-helper` not executable.** With scripts suppressed, node-pty falls back to its checked-in prebuilds, whose `spawn-helper` ships at mode `0644`. On macOS `unixTerminal.js` `posix_spawn`s that helper on every pty, so every session dies with `posix_spawnp failed.`. `jinn-cli`'s own `postinstall` exists to restore that bit and is skipped for exactly the same reason.

### A third cause, which the one-line formula fix would have hit

Enabling scripts alone is **not sufficient, and on its own makes things worse.** `std_npm_args` also passes `--build-from-source`. Under that flag node-pty compiles and **deletes `prebuilds/` entirely**, leaving only `build/Release/{pty.node,spawn-helper}`. The previous `scripts/fix-node-pty-permissions.mjs` did `readdir(nodePtyRoot + "/prebuilds")` and **threw** on ENOENT, which fails `npm install` and would have turned a runtime crash into a hard `brew install` failure.

Verified against the published tarball:

```
npm error command sh -c node scripts/fix-node-pty-permissions.mjs
npm error Error: jinn-cli postinstall could not read node-pty prebuilds at .../node_modules/node-pty
npm error   [cause]: Error: ENOENT: no such file or directory, scandir '.../node-pty/prebuilds'
```

### Why this shipped undetected

`require('better-sqlite3')` **succeeds** on a binding-less install — the binding is resolved lazily inside the `Database` constructor, not at module load. Measured on the broken tree:

```
require('better-sqlite3') alone: SUCCEEDS (false negative!)
construct: threw, classified as: binding-missing
```

So two things that looked like they were guarding this were not:
- `assertNativeRuntime()` in `bin/jinn.ts` and `daemon-entry.ts` only did a bare `require`, so it passed and let the raw `bindings` stack trace escape from deep inside boot.
- The formula's `test do` block asserted `require('better-sqlite3')`. Contrary to the hope in #108, that line would **not** have caught this bug even if `brew test` had run. The same is true of `require('node-pty')`, which passes fine while `spawn-helper` is `0644`.

That block also asserted `require('classic-level')`, which is a root workspace dependency and is **not** published inside `jinn-cli`, so it could only ever fail once someone actually ran `brew test`.

## What changed

1. **`Formula/jinn.rb`** — `system "npm", "install", *std_npm_args(ignore_scripts: false)`. This makes the compile that `depends_on "python" => :build` and `--build-from-source` already imply actually happen.
2. **`packages/jinn/scripts/fix-node-pty-permissions.mjs`** — covers every layout node-pty resolves from (`build/Release`, `build/Debug`, `prebuilds/<platform>-<arch>`) instead of assuming `prebuilds/`, and never fails an install over a permission fix-up. It warns and defers to the runtime repair instead.
3. **`packages/jinn/src/shared/runtime-guard.ts`** — `assertNativeRuntime()` now opens a `:memory:` database rather than only requiring the module, and distinguishes `binding-missing` from `abi-mismatch` so a never-built addon stops being reported as a Node version mismatch it is not. New `repairNodePtySpawnHelper()` restores the `spawn-helper` exec bit at startup; wired into both `bin/jinn.ts` and `daemon-entry.ts`.
4. **Formula `test do`** — opens a database and really spawns through node-pty, since both bugs survive a bare `require`. Drops the `classic-level` assertion.

### Why a runtime self-heal *as well as* the formula fix

The formula fix is the real root-cause fix and is what closes both issues for new installs. The startup repair is kept alongside it for the part packaging cannot reach:

- It fixes **installs already on disk**. Every user hitting #109 today gets it back on the next `jinn start`, without waiting for a formula bump to propagate.
- It is the only layer that survives *any* scripts-disabled install path, not just Homebrew's (`npm ci --ignore-scripts`, corporate npm configs, sandboxed CI).
- It is a `chmod` on a file whose path we derive the same way node-pty does — cheap, idempotent, and a no-op on a healthy install.

The equivalent was deliberately **not** done for better-sqlite3: fabricating a native addon at runtime means shelling out to `node-gyp`/`prebuild-install`, which needs network and a compiler toolchain and takes minutes. Doing that silently from a daemon start is worse than failing. Instead the guard now detects that exact state and prints the precise command to run. Shipping prebuilt binaries in the tarball was also rejected — better-sqlite3 is a transitive dependency, not ours to vendor, and it would multiply the package size per platform.

## Verification

Reproduced and fixed against the real published `jinn-cli-0.29.0` tarball in a scratch prefix, using Homebrew's exact flags.

**Broken (current formula, `--ignore-scripts`)** — both symptoms reproduce:
```
better-sqlite3/build/Release/: No such file or directory
-rw-r--r--  node-pty/prebuilds/darwin-arm64/spawn-helper
Error: posix_spawnp failed.
```

**Startup repair, applied to that same broken tree:**
```
=== BEFORE ===
-rw-r--r--  .../node-pty/prebuilds/darwin-arm64/spawn-helper
Error: posix_spawnp failed.
=== APPLY REPAIR ===
repaired: [ '.../node-pty/prebuilds/darwin-arm64/spawn-helper' ]
=== AFTER ===
-rwxr-xr-x  .../node-pty/prebuilds/darwin-arm64/spawn-helper
PTY SPAWN OK
=== IDEMPOTENT re-run ===
repaired: []
```

**Fixed formula flags + this branch's package** (`npm install --global --build-from-source`, i.e. `std_npm_args(ignore_scripts: false)`):
```
NPM INSTALL EXIT=0
-rwxr-xr-x  node-pty/build/Release/pty.node
-rwxr-xr-x  node-pty/build/Release/spawn-helper
-rwxr-xr-x  better-sqlite3/build/Release/better_sqlite3.node
  -> better-sqlite3 open: PASS
  -> node-pty spawn: PASS
jinn --version -> 0.29.0
```

**Regression coverage.** Three new suites, all of which fail without this change (13 of 15 failed on the pre-fix source; the postinstall suite fails 3 of 5 against the old script):
- `src/shared/__tests__/runtime-guard.test.ts` — failure classification and the spawn-helper repair across all three node-pty layouts.
- `src/shared/__tests__/postinstall-node-pty.test.ts` — runs the real postinstall as npm would, including the source-built layout with no `prebuilds/` that previously threw.
- `src/shared/__tests__/homebrew-formula.test.ts` — locks the formula's `ignore_scripts: false`, the non-false-negative test assertions, and that the test block only requires modules the published package actually depends on.

`ruby -c Formula/jinn.rb` → Syntax OK. `pnpm typecheck` at root → 2 successful. Full suite from `packages/jinn`:

```
 Test Files  317 passed (317)
      Tests  3875 passed | 7 skipped (3882)
   Start at  09:57:31
   Duration  50.32s (transform 10.34s, setup 2.93s, import 43.97s, tests 166.03s, environment 21ms)
```

No flakes tripped; no re-runs needed.

## Note on release gating

`brew test` still never runs during `brew install`, so the hardened test block only protects us if releases are gated on it. That CI job is not added here — worth a follow-up.

Fixes #108
Fixes #109
