### PR TITLE
Add owner-only Telegram auth flows for Claude and Codex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,12 @@ RUN git config --system --add safe.directory '*'
 ARG CLAUDE_CODE_VERSION=2.1.220
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
+# The Telegram auth flow verifies the same persistent Codex CLI account that
+# interactive turns use. Keep it pinned in the image; the writable auth volume
+# stores only its login state, not the executable.
+ARG CODEX_CLI_VERSION=0.149.0
+RUN npm install -g "@openai/codex@${CODEX_CLI_VERSION}"
+
 # Without this the pin is defeatable: the CLI is installed root-owned but runs as
 # `node`, so the updater either warns every turn or relocates itself onto the
 # writable volume, where the drift then survives rebuilds. Unprefixed on purpose —
@@ -106,7 +112,7 @@ RUN chmod 0755 /usr/local/bin/jinn-entrypoint /usr/local/bin/jinn-healthcheck
 # The symlink is the net under CLAUDE_CONFIG_DIR below — a release that stops honouring
 # it writes ~/.claude.json, which the next rebuild discards. Linked after the chown and
 # chowned with -h, because the target does not exist until Claude Code first runs.
-RUN mkdir -p /home/node/.jinn /home/node/.claude /work \
+RUN mkdir -p /home/node/.jinn /home/node/.claude /home/node/.codex /work \
   && chown -R node:node /home/node /work \
   && ln -s /home/node/.claude/.claude.json /home/node/.claude.json \
   && chown -h node:node /home/node/.claude.json
@@ -123,6 +129,7 @@ WORKDIR /home/node
 # which sits in the container layer and is discarded by every rebuild along with
 # the user's MCP servers, project trust and onboarding state.
 ENV CLAUDE_CONFIG_DIR=/home/node/.claude
+ENV CODEX_HOME=/home/node/.codex
 
 # Publish to the host's loopback only. The dashboard authenticates with a shared
 # gateway token, so a routable interface would put agent control on the network.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -10,17 +10,17 @@ connectors:
   telegram:
     botToken: ...
     allowFrom:
-      - 5658965359
+      - 123456789
     telegramAuth:
       enabled: true
       ownerUserIds:
-        - 5658965359
+        - 123456789
       flowTtlSeconds: 600
 ```
 
 `ownerUserIds` must contain numeric Telegram user IDs. It does not replace the
 normal `allowFrom` gate; keep both restricted to the intended owner. Usernames
-are not an authentication boundary.
+are not an authentication boundary. Replace the example ID with your own.
 
 Supported private-chat commands:
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,0 +1,40 @@
+# Connectors
+
+## Telegram Authentication
+
+Telegram auth commands are disabled unless the Telegram connector config enables
+them explicitly:
+
+```yaml
+connectors:
+  telegram:
+    botToken: ...
+    allowFrom:
+      - 5658965359
+    telegramAuth:
+      enabled: true
+      ownerUserIds:
+        - 5658965359
+      flowTtlSeconds: 600
+```
+
+`ownerUserIds` must contain numeric Telegram user IDs. It does not replace the
+normal `allowFrom` gate; keep both restricted to the intended owner. Usernames
+are not an authentication boundary.
+
+Supported private-chat commands:
+
+- `/auth claude` starts `claude auth login --claudeai`.
+- `/auth codex` starts `codex login --device-auth`.
+- `/auth status` reports active flows and each provider's authenticated state.
+  If a provider is not authenticated, the reply includes the matching login
+  command, for example `/auth claude` or `/auth codex`.
+- `/auth cancel` stops active authentication flows.
+- `/auth input <one-time-code>` sends a short one-time code to the active flow
+  and deletes the Telegram message best-effort.
+
+Auth commands are intercepted before normal session routing, attachments, and
+speech-to-text handling. They are not delivered to the normal message handler.
+The connector does not accept provider tokens, add HTTP endpoints, or proxy
+arbitrary callbacks. Post-exit verification runs only fixed status commands and
+reports generic success or failure.

--- a/packages/jinn/src/connectors/telegram/__tests__/auth-flow.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/auth-flow.test.ts
@@ -3,6 +3,7 @@ import {
   AuthFlowManager,
   parseAuthCommand,
   redactAuthOutput,
+  type AuthProvider,
   type AuthPty,
   type SpawnPty,
 } from "../auth-flow.js";
@@ -60,6 +61,14 @@ function authMessage(text: string, userId = 67890) {
   };
 }
 
+function deferredBoolean() {
+  let resolve!: (value: boolean) => void;
+  const promise = new Promise<boolean>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe("Telegram auth flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -110,6 +119,50 @@ describe("Telegram auth flow", () => {
     expect(sends).toEqual([
       [
         "Claude is authenticated.",
+        "Codex is not authenticated. Use /auth codex to sign in.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("checks provider status concurrently", async () => {
+    const calls: AuthProvider[] = [];
+    const claude = deferredBoolean();
+    const codex = deferredBoolean();
+    const { manager, sends } = createManager({
+      getAuthStatus: vi.fn(async (provider) => {
+        calls.push(provider);
+        return provider === "claude" ? claude.promise : codex.promise;
+      }),
+    });
+
+    const status = manager.handleMessage(authMessage("/auth status"));
+    await Promise.resolve();
+
+    expect(calls).toEqual(["claude", "codex"]);
+    claude.resolve(true);
+    codex.resolve(false);
+    await status;
+    expect(sends).toEqual([
+      [
+        "Claude is authenticated.",
+        "Codex is not authenticated. Use /auth codex to sign in.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("bounds provider status checks to the status timeout window", async () => {
+    const { manager, sends, timers } = createManager({
+      getAuthStatus: vi.fn(async () => new Promise<boolean>(() => undefined)),
+    });
+
+    const status = manager.handleMessage(authMessage("/auth status"));
+    await Promise.resolve();
+    timers.splice(0).forEach((timer) => timer());
+    await status;
+
+    expect(sends).toEqual([
+      [
+        "Claude is not authenticated. Use /auth claude to sign in.",
         "Codex is not authenticated. Use /auth codex to sign in.",
       ].join("\n"),
     ]);

--- a/packages/jinn/src/connectors/telegram/__tests__/auth-flow.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/auth-flow.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AuthFlowManager,
+  parseAuthCommand,
+  redactAuthOutput,
+  type AuthPty,
+  type SpawnPty,
+} from "../auth-flow.js";
+
+function createPty(): AuthPty {
+  return {
+    write: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+  };
+}
+
+function createManager(options: {
+  ownerUserIds?: number[];
+  getAuthStatus?: (provider: "claude" | "codex") => Promise<boolean>;
+  spawnPty?: SpawnPty;
+} = {}) {
+  const sends: string[] = [];
+  const deletes: Array<[number | string, number | string]> = [];
+  const timers: Array<() => void> = [];
+  const spawnPty =
+    options.spawnPty ??
+    (vi.fn((_file: string, _args: string[], _options: unknown) => createPty()) as SpawnPty);
+  const manager = new AuthFlowManager({
+    ownerUserIds: options.ownerUserIds ?? [67890],
+    clock: {
+      setTimeout: (handler) => {
+        timers.push(handler);
+        return handler;
+      },
+      clearTimeout: vi.fn(),
+    },
+    send: async (_chatId, text) => {
+      sends.push(text);
+    },
+    deleteMessage: async (chatId, messageId) => {
+      deletes.push([chatId, messageId]);
+    },
+    spawnPty,
+    verifyAuth: vi.fn(async () => true),
+    getAuthStatus: options.getAuthStatus,
+    logger: {},
+  });
+  return { manager, sends, deletes, timers, spawnPty };
+}
+
+function authMessage(text: string, userId = 67890) {
+  return {
+    userId,
+    chatType: "private",
+    chatId: 12345,
+    messageId: 42,
+    text,
+  };
+}
+
+describe("Telegram auth flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses only the supported owner auth commands", () => {
+    expect(parseAuthCommand("/auth claude")).toEqual({ kind: "start", provider: "claude" });
+    expect(parseAuthCommand("/auth codex")).toEqual({ kind: "start", provider: "codex" });
+    expect(parseAuthCommand("/auth status")).toEqual({ kind: "status" });
+    expect(parseAuthCommand("/auth cancel")).toEqual({ kind: "cancel" });
+    expect(parseAuthCommand("/auth input AB12-CD34")).toEqual({ kind: "input", code: "AB12-CD34" });
+    expect(parseAuthCommand("/auth token never-accepted")).toEqual({ kind: "rejected" });
+    expect(parseAuthCommand("hello")).toBeNull();
+  });
+
+  it("redacts URLs, bearer-like values, and one-time codes from log text", () => {
+    const safe = redactAuthOutput(
+      "Open https://auth.example.test/callback?state=secret-state code AB12-CD34 Bearer eyJsecret",
+    );
+    expect(safe).not.toContain("auth.example.test");
+    expect(safe).not.toContain("secret-state");
+    expect(safe).not.toContain("AB12-CD34");
+    expect(safe).not.toContain("eyJsecret");
+  });
+
+  it("offers login commands for unauthenticated provider status", async () => {
+    const { manager, sends } = createManager({
+      getAuthStatus: vi.fn(async () => false),
+    });
+
+    await manager.handleMessage(authMessage("/auth status"));
+
+    expect(sends).toEqual([
+      [
+        "Claude is not authenticated. Use /auth claude to sign in.",
+        "Codex is not authenticated. Use /auth codex to sign in.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("reports authenticated provider states without login prompts", async () => {
+    const { manager, sends } = createManager({
+      getAuthStatus: vi.fn(async (provider) => provider === "claude"),
+    });
+
+    await manager.handleMessage(authMessage("/auth status"));
+
+    expect(sends).toEqual([
+      [
+        "Claude is authenticated.",
+        "Codex is not authenticated. Use /auth codex to sign in.",
+      ].join("\n"),
+    ]);
+  });
+
+  it("keeps active-flow status isolated by owner", async () => {
+    const spawnPty = vi.fn(
+      (_file: string, _args: string[], _options: unknown) => createPty(),
+    ) as SpawnPty;
+    const { manager, sends } = createManager({
+      ownerUserIds: [67890, 11111],
+      getAuthStatus: vi.fn(async () => false),
+      spawnPty,
+    });
+    await manager.handleMessage(authMessage("/auth claude", 67890));
+
+    await manager.handleMessage(authMessage("/auth status", 11111));
+
+    expect(sends.at(-1)).toBe(
+      [
+        "Claude is not authenticated. Use /auth claude to sign in.",
+        "Codex is not authenticated. Use /auth codex to sign in.",
+      ].join("\n"),
+    );
+  });
+
+  it("preserves active-flow status for the requesting owner", async () => {
+    const spawnPty = vi.fn(
+      (_file: string, _args: string[], _options: unknown) => createPty(),
+    ) as SpawnPty;
+    const { manager, sends } = createManager({
+      getAuthStatus: vi.fn(async () => false),
+      spawnPty,
+    });
+    await manager.handleMessage(authMessage("/auth claude"));
+
+    await manager.handleMessage(authMessage("/auth status"));
+
+    expect(sends.at(-1)).toBe(
+      [
+        "Active authentication flows: Claude.",
+        "Claude is not authenticated. Use /auth claude to sign in.",
+        "Codex is not authenticated. Use /auth codex to sign in.",
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
@@ -663,6 +663,58 @@ describe("TelegramConnector", () => {
     });
   });
 
+  describe("authentication failures", () => {
+    it("offers the owner login commands after a provider authentication failure", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+
+      await authConnector.replyMessage(
+        { channel: "12345", replyContext: { chatId: "12345", messageId: 42 } },
+        "⛔ Interactive turn failed: authentication_failed",
+      );
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "12345",
+        expect.stringContaining("use /auth claude or /auth codex to sign in."),
+        expect.objectContaining({
+          parse_mode: "Markdown",
+          reply_parameters: { message_id: 42 },
+        }),
+      );
+    });
+
+    it("does not add login prompts to unrelated provider errors", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+
+      await authConnector.replyMessage(
+        { channel: "12345", replyContext: { chatId: "12345", messageId: 42 } },
+        "⛔ Interactive turn failed: rate_limit",
+      );
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "12345",
+        "⛔ Interactive turn failed: rate_limit",
+        {
+          parse_mode: "Markdown",
+          reply_parameters: { message_id: 42 },
+        },
+      );
+    });
+  });
+
   describe("replyMessage", () => {
     it("sends a reply to a specific message", async () => {
       const target: Target = {

--- a/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
@@ -717,12 +717,12 @@ describe("TelegramConnector", () => {
             userId: 67890,
           },
         },
-        "⛔ HTTP 401 from an unrelated MCP server",
+        "⛔ unrelated MCP: browser is not logged in",
       );
 
       expect(mockSendMessage).toHaveBeenCalledWith(
         "12345",
-        "⛔ HTTP 401 from an unrelated MCP server",
+        "⛔ unrelated MCP: browser is not logged in",
         {
           parse_mode: "Markdown",
           reply_parameters: { message_id: 42 },

--- a/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
@@ -675,7 +675,15 @@ describe("TelegramConnector", () => {
       });
 
       await authConnector.replyMessage(
-        { channel: "12345", replyContext: { chatId: "12345", messageId: 42 } },
+        {
+          channel: "12345",
+          replyContext: {
+            chatId: "12345",
+            messageId: 42,
+            chatType: "private",
+            userId: 67890,
+          },
+        },
         "⛔ Interactive turn failed: authentication_failed",
       );
 
@@ -700,13 +708,87 @@ describe("TelegramConnector", () => {
       });
 
       await authConnector.replyMessage(
-        { channel: "12345", replyContext: { chatId: "12345", messageId: 42 } },
-        "⛔ Interactive turn failed: rate_limit",
+        {
+          channel: "12345",
+          replyContext: {
+            chatId: "12345",
+            messageId: 42,
+            chatType: "private",
+            userId: 67890,
+          },
+        },
+        "⛔ HTTP 401 from an unrelated MCP server",
       );
 
       expect(mockSendMessage).toHaveBeenCalledWith(
         "12345",
-        "⛔ Interactive turn failed: rate_limit",
+        "⛔ HTTP 401 from an unrelated MCP server",
+        {
+          parse_mode: "Markdown",
+          reply_parameters: { message_id: 42 },
+        },
+      );
+    });
+
+    it("does not offer login outside the owner private chat", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+
+      await authConnector.replyMessage(
+        {
+          channel: "-100999",
+          replyContext: {
+            chatId: "-100999",
+            messageId: 42,
+            chatType: "group",
+            userId: 67890,
+          },
+        },
+        "⛔ Interactive turn failed: authentication_failed",
+      );
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "-100999",
+        "⛔ Interactive turn failed: authentication_failed",
+        {
+          parse_mode: "Markdown",
+          reply_parameters: { message_id: 42 },
+        },
+      );
+    });
+
+    it("does not offer login to a non-owner private chat", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [11111],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+
+      await authConnector.replyMessage(
+        {
+          channel: "12345",
+          replyContext: {
+            chatId: "12345",
+            messageId: 42,
+            chatType: "private",
+            userId: 11111,
+          },
+        },
+        "⛔ Interactive turn failed: authentication_failed",
+      );
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "12345",
+        "⛔ Interactive turn failed: authentication_failed",
         {
           parse_mode: "Markdown",
           reply_parameters: { message_id: 42 },

--- a/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
@@ -4,15 +4,43 @@ import type { IncomingMessage, Session, Target } from "../../../shared/types.js"
 // Mock node-telegram-bot-api before importing connector
 const mockSendMessage = vi.fn().mockResolvedValue({ message_id: 1 });
 const mockEditMessageText = vi.fn().mockResolvedValue(true);
+const mockDeleteMessage = vi.fn().mockResolvedValue(true);
 const mockGetMe = vi.fn().mockResolvedValue({ id: 999, username: "test_bot" });
 const mockStartPolling = vi.fn();
 const mockStopPolling = vi.fn().mockResolvedValue(undefined);
 const mockOn = vi.fn();
+const mockPtyWrite = vi.fn();
+const mockPtyKill = vi.fn();
+const mockPtyOnData = vi.fn();
+const mockPtyOnExit = vi.fn();
+const mockPtySpawn = vi.fn(() => ({
+  write: mockPtyWrite,
+  kill: mockPtyKill,
+  onData: mockPtyOnData,
+  onExit: mockPtyOnExit,
+}));
+let mockClaudeLoggedIn = false;
+let mockCodexExitCode = 1;
+const mockExecFile = vi.fn((_file, _args, _options, callback) => {
+  callback(null, JSON.stringify({ loggedIn: mockClaudeLoggedIn }));
+});
+const mockChildKill = vi.fn();
+const mockSpawnOnce = vi.fn(function (this: any, event: string, handler: (code?: number) => void) {
+  if (event === "exit") {
+    queueMicrotask(() => handler(mockCodexExitCode));
+  }
+  return this;
+});
+const mockSpawn = vi.fn(() => ({
+  kill: mockChildKill,
+  once: mockSpawnOnce,
+}));
 
 vi.mock("node-telegram-bot-api", () => {
   const MockBot = vi.fn(function (this: any) {
     this.sendMessage = mockSendMessage;
     this.editMessageText = mockEditMessageText;
+    this.deleteMessage = mockDeleteMessage;
     this.getMe = mockGetMe;
     this.startPolling = mockStartPolling;
     this.stopPolling = mockStopPolling;
@@ -20,6 +48,15 @@ vi.mock("node-telegram-bot-api", () => {
   });
   return { default: MockBot };
 });
+
+vi.mock("node-pty", () => ({
+  spawn: mockPtySpawn,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: mockExecFile,
+  spawn: mockSpawn,
+}));
 
 vi.mock("../../../shared/logger.js", () => ({
   logger: {
@@ -39,6 +76,8 @@ describe("TelegramConnector", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClaudeLoggedIn = false;
+    mockCodexExitCode = 1;
     connector = new TelegramConnector({
       botToken: "123456:ABC-DEF",
     });
@@ -98,6 +137,279 @@ describe("TelegramConnector", () => {
   });
 
   describe("onMessage", () => {
+    it("preserves default-disabled auth text routing", async () => {
+      const handler = vi.fn();
+      connector.onMessage(handler);
+      await connector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 42,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 67890, username: "testuser", first_name: "Test", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth status",
+      });
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler.mock.calls[0][0].text).toBe("/auth status");
+      expect(mockSendMessage).not.toHaveBeenCalled();
+      expect(mockPtySpawn).not.toHaveBeenCalled();
+    });
+
+    it("handles owner auth status without a normal handler", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 42,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 67890, username: "owner", first_name: "Owner", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth status",
+      });
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "12345",
+        [
+          "Claude is not authenticated. Use /auth claude to sign in.",
+          "Codex is not authenticated. Use /auth codex to sign in.",
+        ].join("\n"),
+        { parse_mode: "Markdown" },
+      );
+      expect(mockPtySpawn).not.toHaveBeenCalled();
+    });
+
+    it("reports authenticated provider status without CLI output", async () => {
+      mockClaudeLoggedIn = true;
+      mockCodexExitCode = 0;
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      const handler = vi.fn();
+      authConnector.onMessage(handler);
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 42,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 67890, username: "owner", first_name: "Owner", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth status",
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "12345",
+        ["Claude is authenticated.", "Codex is authenticated."].join("\n"),
+        { parse_mode: "Markdown" },
+      );
+      expect(mockExecFile).toHaveBeenCalledWith(
+        "claude",
+        ["auth", "status", "--json"],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            HOME: "/home/node",
+            CLAUDE_CONFIG_DIR: "/home/node/.claude",
+            CODEX_HOME: "/home/node/.codex",
+          }),
+        }),
+        expect.any(Function),
+      );
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "codex",
+        ["login", "status"],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            HOME: "/home/node",
+            CLAUDE_CONFIG_DIR: "/home/node/.claude",
+            CODEX_HOME: "/home/node/.codex",
+          }),
+          stdio: "ignore",
+        }),
+      );
+    });
+
+    it("starts owner auth without calling the normal handler", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      const handler = vi.fn();
+      authConnector.onMessage(handler);
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 43,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 67890, username: "owner", first_name: "Owner", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth claude",
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(mockPtySpawn).toHaveBeenCalledWith(
+        "claude",
+        ["auth", "login", "--claudeai"],
+        expect.objectContaining({
+          cwd: "/home/node",
+          env: expect.objectContaining({
+            HOME: "/home/node",
+            CLAUDE_CONFIG_DIR: "/home/node/.claude",
+            CODEX_HOME: "/home/node/.codex",
+          }),
+        }),
+      );
+    });
+
+    it("deletes owner auth input best-effort without calling the normal handler", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      const handler = vi.fn();
+      authConnector.onMessage(handler);
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 44,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 67890, username: "owner", first_name: "Owner", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth input AB12-CD34",
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(mockDeleteMessage).toHaveBeenCalledWith("12345", 44);
+    });
+
+    it("ignores non-owner auth text after allowFrom without normal routing", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890, 99999],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      const handler = vi.fn();
+      authConnector.onMessage(handler);
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 45,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 99999, username: "stranger", first_name: "Stranger", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth status",
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(mockSendMessage).not.toHaveBeenCalled();
+      expect(mockPtySpawn).not.toHaveBeenCalled();
+    });
+
+    it("rejects owner auth commands in groups without normal routing", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      const handler = vi.fn();
+      authConnector.onMessage(handler);
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 46,
+        chat: { id: -10012345, type: "group" as const },
+        from: { id: 67890, username: "owner", first_name: "Owner", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth status",
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "-10012345",
+        "Authentication commands are available only in a private chat.",
+        { parse_mode: "Markdown" },
+      );
+    });
+
+    it("routes ordinary owner messages unchanged when auth is enabled", async () => {
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      const handler = vi.fn();
+      authConnector.onMessage(handler);
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      await messageCallback({
+        message_id: 47,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 67890, username: "owner", first_name: "Owner", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "Hello bot!",
+      });
+
+      expect(handler).toHaveBeenCalledOnce();
+      const msg: IncomingMessage = handler.mock.calls[0][0];
+      expect(msg.text).toBe("Hello bot!");
+      expect(msg.userId).toBe("67890");
+      expect(msg.channel).toBe("12345");
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
     it("stamps and replies through a named connector instance id", async () => {
       const named = new TelegramConnector({
         id: "telegram-support",

--- a/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/connector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { IncomingMessage, Session, Target } from "../../../shared/types.js";
 
 // Mock node-telegram-bot-api before importing connector
@@ -21,12 +21,14 @@ const mockPtySpawn = vi.fn(() => ({
 }));
 let mockClaudeLoggedIn = false;
 let mockCodexExitCode = 1;
+let mockCodexHang = false;
 const mockExecFile = vi.fn((_file, _args, _options, callback) => {
   callback(null, JSON.stringify({ loggedIn: mockClaudeLoggedIn }));
 });
 const mockChildKill = vi.fn();
+const mockSpawnRemoveListener = vi.fn();
 const mockSpawnOnce = vi.fn(function (this: any, event: string, handler: (code?: number) => void) {
-  if (event === "exit") {
+  if (event === "exit" && !mockCodexHang) {
     queueMicrotask(() => handler(mockCodexExitCode));
   }
   return this;
@@ -34,6 +36,7 @@ const mockSpawnOnce = vi.fn(function (this: any, event: string, handler: (code?:
 const mockSpawn = vi.fn(() => ({
   kill: mockChildKill,
   once: mockSpawnOnce,
+  removeListener: mockSpawnRemoveListener,
 }));
 
 vi.mock("node-telegram-bot-api", () => {
@@ -78,9 +81,14 @@ describe("TelegramConnector", () => {
     vi.clearAllMocks();
     mockClaudeLoggedIn = false;
     mockCodexExitCode = 1;
+    mockCodexHang = false;
     connector = new TelegramConnector({
       botToken: "123456:ABC-DEF",
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe("constructor", () => {
@@ -247,6 +255,51 @@ describe("TelegramConnector", () => {
           }),
           stdio: "ignore",
         }),
+      );
+    });
+
+    it("terminates timed-out Codex status and escalates to SIGKILL", async () => {
+      vi.useFakeTimers();
+      mockClaudeLoggedIn = true;
+      mockCodexHang = true;
+      const authConnector = new TelegramConnector({
+        botToken: "123456:ABC-DEF",
+        allowFrom: [67890],
+        telegramAuth: {
+          enabled: true,
+          ownerUserIds: [67890],
+        },
+      });
+      await authConnector.start();
+
+      const messageCallback = mockOn.mock.calls.find(
+        (call) => call[0] === "message",
+      )?.[1];
+      const statusPromise = messageCallback({
+        message_id: 42,
+        chat: { id: 12345, type: "private" as const },
+        from: { id: 67890, username: "owner", first_name: "Owner", is_bot: false },
+        date: Math.floor(Date.now() / 1000) + 10,
+        text: "/auth status",
+      });
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(mockChildKill).toHaveBeenCalledWith("SIGTERM");
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(mockChildKill).toHaveBeenCalledWith("SIGKILL");
+      await vi.advanceTimersByTimeAsync(2_000);
+      await statusPromise;
+
+      expect(mockSpawnRemoveListener).toHaveBeenCalledWith("error", expect.any(Function));
+      expect(mockSpawnRemoveListener).toHaveBeenCalledWith("exit", expect.any(Function));
+      expect(mockSpawnRemoveListener).toHaveBeenCalledWith("close", expect.any(Function));
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        "12345",
+        [
+          "Claude is authenticated.",
+          "Codex is not authenticated. Use /auth codex to sign in.",
+        ].join("\n"),
+        { parse_mode: "Markdown" },
       );
     });
 

--- a/packages/jinn/src/connectors/telegram/__tests__/threads.test.ts
+++ b/packages/jinn/src/connectors/telegram/__tests__/threads.test.ts
@@ -32,10 +32,13 @@ describe("buildReplyContext", () => {
     const ctx = buildReplyContext({
       chat: { id: 12345, type: "private" },
       message_id: 42,
+      from: { id: 67890 },
     });
     expect(ctx).toEqual({
       chatId: 12345,
       messageId: 42,
+      chatType: "private",
+      userId: 67890,
     });
   });
 
@@ -47,6 +50,7 @@ describe("buildReplyContext", () => {
     expect(ctx).toEqual({
       chatId: -100999,
       messageId: 99,
+      chatType: "group",
     });
   });
 });

--- a/packages/jinn/src/connectors/telegram/auth-flow.ts
+++ b/packages/jinn/src/connectors/telegram/auth-flow.ts
@@ -1,4 +1,5 @@
 export type AuthProvider = "claude" | "codex";
+const AUTH_PROVIDERS = ["claude", "codex"] as const satisfies readonly AuthProvider[];
 
 export type AuthCommand =
   | { kind: "start"; provider: AuthProvider }
@@ -104,29 +105,90 @@ export function parseAuthCommand(text: string): AuthCommand | null {
     return null;
   }
 
-  const args = match[1]?.trim().split(/\s+/) ?? [];
-  if (args.length !== 1 && args.length !== 2) {
-    return { kind: "rejected" };
-  }
+  return parseAuthArgs(match[1]?.trim().split(/\s+/) ?? []);
+}
 
-  const action = args[0]?.toLowerCase();
-  if (action === "claude" && args.length === 1) {
-    return { kind: "start", provider: "claude" };
+function parseAuthArgs(args: string[]): AuthCommand {
+  if (args.length === 1) {
+    return parseSingleArgCommand(args[0].toLowerCase());
   }
-  if (action === "codex" && args.length === 1) {
-    return { kind: "start", provider: "codex" };
-  }
-  if (action === "status" && args.length === 1) {
-    return { kind: "status" };
-  }
-  if (action === "cancel" && args.length === 1) {
-    return { kind: "cancel" };
-  }
-  if (action === "input" && args.length === 2 && isAuthCode(args[1])) {
+  if (args.length === 2 && args[0].toLowerCase() === "input" && isAuthCode(args[1])) {
     return { kind: "input", code: args[1] };
   }
-
   return { kind: "rejected" };
+}
+
+function parseSingleArgCommand(action: string): AuthCommand {
+  switch (action) {
+    case "claude":
+      return { kind: "start", provider: "claude" };
+    case "codex":
+      return { kind: "start", provider: "codex" };
+    case "status":
+      return { kind: "status" };
+    case "cancel":
+      return { kind: "cancel" };
+    default:
+      return { kind: "rejected" };
+  }
+}
+
+function dispatchableCommand(command: AuthCommand | null): command is AuthCommand {
+  return command !== null;
+}
+
+function providerArgs(provider: AuthProvider): string[] {
+  return provider === "claude"
+    ? ["auth", "login", "--claudeai"]
+    : ["login", "--device-auth"];
+}
+
+function providerEnv(): Record<string, string> {
+  return {
+    PATH:
+      process.env.PATH ??
+      "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    HOME: "/home/node",
+    CLAUDE_CONFIG_DIR: "/home/node/.claude",
+    CODEX_HOME: "/home/node/.codex",
+  };
+}
+
+function flowHasActiveDiscovery(flow: ActiveFlow): boolean {
+  return Boolean(
+    (flow.discoveredUrl && !flow.urlSent) ||
+      (flow.discoveredCode && !flow.codeSent),
+  );
+}
+
+function discoveryLines(flow: ActiveFlow): string[] {
+  const lines = ["Continue authentication:"];
+  if (flow.discoveredUrl && !flow.urlSent) {
+    flow.urlSent = true;
+    lines.push(flow.discoveredUrl);
+  }
+  if (flow.discoveredCode && !flow.codeSent) {
+    flow.codeSent = true;
+    lines.push("Device code: " + flow.discoveredCode);
+  }
+  return lines;
+}
+
+function activeProviderStatusLine(providers: AuthProvider[]): string | null {
+  if (providers.length === 0) {
+    return null;
+  }
+  return (
+    "Active authentication flows: " +
+    providers.map((provider) => providerLabel(provider)).join(", ") +
+    "."
+  );
+}
+
+function validDurationSeconds(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
 }
 
 export function redactAuthOutput(text: string): string {
@@ -196,6 +258,47 @@ interface ActiveFlow {
   exitSubscription?: { dispose?: () => void };
 }
 
+function createFlow(options: {
+  ownerId: number;
+  key: FlowKey;
+  provider: AuthProvider;
+  chatId: AuthChatId;
+  pty: AuthPty;
+}): ActiveFlow {
+  return {
+    ...options,
+    output: "",
+    discoveryTail: "",
+    timer: undefined,
+    urlSent: false,
+    codeSent: false,
+    discoveryScheduled: false,
+    invalidated: false,
+  };
+}
+
+function subscriptionObject(
+  subscription: { dispose?: () => void } | void,
+): { dispose?: () => void } | undefined {
+  return subscription && typeof subscription === "object"
+    ? subscription
+    : undefined;
+}
+
+function statusLines(
+  activeProviders: AuthProvider[],
+  statuses: Array<{ provider: AuthProvider; authenticated: boolean }>,
+): string[] {
+  const activeLine = activeProviderStatusLine(activeProviders);
+  const lines = activeLine ? [activeLine] : [];
+  lines.push(
+    ...statuses.map(({ provider, authenticated }) =>
+      statusLine(provider, authenticated),
+    ),
+  );
+  return lines;
+}
+
 export class AuthFlowManager {
   private readonly ownerUserIds: ReadonlySet<number>;
   private readonly clock: AuthClock;
@@ -218,17 +321,15 @@ export class AuthFlowManager {
     this.spawnPty = options.spawnPty;
     this.verifyAuth = options.verifyAuth;
     this.getAuthStatus = options.getAuthStatus;
-    this.verifyTimeoutSeconds =
-      options.verifyTimeoutSeconds &&
-      Number.isFinite(options.verifyTimeoutSeconds) &&
-      options.verifyTimeoutSeconds > 0
-        ? options.verifyTimeoutSeconds
-        : DEFAULT_VERIFY_TIMEOUT_SECONDS;
+    this.verifyTimeoutSeconds = validDurationSeconds(
+      options.verifyTimeoutSeconds,
+      DEFAULT_VERIFY_TIMEOUT_SECONDS,
+    );
     this.logger = options.logger;
-    this.flowTtlSeconds =
-      options.flowTtlSeconds && options.flowTtlSeconds > 0
-        ? options.flowTtlSeconds
-        : DEFAULT_FLOW_TTL_SECONDS;
+    this.flowTtlSeconds = validDurationSeconds(
+      options.flowTtlSeconds,
+      DEFAULT_FLOW_TTL_SECONDS,
+    );
   }
 
   async handleMessage(message: AuthMessage): Promise<boolean> {
@@ -255,31 +356,13 @@ export class AuthFlowManager {
       return true;
     }
 
-    if (!command) {
+    if (!dispatchableCommand(command)) {
       await this.sendSafely(message.chatId, "Unsupported authentication command.");
       return true;
     }
 
-    switch (command.kind) {
-      case "start":
-        await this.startFlow(ownerId, command.provider, message.chatId);
-        return true;
-      case "status":
-        await this.sendStatus(ownerId, message.chatId);
-        return true;
-      case "cancel":
-        await this.cancelFlow(ownerId, message.chatId);
-        return true;
-      case "input":
-        await this.writeCode(ownerId, command.code, message.chatId);
-        return true;
-      case "rejected":
-        await this.sendSafely(
-          message.chatId,
-          "Unsupported authentication command. One-time codes must match the short-code format; tokens are not accepted.",
-        );
-        return true;
-    }
+    await this.dispatchCommand(ownerId, command, message.chatId);
+    return true;
   }
 
   stop(): void {
@@ -296,6 +379,86 @@ export class AuthFlowManager {
       : null;
   }
 
+  private async dispatchCommand(
+    ownerId: number,
+    command: AuthCommand,
+    chatId: AuthChatId,
+  ): Promise<void> {
+    switch (command.kind) {
+      case "start":
+        await this.startFlow(ownerId, command.provider, chatId);
+        return;
+      case "status":
+        await this.sendStatus(ownerId, chatId);
+        return;
+      case "cancel":
+        await this.cancelFlow(ownerId, chatId);
+        return;
+      case "input":
+        await this.writeCode(ownerId, command.code, chatId);
+        return;
+      case "rejected":
+        await this.sendRejectedCommand(chatId);
+    }
+  }
+
+  private async sendRejectedCommand(chatId: AuthChatId): Promise<void> {
+    await this.sendSafely(
+      chatId,
+      "Unsupported authentication command. One-time codes must match the short-code format; tokens are not accepted.",
+    );
+  }
+
+  private clearPreviousFlow(key: FlowKey): void {
+    const previous = this.activeFlows.get(key);
+    if (previous) {
+      this.clearFlow(previous, true);
+    }
+  }
+
+  private async spawnProviderPty(
+    provider: AuthProvider,
+    chatId: AuthChatId,
+  ): Promise<AuthPty | null> {
+    try {
+      return this.spawnPty(provider, providerArgs(provider), {
+        name: "xterm-256color",
+        cols: 120,
+        rows: 40,
+        cwd: "/home/node",
+        env: providerEnv(),
+      });
+    } catch {
+      await this.sendSafely(chatId, providerLabel(provider) + " authentication failed to start.");
+      this.logger.error?.("[telegram-auth] failed to start provider process");
+      return null;
+    }
+  }
+
+  private attachFlowHandlers(flow: ActiveFlow): void {
+    const dataSubscription = flow.pty.onData((data) => {
+      if (!this.isActiveFlow(flow)) {
+        return;
+      }
+      this.captureDiscovery(flow, data);
+      flow.output = appendOutput(flow.output, data);
+      this.scheduleDiscovery(flow);
+    });
+    const exitSubscription = flow.pty.onExit((event) => {
+      void this.finishFlow(flow, event.exitCode);
+    });
+    flow.dataSubscription = subscriptionObject(dataSubscription);
+    flow.exitSubscription = subscriptionObject(exitSubscription);
+    flow.timer = this.clock.setTimeout(
+      () => this.timeoutFlow(flow),
+      this.flowTtlSeconds * 1000,
+    );
+  }
+
+  private isActiveFlow(flow: ActiveFlow): boolean {
+    return this.activeFlows.get(flow.key) === flow && !flow.invalidated;
+  }
+
   private async startFlow(
     ownerId: number,
     provider: AuthProvider,
@@ -303,79 +466,16 @@ export class AuthFlowManager {
   ): Promise<void> {
     const key = flowKey(ownerId, provider);
     this.invalidatePendingVerifications(key);
-    const previous = this.activeFlows.get(key);
-    if (previous) {
-      this.clearFlow(previous, true);
-    }
+    this.clearPreviousFlow(key);
 
-    const args =
-      provider === "claude"
-        ? ["auth", "login", "--claudeai"]
-        : ["login", "--device-auth"];
-    const env = {
-      PATH:
-        process.env.PATH ??
-        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-      HOME: "/home/node",
-      CLAUDE_CONFIG_DIR: "/home/node/.claude",
-      CODEX_HOME: "/home/node/.codex",
-    };
-
-    let pty: AuthPty;
-    try {
-      pty = this.spawnPty(provider, args, {
-        name: "xterm-256color",
-        cols: 120,
-        rows: 40,
-        cwd: "/home/node",
-        env,
-      });
-    } catch {
-      await this.sendSafely(chatId, providerLabel(provider) + " authentication failed to start.");
-      this.logger.error?.("[telegram-auth] failed to start provider process");
+    const pty = await this.spawnProviderPty(provider, chatId);
+    if (!pty) {
       return;
     }
 
-    const flow: ActiveFlow = {
-      ownerId,
-      key,
-      provider,
-      chatId,
-      pty,
-      output: "",
-      discoveryTail: "",
-      timer: undefined,
-      urlSent: false,
-      codeSent: false,
-      discoveryScheduled: false,
-      invalidated: false,
-    };
+    const flow = createFlow({ ownerId, key, provider, chatId, pty });
     this.activeFlows.set(key, flow);
-
-    const dataSubscription = pty.onData((data) => {
-      if (this.activeFlows.get(key) !== flow || flow.invalidated) {
-        return;
-      }
-      this.captureDiscovery(flow, data);
-      flow.output = appendOutput(flow.output, data);
-      this.scheduleDiscovery(flow);
-    });
-    const exitSubscription = pty.onExit((event) => {
-      void this.finishFlow(flow, event.exitCode);
-    });
-    flow.dataSubscription =
-      dataSubscription && typeof dataSubscription === "object"
-        ? dataSubscription
-        : undefined;
-    flow.exitSubscription =
-      exitSubscription && typeof exitSubscription === "object"
-        ? exitSubscription
-        : undefined;
-    flow.timer = this.clock.setTimeout(
-      () => this.timeoutFlow(flow),
-      this.flowTtlSeconds * 1000,
-    );
-
+    this.attachFlowHandlers(flow);
     await this.sendSafely(
       chatId,
       providerLabel(provider) + " authentication started. Follow the instructions below.",
@@ -418,19 +518,10 @@ export class AuthFlowManager {
       flow.discoveredCode = discovery.code;
     }
 
-    const lines = ["Continue authentication:"];
-    if (flow.discoveredUrl && !flow.urlSent) {
-      flow.urlSent = true;
-      lines.push(flow.discoveredUrl);
-    }
-    if (flow.discoveredCode && !flow.codeSent) {
-      flow.codeSent = true;
-      lines.push("Device code: " + flow.discoveredCode);
-    }
-    if (lines.length === 1) {
+    if (!flowHasActiveDiscovery(flow)) {
       return;
     }
-    void this.sendSafely(flow.chatId, lines.join("\n"));
+    void this.sendSafely(flow.chatId, discoveryLines(flow).join("\n"));
   }
 
   private async sendStatus(ownerId: number, chatId: AuthChatId): Promise<void> {
@@ -438,18 +529,13 @@ export class AuthFlowManager {
       .filter((flow) => flow.ownerId === ownerId)
       .map((flow) => flow.provider)
       .sort();
-    const lines: string[] = [];
-    if (activeProviders.length > 0) {
-      lines.push(
-        "Active authentication flows: " +
-          activeProviders.map((provider) => providerLabel(provider)).join(", ") +
-          ".",
-      );
-    }
-    for (const provider of ["claude", "codex"] as const) {
-      const authenticated = await this.readAuthStatus(provider);
-      lines.push(statusLine(provider, authenticated));
-    }
+    const statuses = await Promise.all(
+      AUTH_PROVIDERS.map(async (provider) => ({
+        provider,
+        authenticated: await this.readAuthStatusWithTimeout(provider),
+      })),
+    );
+    const lines = statusLines(activeProviders, statuses);
     await this.sendSafely(chatId, lines.join("\n"));
   }
 
@@ -544,26 +630,14 @@ export class AuthFlowManager {
     if (!this.verifyAuth) {
       return false;
     }
-
-    let timeoutHandle: unknown;
-    let timerCreated = false;
     try {
-      const verification = Promise.resolve(this.verifyAuth(provider));
-      const timeout = new Promise<boolean>((resolve) => {
-        timeoutHandle = this.clock.setTimeout(
-          () => resolve(false),
-          this.verifyTimeoutSeconds * 1000,
-        );
-        timerCreated = true;
-      });
-      return await Promise.race([verification, timeout]);
+      return await this.booleanWithTimeout(
+        () => Promise.resolve(this.verifyAuth?.(provider) ?? false),
+        "[telegram-auth] post-exit authentication verification timed out",
+      );
     } catch {
       this.logger.warn?.("[telegram-auth] post-exit authentication verification failed");
       return false;
-    } finally {
-      if (timerCreated) {
-        this.clock.clearTimeout(timeoutHandle);
-      }
     }
   }
 
@@ -576,6 +650,33 @@ export class AuthFlowManager {
     } catch {
       this.logger.warn?.("[telegram-auth] authentication status check failed");
       return false;
+    }
+  }
+
+  private async readAuthStatusWithTimeout(provider: AuthProvider): Promise<boolean> {
+    return await this.booleanWithTimeout(
+      () => this.readAuthStatus(provider),
+      "[telegram-auth] authentication status check timed out",
+    );
+  }
+
+  private async booleanWithTimeout(
+    action: () => Promise<boolean>,
+    timeoutLogMessage: string,
+  ): Promise<boolean> {
+    let timeoutHandle: unknown;
+    try {
+      const timeout = new Promise<boolean>((resolve) => {
+        timeoutHandle = this.clock.setTimeout(() => {
+          this.logger.warn?.(timeoutLogMessage);
+          resolve(false);
+        }, this.verifyTimeoutSeconds * 1000);
+      });
+      return await Promise.race([action(), timeout]);
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.clock.clearTimeout(timeoutHandle);
+      }
     }
   }
 

--- a/packages/jinn/src/connectors/telegram/auth-flow.ts
+++ b/packages/jinn/src/connectors/telegram/auth-flow.ts
@@ -1,0 +1,667 @@
+export type AuthProvider = "claude" | "codex";
+
+export type AuthCommand =
+  | { kind: "start"; provider: AuthProvider }
+  | { kind: "status" }
+  | { kind: "cancel" }
+  | { kind: "input"; code: string }
+  | { kind: "rejected" };
+
+export type AuthChatId = number | string;
+
+export interface AuthMessage {
+  userId: number | string;
+  chatType: string;
+  chatId: AuthChatId;
+  messageId?: number | string;
+  text: string;
+}
+
+export interface AuthPty {
+  write(data: string): void;
+  kill(signal?: string): void;
+  onData(handler: (data: string) => void): { dispose?: () => void } | void;
+  onExit(
+    handler: (event: { exitCode: number; signal?: number }) => void,
+  ): { dispose?: () => void } | void;
+}
+
+export interface AuthClock {
+  now?: () => number;
+  setTimeout(handler: () => void, delayMs: number): unknown;
+  clearTimeout(handle: unknown): void;
+}
+
+export interface AuthLogger {
+  debug?: (message: string) => void;
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+}
+
+export interface AuthSpawnOptions {
+  name: string;
+  cols: number;
+  rows: number;
+  cwd: string;
+  env: Record<string, string>;
+}
+
+export type SpawnPty = (
+  file: string,
+  args: string[],
+  options: AuthSpawnOptions,
+) => AuthPty;
+
+export interface AuthFlowManagerOptions {
+  ownerUserIds: readonly number[];
+  clock: AuthClock;
+  send: (chatId: AuthChatId, text: string) => void | Promise<void>;
+  deleteMessage: (
+    chatId: AuthChatId,
+    messageId: number | string,
+  ) => void | Promise<void>;
+  spawnPty: SpawnPty;
+  verifyAuth?: (provider: AuthProvider) => Promise<boolean>;
+  getAuthStatus?: (provider: AuthProvider) => Promise<boolean>;
+  verifyTimeoutSeconds?: number;
+  logger: AuthLogger;
+  flowTtlSeconds?: number;
+}
+
+const DEFAULT_FLOW_TTL_SECONDS = 600;
+const DEFAULT_VERIFY_TIMEOUT_SECONDS = 30;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+const MAX_DISCOVERY_TAIL_BYTES = 4096;
+const CODE_PATTERN = /^[A-Z0-9][A-Z0-9-]{3,31}$/;
+const AUTH_PREFIX_PATTERN = /^\/auth(?:@[A-Za-z0-9_]+)?(?:\s|$)/i;
+const SENSITIVE_INPUT_PATTERN =
+  /^\/auth(?:@[A-Za-z0-9_]+)?\s+(?:input|token|access[-_]token|refresh[-_]token|oauth[-_]token|api[-_]key|apikey)\b/i;
+const ANSI_PATTERN = /\u001b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+const defaultClock: AuthClock = {
+  now: () => Date.now(),
+  setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+  clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+};
+
+function isAuthCode(value: string): boolean {
+  return CODE_PATTERN.test(value);
+}
+
+function providerLabel(provider: AuthProvider): string {
+  return provider === "claude" ? "Claude" : "Codex";
+}
+
+export function parseAuthCommand(text: string): AuthCommand | null {
+  const normalized = text.trim();
+  if (!normalized || /\r|\n/.test(normalized)) {
+    return null;
+  }
+
+  const match = normalized.match(/^\/auth(?:@[A-Za-z0-9_]+)?(?:\s+(.+))?$/i);
+  if (!match) {
+    return null;
+  }
+
+  const args = match[1]?.trim().split(/\s+/) ?? [];
+  if (args.length !== 1 && args.length !== 2) {
+    return { kind: "rejected" };
+  }
+
+  const action = args[0]?.toLowerCase();
+  if (action === "claude" && args.length === 1) {
+    return { kind: "start", provider: "claude" };
+  }
+  if (action === "codex" && args.length === 1) {
+    return { kind: "start", provider: "codex" };
+  }
+  if (action === "status" && args.length === 1) {
+    return { kind: "status" };
+  }
+  if (action === "cancel" && args.length === 1) {
+    return { kind: "cancel" };
+  }
+  if (action === "input" && args.length === 2 && isAuthCode(args[1])) {
+    return { kind: "input", code: args[1] };
+  }
+
+  return { kind: "rejected" };
+}
+
+export function redactAuthOutput(text: string): string {
+  return text
+    .replace(/https?:\/\/[^\s"'<>]+/gi, "[URL REDACTED]")
+    .replace(/\bBearer\s+[^\s]+/gi, "Bearer [TOKEN REDACTED]")
+    .replace(
+      /\b(?:access|refresh|oauth)[_-]?token\s*[:=]\s*[^\s,;]+/gi,
+      "[TOKEN REDACTED]",
+    )
+    .replace(
+      /\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
+      "[TOKEN REDACTED]",
+    )
+    .replace(/\b[A-Z0-9][A-Z0-9-]{3,31}\b/g, "[CODE REDACTED]");
+}
+
+function extractDiscovery(text: string): { url?: string; code?: string } {
+  const normalized = text.replace(ANSI_PATTERN, "");
+  const urlMatch = normalized.match(/https:\/\/[^\s"'<>\x60]+/i);
+  const url = urlMatch?.[0]?.replace(/[.,!?;:)\]}]+$/g, "");
+
+  const codeMatch =
+    normalized.match(
+      /(?:device\s+code|user\s+code|code)\s*[:=]?\s*([A-Z0-9][A-Z0-9-]{3,31})\b/i,
+    ) ?? normalized.match(/(?:device_code|user_code)=([A-Z0-9][A-Z0-9-]{3,31})\b/i);
+  const code = codeMatch?.[1] && isAuthCode(codeMatch[1]) ? codeMatch[1] : undefined;
+
+  return { url, code };
+}
+
+function appendBoundedText(current: string, data: string, maxBytes: number): string {
+  const bytes = Buffer.concat([Buffer.from(current, "utf8"), Buffer.from(data, "utf8")]);
+  const kept =
+    bytes.length > maxBytes
+      ? bytes.subarray(bytes.length - maxBytes)
+      : bytes;
+  return kept.toString("utf8");
+}
+
+function appendOutput(current: string, data: string): string {
+  return appendBoundedText(current, data, MAX_OUTPUT_BYTES);
+}
+
+type FlowKey = string;
+
+function flowKey(ownerId: number, provider: AuthProvider): FlowKey {
+  return ownerId + ":" + provider;
+}
+
+interface ActiveFlow {
+  ownerId: number;
+  key: FlowKey;
+  provider: AuthProvider;
+  chatId: AuthChatId;
+  pty: AuthPty;
+  output: string;
+  discoveryTail: string;
+  timer: unknown;
+  discoveredUrl?: string;
+  discoveredCode?: string;
+  urlSent: boolean;
+  codeSent: boolean;
+  discoveryScheduled: boolean;
+  invalidated: boolean;
+  dataSubscription?: { dispose?: () => void };
+  exitSubscription?: { dispose?: () => void };
+}
+
+export class AuthFlowManager {
+  private readonly ownerUserIds: ReadonlySet<number>;
+  private readonly clock: AuthClock;
+  private readonly send: AuthFlowManagerOptions["send"];
+  private readonly deleteMessage: AuthFlowManagerOptions["deleteMessage"];
+  private readonly spawnPty: SpawnPty;
+  private readonly verifyAuth: AuthFlowManagerOptions["verifyAuth"];
+  private readonly getAuthStatus: AuthFlowManagerOptions["getAuthStatus"];
+  private readonly verifyTimeoutSeconds: number;
+  private readonly logger: AuthLogger;
+  private readonly flowTtlSeconds: number;
+  private readonly activeFlows = new Map<FlowKey, ActiveFlow>();
+  private readonly pendingVerifications = new Map<FlowKey, ActiveFlow>();
+
+  constructor(options: AuthFlowManagerOptions) {
+    this.ownerUserIds = new Set(options.ownerUserIds);
+    this.clock = options.clock ?? defaultClock;
+    this.send = options.send;
+    this.deleteMessage = options.deleteMessage;
+    this.spawnPty = options.spawnPty;
+    this.verifyAuth = options.verifyAuth;
+    this.getAuthStatus = options.getAuthStatus;
+    this.verifyTimeoutSeconds =
+      options.verifyTimeoutSeconds &&
+      Number.isFinite(options.verifyTimeoutSeconds) &&
+      options.verifyTimeoutSeconds > 0
+        ? options.verifyTimeoutSeconds
+        : DEFAULT_VERIFY_TIMEOUT_SECONDS;
+    this.logger = options.logger;
+    this.flowTtlSeconds =
+      options.flowTtlSeconds && options.flowTtlSeconds > 0
+        ? options.flowTtlSeconds
+        : DEFAULT_FLOW_TTL_SECONDS;
+  }
+
+  async handleMessage(message: AuthMessage): Promise<boolean> {
+    const rawText = message.text.trim();
+    if (!AUTH_PREFIX_PATTERN.test(rawText)) {
+      return false;
+    }
+
+    const command = parseAuthCommand(message.text);
+    const ownerId = this.canonicalOwnerId(message.userId);
+    if (ownerId === null) {
+      return true;
+    }
+
+    if (SENSITIVE_INPUT_PATTERN.test(rawText)) {
+      await this.deleteMessageSafely(message);
+    }
+
+    if (message.chatType !== "private") {
+      await this.sendSafely(
+        message.chatId,
+        "Authentication commands are available only in a private chat.",
+      );
+      return true;
+    }
+
+    if (!command) {
+      await this.sendSafely(message.chatId, "Unsupported authentication command.");
+      return true;
+    }
+
+    switch (command.kind) {
+      case "start":
+        await this.startFlow(ownerId, command.provider, message.chatId);
+        return true;
+      case "status":
+        await this.sendStatus(ownerId, message.chatId);
+        return true;
+      case "cancel":
+        await this.cancelFlow(ownerId, message.chatId);
+        return true;
+      case "input":
+        await this.writeCode(ownerId, command.code, message.chatId);
+        return true;
+      case "rejected":
+        await this.sendSafely(
+          message.chatId,
+          "Unsupported authentication command. One-time codes must match the short-code format; tokens are not accepted.",
+        );
+        return true;
+    }
+  }
+
+  stop(): void {
+    for (const flow of this.activeFlows.values()) {
+      this.clearFlow(flow, true);
+    }
+    this.invalidatePendingVerifications();
+  }
+
+  private canonicalOwnerId(userId: number | string): number | null {
+    const numericId = typeof userId === "number" ? userId : Number(userId);
+    return Number.isSafeInteger(numericId) && this.ownerUserIds.has(numericId)
+      ? numericId
+      : null;
+  }
+
+  private async startFlow(
+    ownerId: number,
+    provider: AuthProvider,
+    chatId: AuthChatId,
+  ): Promise<void> {
+    const key = flowKey(ownerId, provider);
+    this.invalidatePendingVerifications(key);
+    const previous = this.activeFlows.get(key);
+    if (previous) {
+      this.clearFlow(previous, true);
+    }
+
+    const args =
+      provider === "claude"
+        ? ["auth", "login", "--claudeai"]
+        : ["login", "--device-auth"];
+    const env = {
+      PATH:
+        process.env.PATH ??
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      HOME: "/home/node",
+      CLAUDE_CONFIG_DIR: "/home/node/.claude",
+      CODEX_HOME: "/home/node/.codex",
+    };
+
+    let pty: AuthPty;
+    try {
+      pty = this.spawnPty(provider, args, {
+        name: "xterm-256color",
+        cols: 120,
+        rows: 40,
+        cwd: "/home/node",
+        env,
+      });
+    } catch {
+      await this.sendSafely(chatId, providerLabel(provider) + " authentication failed to start.");
+      this.logger.error?.("[telegram-auth] failed to start provider process");
+      return;
+    }
+
+    const flow: ActiveFlow = {
+      ownerId,
+      key,
+      provider,
+      chatId,
+      pty,
+      output: "",
+      discoveryTail: "",
+      timer: undefined,
+      urlSent: false,
+      codeSent: false,
+      discoveryScheduled: false,
+      invalidated: false,
+    };
+    this.activeFlows.set(key, flow);
+
+    const dataSubscription = pty.onData((data) => {
+      if (this.activeFlows.get(key) !== flow || flow.invalidated) {
+        return;
+      }
+      this.captureDiscovery(flow, data);
+      flow.output = appendOutput(flow.output, data);
+      this.scheduleDiscovery(flow);
+    });
+    const exitSubscription = pty.onExit((event) => {
+      void this.finishFlow(flow, event.exitCode);
+    });
+    flow.dataSubscription =
+      dataSubscription && typeof dataSubscription === "object"
+        ? dataSubscription
+        : undefined;
+    flow.exitSubscription =
+      exitSubscription && typeof exitSubscription === "object"
+        ? exitSubscription
+        : undefined;
+    flow.timer = this.clock.setTimeout(
+      () => this.timeoutFlow(flow),
+      this.flowTtlSeconds * 1000,
+    );
+
+    await this.sendSafely(
+      chatId,
+      providerLabel(provider) + " authentication started. Follow the instructions below.",
+    );
+  }
+
+  private captureDiscovery(flow: ActiveFlow, data: string): void {
+    const discovery = extractDiscovery(flow.discoveryTail + data);
+    if (discovery.url && !flow.discoveredUrl) {
+      flow.discoveredUrl = discovery.url;
+    }
+    if (discovery.code && !flow.discoveredCode) {
+      flow.discoveredCode = discovery.code;
+    }
+    flow.discoveryTail = appendBoundedText(
+      flow.discoveryTail,
+      data,
+      MAX_DISCOVERY_TAIL_BYTES,
+    );
+  }
+
+  private scheduleDiscovery(flow: ActiveFlow): void {
+    if (this.activeFlows.get(flow.key) !== flow || flow.invalidated) {
+      return;
+    }
+    this.flushDiscovery(flow);
+  }
+
+  private flushDiscovery(flow: ActiveFlow): void {
+    if (flow.invalidated) {
+      return;
+    }
+
+    flow.discoveryScheduled = false;
+    const discovery = extractDiscovery(flow.output);
+    if (discovery.url && !flow.discoveredUrl) {
+      flow.discoveredUrl = discovery.url;
+    }
+    if (discovery.code && !flow.discoveredCode) {
+      flow.discoveredCode = discovery.code;
+    }
+
+    const lines = ["Continue authentication:"];
+    if (flow.discoveredUrl && !flow.urlSent) {
+      flow.urlSent = true;
+      lines.push(flow.discoveredUrl);
+    }
+    if (flow.discoveredCode && !flow.codeSent) {
+      flow.codeSent = true;
+      lines.push("Device code: " + flow.discoveredCode);
+    }
+    if (lines.length === 1) {
+      return;
+    }
+    void this.sendSafely(flow.chatId, lines.join("\n"));
+  }
+
+  private async sendStatus(ownerId: number, chatId: AuthChatId): Promise<void> {
+    const activeProviders = [...this.activeFlows.values()]
+      .filter((flow) => flow.ownerId === ownerId)
+      .map((flow) => flow.provider)
+      .sort();
+    const lines: string[] = [];
+    if (activeProviders.length > 0) {
+      lines.push(
+        "Active authentication flows: " +
+          activeProviders.map((provider) => providerLabel(provider)).join(", ") +
+          ".",
+      );
+    }
+    for (const provider of ["claude", "codex"] as const) {
+      const authenticated = await this.readAuthStatus(provider);
+      lines.push(statusLine(provider, authenticated));
+    }
+    await this.sendSafely(chatId, lines.join("\n"));
+  }
+
+  private async cancelFlow(ownerId: number, chatId: AuthChatId): Promise<void> {
+    const activeFlows = [...this.activeFlows.values()].filter(
+      (flow) => flow.ownerId === ownerId,
+    );
+    const pendingVerifications = [...this.pendingVerifications.values()].filter(
+      (flow) => flow.ownerId === ownerId,
+    );
+    if (activeFlows.length === 0 && pendingVerifications.length === 0) {
+      await this.sendSafely(chatId, "No authentication flow is active.");
+      return;
+    }
+
+    for (const flow of activeFlows) {
+      this.clearFlow(flow, true);
+    }
+    this.invalidatePendingVerifications(undefined, ownerId);
+    await this.sendSafely(chatId, "Authentication cancelled.");
+  }
+
+  private async writeCode(
+    ownerId: number,
+    code: string,
+    chatId: AuthChatId,
+  ): Promise<void> {
+    const flows = [...this.activeFlows.values()].filter(
+      (flow) => flow.ownerId === ownerId,
+    );
+    if (flows.length === 0) {
+      await this.sendSafely(chatId, "No authentication flow is active.");
+      return;
+    }
+    if (flows.length > 1) {
+      await this.sendSafely(
+        chatId,
+        "Authentication input is ambiguous while multiple providers are active.",
+      );
+      return;
+    }
+
+    try {
+      flows[0].pty.write(code + "\r");
+    } catch {
+      this.logger.warn?.("[telegram-auth] failed to write authentication input");
+      await this.sendSafely(chatId, "Authentication input failed.");
+    }
+  }
+
+  private async finishFlow(flow: ActiveFlow, exitCode: number): Promise<void> {
+    if (this.activeFlows.get(flow.key) !== flow || flow.invalidated) {
+      return;
+    }
+
+    this.flushDiscovery(flow);
+    const chatId = flow.chatId;
+    const provider = providerLabel(flow.provider);
+    if (exitCode !== 0) {
+      this.clearFlow(flow, false);
+      await this.sendSafely(chatId, provider + " authentication failed.");
+      return;
+    }
+
+    this.detachFlow(flow, false);
+    this.pendingVerifications.set(flow.key, flow);
+
+    let verified = false;
+    try {
+      verified = await this.verifyWithTimeout(flow.provider);
+    } catch {
+      this.logger.warn?.("[telegram-auth] post-exit authentication verification failed");
+    } finally {
+      if (this.pendingVerifications.get(flow.key) === flow) {
+        this.pendingVerifications.delete(flow.key);
+      }
+    }
+
+    if (flow.invalidated) {
+      return;
+    }
+
+    await this.sendSafely(
+      chatId,
+      verified
+        ? provider + " authentication succeeded: authenticated."
+        : provider + " authentication failed.",
+    );
+  }
+
+  private async verifyWithTimeout(provider: AuthProvider): Promise<boolean> {
+    if (!this.verifyAuth) {
+      return false;
+    }
+
+    let timeoutHandle: unknown;
+    let timerCreated = false;
+    try {
+      const verification = Promise.resolve(this.verifyAuth(provider));
+      const timeout = new Promise<boolean>((resolve) => {
+        timeoutHandle = this.clock.setTimeout(
+          () => resolve(false),
+          this.verifyTimeoutSeconds * 1000,
+        );
+        timerCreated = true;
+      });
+      return await Promise.race([verification, timeout]);
+    } catch {
+      this.logger.warn?.("[telegram-auth] post-exit authentication verification failed");
+      return false;
+    } finally {
+      if (timerCreated) {
+        this.clock.clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  private async readAuthStatus(provider: AuthProvider): Promise<boolean> {
+    if (!this.getAuthStatus) {
+      return false;
+    }
+    try {
+      return await this.getAuthStatus(provider);
+    } catch {
+      this.logger.warn?.("[telegram-auth] authentication status check failed");
+      return false;
+    }
+  }
+
+  private timeoutFlow(flow: ActiveFlow): void {
+    if (this.activeFlows.get(flow.key) !== flow || flow.invalidated) {
+      return;
+    }
+    const chatId = flow.chatId;
+    this.clearFlow(flow, true);
+    void this.sendSafely(chatId, "Authentication timed out.");
+  }
+
+  private invalidatePendingVerifications(
+    key?: FlowKey,
+    ownerId?: number,
+  ): void {
+    for (const [pendingKey, flow] of this.pendingVerifications) {
+      if (
+        (key === undefined || pendingKey === key) &&
+        (ownerId === undefined || flow.ownerId === ownerId)
+      ) {
+        flow.invalidated = true;
+        this.pendingVerifications.delete(pendingKey);
+      }
+    }
+  }
+
+  private detachFlow(flow: ActiveFlow, invalidate: boolean): void {
+    if (this.activeFlows.get(flow.key) !== flow) {
+      return;
+    }
+
+    this.activeFlows.delete(flow.key);
+    if (invalidate) {
+      flow.invalidated = true;
+    }
+    if (flow.timer !== undefined) {
+      this.clock.clearTimeout(flow.timer);
+      flow.timer = undefined;
+    }
+    flow.dataSubscription?.dispose?.();
+    flow.exitSubscription?.dispose?.();
+    flow.output = "";
+    flow.discoveryTail = "";
+    flow.discoveryScheduled = false;
+  }
+
+  private clearFlow(flow: ActiveFlow, kill: boolean): void {
+    if (this.activeFlows.get(flow.key) !== flow) {
+      return;
+    }
+
+    this.detachFlow(flow, true);
+    if (kill) {
+      try {
+        flow.pty.kill();
+      } catch {
+        this.logger.warn?.("[telegram-auth] failed to stop provider process");
+      }
+    }
+  }
+
+  private async deleteMessageSafely(message: AuthMessage): Promise<void> {
+    if (message.messageId === undefined) {
+      return;
+    }
+    try {
+      await this.deleteMessage(message.chatId, message.messageId);
+    } catch {
+      this.logger.debug?.("[telegram-auth] unable to delete sensitive auth message");
+    }
+  }
+
+  private async sendSafely(chatId: AuthChatId, text: string): Promise<void> {
+    try {
+      await this.send(chatId, text);
+    } catch {
+      this.logger.warn?.("[telegram-auth] unable to send auth update");
+    }
+  }
+}
+
+function statusLine(provider: AuthProvider, authenticated: boolean): string {
+  const label = providerLabel(provider);
+  if (authenticated) {
+    return label + " is authenticated.";
+  }
+  return label + " is not authenticated. Use /auth " + provider + " to sign in.";
+}

--- a/packages/jinn/src/connectors/telegram/index.ts
+++ b/packages/jinn/src/connectors/telegram/index.ts
@@ -36,7 +36,7 @@ const AUTH_KILL_GRACE_MS = 2_000;
 const AUTH_LOGIN_PROMPT =
   "Provider authentication is required. Check /auth status, then use /auth claude or /auth codex to sign in.";
 const AUTHENTICATION_FAILURE_PATTERN =
-  /\binteractive turn failed:\s*authentication_failed\b|\b(?:claude|codex)(?:\s+cli)?\s+(?:authentication failed|is not authenticated|is not logged in)\b|\b(?:codex|claude)\s+(?:login required|login needed)\b|\bnot logged in\b/i;
+  /\binteractive turn failed:\s*authentication_failed\b|\b(?:claude|codex)(?:\s+cli)?\s+(?:authentication failed|is not authenticated|is not logged in)\b|\b(?:codex|claude)\s+(?:login required|login needed)\b/i;
 const AUTH_VERIFY_ENV = {
   PATH:
     process.env.PATH ??

--- a/packages/jinn/src/connectors/telegram/index.ts
+++ b/packages/jinn/src/connectors/telegram/index.ts
@@ -36,7 +36,7 @@ const AUTH_KILL_GRACE_MS = 2_000;
 const AUTH_LOGIN_PROMPT =
   "Provider authentication is required. Check /auth status, then use /auth claude or /auth codex to sign in.";
 const AUTHENTICATION_FAILURE_PATTERN =
-  /\bauthentication(?:[_ ]failed|required)\b|\bnot authenticated\b|\bunauthori[sz]ed\b|\b401\b/i;
+  /\binteractive turn failed:\s*authentication_failed\b|\b(?:claude|codex)(?:\s+cli)?\s+(?:authentication failed|is not authenticated|is not logged in)\b|\b(?:codex|claude)\s+(?:login required|login needed)\b|\bnot logged in\b/i;
 const AUTH_VERIFY_ENV = {
   PATH:
     process.env.PATH ??
@@ -52,6 +52,7 @@ export class TelegramConnector implements Connector {
   private bot: TelegramBot;
   private handler: ((msg: IncomingMessage) => void) | null = null;
   private readonly allowedUsers: Set<number> | null;
+  private readonly authOwnerUserIds: ReadonlySet<number>;
   private readonly ignoreOldMessagesOnBoot: boolean;
   private readonly bootTimeMs = Date.now();
   private started = false;
@@ -78,6 +79,7 @@ export class TelegramConnector implements Connector {
       config.allowFrom && config.allowFrom.length > 0
         ? new Set(config.allowFrom)
         : null;
+    this.authOwnerUserIds = new Set(config.telegramAuth?.ownerUserIds ?? []);
     this.sttConfig = config.stt;
     if (config.telegramAuth?.enabled === true) {
       this.authManager = new AuthFlowManager({
@@ -470,7 +472,9 @@ export class TelegramConnector implements Connector {
   async replyMessage(target: Target, text: string): Promise<string | undefined> {
     if (!text || !text.trim()) return undefined;
     const replyText =
-      this.authManager && AUTHENTICATION_FAILURE_PATTERN.test(text)
+      this.authManager &&
+      isOwnerPrivateAuthTarget(target, this.authOwnerUserIds) &&
+      AUTHENTICATION_FAILURE_PATTERN.test(text)
         ? `${text}\n\n${AUTH_LOGIN_PROMPT}`
         : text;
     const replyToId =
@@ -540,6 +544,24 @@ export class TelegramConnector implements Connector {
 
 function verifyProviderAuth(provider: AuthProvider): Promise<boolean> {
   return getProviderAuthStatus(provider);
+}
+
+function isOwnerPrivateAuthTarget(
+  target: Target,
+  ownerUserIds: ReadonlySet<number>,
+): boolean {
+  const context = target.replyContext;
+  if (!context || context.chatType !== "private") {
+    return false;
+  }
+  const rawUserId = context.userId;
+  const userId =
+    typeof rawUserId === "number"
+      ? rawUserId
+      : typeof rawUserId === "string"
+        ? Number(rawUserId)
+        : NaN;
+  return Number.isSafeInteger(userId) && ownerUserIds.has(userId);
 }
 
 function getProviderAuthStatus(provider: AuthProvider): Promise<boolean> {

--- a/packages/jinn/src/connectors/telegram/index.ts
+++ b/packages/jinn/src/connectors/telegram/index.ts
@@ -33,6 +33,10 @@ import {
 type SendMessageOptions = Omit<SendMessageParams, "chat_id" | "text">;
 const AUTH_VERIFY_TIMEOUT_MS = 15_000;
 const AUTH_KILL_GRACE_MS = 2_000;
+const AUTH_LOGIN_PROMPT =
+  "Provider authentication is required. Check /auth status, then use /auth claude or /auth codex to sign in.";
+const AUTHENTICATION_FAILURE_PATTERN =
+  /\bauthentication(?:[_ ]failed|required)\b|\bnot authenticated\b|\bunauthori[sz]ed\b|\b401\b/i;
 const AUTH_VERIFY_ENV = {
   PATH:
     process.env.PATH ??
@@ -465,6 +469,10 @@ export class TelegramConnector implements Connector {
 
   async replyMessage(target: Target, text: string): Promise<string | undefined> {
     if (!text || !text.trim()) return undefined;
+    const replyText =
+      this.authManager && AUTHENTICATION_FAILURE_PATTERN.test(text)
+        ? `${text}\n\n${AUTH_LOGIN_PROMPT}`
+        : text;
     const replyToId =
       target.replyContext?.messageId != null
         ? Number(target.replyContext.messageId)
@@ -473,7 +481,7 @@ export class TelegramConnector implements Connector {
     if (replyToId) {
       opts.reply_parameters = { message_id: replyToId };
     }
-    const chunks = formatResponse(text);
+    const chunks = formatResponse(replyText);
     let lastMessageId: string | undefined;
     for (const chunk of chunks) {
       if (!chunk.trim()) continue;

--- a/packages/jinn/src/connectors/telegram/index.ts
+++ b/packages/jinn/src/connectors/telegram/index.ts
@@ -1,8 +1,10 @@
 import TelegramBot, { type SendMessageParams } from "node-telegram-bot-api";
+import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import * as pty from "node-pty";
 import type {
   Attachment,
   Connector,
@@ -22,8 +24,22 @@ import {
   resolveLanguages,
   getModelPath,
 } from "../../stt/stt.js";
+import {
+  AuthFlowManager,
+  type AuthChatId,
+  type AuthProvider,
+} from "./auth-flow.js";
 
 type SendMessageOptions = Omit<SendMessageParams, "chat_id" | "text">;
+const AUTH_VERIFY_TIMEOUT_MS = 15_000;
+const AUTH_VERIFY_ENV = {
+  PATH:
+    process.env.PATH ??
+    "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+  HOME: "/home/node",
+  CLAUDE_CONFIG_DIR: "/home/node/.claude",
+  CODEX_HOME: "/home/node/.codex",
+};
 
 export class TelegramConnector implements Connector {
   name = "telegram";
@@ -36,6 +52,7 @@ export class TelegramConnector implements Connector {
   private started = false;
   private lastError: string | null = null;
   private typingIntervals = new Map<string, ReturnType<typeof setInterval>>();
+  private readonly authManager?: AuthFlowManager;
 
   private readonly capabilities: ConnectorCapabilities = {
     threading: false,
@@ -57,6 +74,27 @@ export class TelegramConnector implements Connector {
         ? new Set(config.allowFrom)
         : null;
     this.sttConfig = config.stt;
+    if (config.telegramAuth?.enabled === true) {
+      this.authManager = new AuthFlowManager({
+        ownerUserIds: config.telegramAuth.ownerUserIds ?? [],
+        flowTtlSeconds: config.telegramAuth.flowTtlSeconds,
+        clock: {
+          now: () => Date.now(),
+          setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+          clearTimeout: (handle) =>
+            clearTimeout(handle as ReturnType<typeof setTimeout>),
+        },
+        send: async (chatId, text) => {
+          await this.safeSend(String(chatId), text);
+        },
+        deleteMessage: (chatId, messageId) =>
+          this.deleteMessageSafely(chatId, messageId),
+        spawnPty: (file, args, options) => pty.spawn(file, args, options),
+        verifyAuth: (provider) => verifyProviderAuth(provider),
+        getAuthStatus: (provider) => getProviderAuthStatus(provider),
+        logger,
+      });
+    }
   }
 
   async start(): Promise<void> {
@@ -80,11 +118,6 @@ export class TelegramConnector implements Connector {
         return;
       }
 
-      if (!this.handler) {
-        logger.debug("[telegram] No handler registered, dropping message");
-        return;
-      }
-
       if (
         this.ignoreOldMessagesOnBoot &&
         isOldTelegramMessage(telegramMsg.date, this.bootTimeMs)
@@ -103,14 +136,33 @@ export class TelegramConnector implements Connector {
         }
       }
 
+      const rawMessageText: string =
+        (telegramMsg as any).text || (telegramMsg as any).caption || "";
+      if (this.authManager) {
+        const handled = await this.authManager.handleMessage({
+          userId: userId ?? "unknown",
+          chatType: telegramMsg.chat.type,
+          chatId: telegramMsg.chat.id,
+          messageId: telegramMsg.message_id,
+          text: rawMessageText,
+        });
+        if (handled) {
+          return;
+        }
+      }
+
+      if (!this.handler) {
+        logger.debug("[telegram] No handler registered, dropping message");
+        return;
+      }
+
       const sessionKey = deriveSessionKey(telegramMsg, this.id);
       const replyContext = buildReplyContext(telegramMsg);
 
       const username =
         telegramMsg.from?.username || telegramMsg.from?.first_name || "unknown";
 
-      let messageText: string =
-        (telegramMsg as any).text || (telegramMsg as any).caption || "";
+      let messageText = rawMessageText;
 
       // File attachments: download via bot token and push to msg.attachments.
       // sessions/manager.ts pulls localPath and engines auto-inject
@@ -325,6 +377,7 @@ export class TelegramConnector implements Connector {
   }
 
   async stop(): Promise<void> {
+    this.authManager?.stop();
     for (const interval of this.typingIntervals.values()) {
       clearInterval(interval);
     }
@@ -376,6 +429,17 @@ export class TelegramConnector implements Connector {
         logger.error(`[telegram] Send failed: ${retryErr}`);
         return undefined;
       }
+    }
+  }
+
+  private async deleteMessageSafely(
+    chatId: AuthChatId,
+    messageId: number | string,
+  ): Promise<void> {
+    try {
+      await (this.bot as any).deleteMessage(String(chatId), Number(messageId));
+    } catch {
+      logger.debug("[telegram] Unable to delete auth message");
     }
   }
 
@@ -456,4 +520,59 @@ export class TelegramConnector implements Connector {
   onMessage(handler: (msg: IncomingMessage) => void): void {
     this.handler = handler;
   }
+}
+
+function verifyProviderAuth(provider: AuthProvider): Promise<boolean> {
+  return getProviderAuthStatus(provider);
+}
+
+function getProviderAuthStatus(provider: AuthProvider): Promise<boolean> {
+  return provider === "claude" ? verifyClaudeAuth() : verifyCodexAuth();
+}
+
+function verifyClaudeAuth(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(
+      "claude",
+      ["auth", "status", "--json"],
+      {
+        env: AUTH_VERIFY_ENV,
+        timeout: AUTH_VERIFY_TIMEOUT_MS,
+        maxBuffer: 16 * 1024,
+      },
+      (error, stdout) => {
+        if (error) {
+          resolve(false);
+          return;
+        }
+        try {
+          const status = JSON.parse(stdout);
+          resolve(status?.loggedIn === true);
+        } catch {
+          resolve(false);
+        }
+      },
+    );
+  });
+}
+
+function verifyCodexAuth(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn("codex", ["login", "status"], {
+      env: AUTH_VERIFY_ENV,
+      stdio: "ignore",
+    });
+    const timeout = setTimeout(() => {
+      child.kill();
+      resolve(false);
+    }, AUTH_VERIFY_TIMEOUT_MS);
+    child.once("error", () => {
+      clearTimeout(timeout);
+      resolve(false);
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      resolve(code === 0);
+    });
+  });
 }

--- a/packages/jinn/src/connectors/telegram/index.ts
+++ b/packages/jinn/src/connectors/telegram/index.ts
@@ -32,6 +32,7 @@ import {
 
 type SendMessageOptions = Omit<SendMessageParams, "chat_id" | "text">;
 const AUTH_VERIFY_TIMEOUT_MS = 15_000;
+const AUTH_KILL_GRACE_MS = 2_000;
 const AUTH_VERIFY_ENV = {
   PATH:
     process.env.PATH ??
@@ -136,19 +137,9 @@ export class TelegramConnector implements Connector {
         }
       }
 
-      const rawMessageText: string =
-        (telegramMsg as any).text || (telegramMsg as any).caption || "";
-      if (this.authManager) {
-        const handled = await this.authManager.handleMessage({
-          userId: userId ?? "unknown",
-          chatType: telegramMsg.chat.type,
-          chatId: telegramMsg.chat.id,
-          messageId: telegramMsg.message_id,
-          text: rawMessageText,
-        });
-        if (handled) {
-          return;
-        }
+      const rawMessageText = messageTextFromTelegram(telegramMsg);
+      if (await this.tryHandleAuthMessage(telegramMsg, userId, rawMessageText)) {
+        return;
       }
 
       if (!this.handler) {
@@ -432,6 +423,23 @@ export class TelegramConnector implements Connector {
     }
   }
 
+  private async tryHandleAuthMessage(
+    telegramMsg: any,
+    userId: number | undefined,
+    text: string,
+  ): Promise<boolean> {
+    if (!this.authManager) {
+      return false;
+    }
+    return await this.authManager.handleMessage({
+      userId: userId ?? "unknown",
+      chatType: telegramMsg.chat.type,
+      chatId: telegramMsg.chat.id,
+      messageId: telegramMsg.message_id,
+      text,
+    });
+  }
+
   private async deleteMessageSafely(
     chatId: AuthChatId,
     messageId: number | string,
@@ -557,22 +565,73 @@ function verifyClaudeAuth(): Promise<boolean> {
 }
 
 function verifyCodexAuth(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const child = spawn("codex", ["login", "status"], {
-      env: AUTH_VERIFY_ENV,
-      stdio: "ignore",
-    });
-    const timeout = setTimeout(() => {
-      child.kill();
-      resolve(false);
-    }, AUTH_VERIFY_TIMEOUT_MS);
-    child.once("error", () => {
-      clearTimeout(timeout);
-      resolve(false);
-    });
-    child.once("exit", (code) => {
-      clearTimeout(timeout);
-      resolve(code === 0);
-    });
+  const child = spawn("codex", ["login", "status"], {
+    env: AUTH_VERIFY_ENV,
+    stdio: "ignore",
   });
+  return waitForCodexStatus(child);
+}
+
+function waitForCodexStatus(child: ReturnType<typeof spawn>): Promise<boolean> {
+  return new Promise((resolve) => {
+    let authTimer: ReturnType<typeof setTimeout> | undefined;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    let finalTimer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+    const settle = (authenticated: boolean) => {
+      if (settled) return;
+      settled = true;
+      cleanupCodexStatusChild(child, listeners, [authTimer, killTimer, finalTimer]);
+      resolve(authenticated);
+    };
+    const forceKill = () => {
+      killCodexStatusChild(child, "SIGKILL");
+      finalTimer = setTimeout(() => settle(false), AUTH_KILL_GRACE_MS);
+    };
+    const terminate = () => {
+      killCodexStatusChild(child, "SIGTERM");
+      killTimer = setTimeout(forceKill, AUTH_KILL_GRACE_MS);
+    };
+    const listeners = {
+      error: () => settle(false),
+      exit: (code: number | null) => settle(code === 0),
+      close: (code: number | null) => settle(code === 0),
+    };
+    child.once("error", listeners.error);
+    child.once("exit", listeners.exit);
+    child.once("close", listeners.close);
+    authTimer = setTimeout(terminate, AUTH_VERIFY_TIMEOUT_MS);
+  });
+}
+
+function killCodexStatusChild(
+  child: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals,
+): void {
+  try {
+    child.kill(signal);
+  } catch {
+    // Generic failure is reported by the caller's settled false result.
+  }
+}
+
+function cleanupCodexStatusChild(
+  child: ReturnType<typeof spawn>,
+  listeners: {
+    error: () => void;
+    exit: (code: number | null) => void;
+    close: (code: number | null) => void;
+  },
+  timers: Array<ReturnType<typeof setTimeout> | undefined>,
+): void {
+  for (const timer of timers) {
+    if (timer) clearTimeout(timer);
+  }
+  child.removeListener("error", listeners.error);
+  child.removeListener("exit", listeners.exit);
+  child.removeListener("close", listeners.close);
+}
+
+function messageTextFromTelegram(telegramMsg: any): string {
+  return telegramMsg.text || telegramMsg.caption || "";
 }

--- a/packages/jinn/src/connectors/telegram/threads.ts
+++ b/packages/jinn/src/connectors/telegram/threads.ts
@@ -16,10 +16,15 @@ export function deriveSessionKey(msg: TelegramMessageLike, prefix = "telegram"):
  * Build a reply context from a Telegram message.
  */
 export function buildReplyContext(msg: TelegramMessageLike): ReplyContext {
-  return {
+  const context: ReplyContext = {
     chatId: msg.chat.id,
     messageId: msg.message_id,
+    chatType: msg.chat.type,
   };
+  if (msg.from?.id !== undefined) {
+    context.userId = msg.from.id;
+  }
+  return context;
 }
 
 /**

--- a/packages/jinn/src/shared/types.ts
+++ b/packages/jinn/src/shared/types.ts
@@ -672,6 +672,12 @@ export interface TelegramConnectorConfig {
   botToken: string;
   allowFrom?: number[];
   ignoreOldMessagesOnBoot?: boolean;
+  /** Owner-only interactive provider authentication commands. Disabled by default. */
+  telegramAuth?: {
+    enabled?: boolean;
+    ownerUserIds?: number[];
+    flowTtlSeconds?: number;
+  };
   /** Speech-to-text settings forwarded from top-level `config.stt` */
   stt?: {
     enabled?: boolean;

--- a/packages/jinn/template/docs/connectors.md
+++ b/packages/jinn/template/docs/connectors.md
@@ -105,17 +105,17 @@ connectors:
   telegram:
     botToken: ...
     allowFrom:
-      - 5658965359
+      - 123456789
     telegramAuth:
       enabled: true
       ownerUserIds:
-        - 5658965359
+        - 123456789
       flowTtlSeconds: 600
 ```
 
 `ownerUserIds` must contain numeric Telegram user IDs. It does not replace the
 normal `allowFrom` gate; keep both restricted to the intended owner. Usernames
-are not an authentication boundary.
+are not an authentication boundary. Replace the example ID with your own.
 
 Supported private-chat commands:
 

--- a/packages/jinn/template/docs/connectors.md
+++ b/packages/jinn/template/docs/connectors.md
@@ -95,6 +95,45 @@ Connector ids are what the rest of the gateway addresses:
 - `POST /api/connectors/reload`, which stops every running connector and restarts it
   from the current `config.yaml` — regardless of which form declared it
 
+## Telegram Authentication
+
+Telegram auth commands are disabled unless the Telegram connector config enables
+them explicitly:
+
+```yaml
+connectors:
+  telegram:
+    botToken: ...
+    allowFrom:
+      - 5658965359
+    telegramAuth:
+      enabled: true
+      ownerUserIds:
+        - 5658965359
+      flowTtlSeconds: 600
+```
+
+`ownerUserIds` must contain numeric Telegram user IDs. It does not replace the
+normal `allowFrom` gate; keep both restricted to the intended owner. Usernames
+are not an authentication boundary.
+
+Supported private-chat commands:
+
+- `/auth claude` starts `claude auth login --claudeai`.
+- `/auth codex` starts `codex login --device-auth`.
+- `/auth status` reports active flows and each provider's authenticated state.
+  If a provider is not authenticated, the reply includes the matching login
+  command, for example `/auth claude` or `/auth codex`.
+- `/auth cancel` stops active authentication flows.
+- `/auth input <one-time-code>` sends a short one-time code to the active flow
+  and deletes the Telegram message best-effort.
+
+Auth commands are intercepted before normal session routing, attachments, and
+speech-to-text handling. They are not delivered to the normal message handler.
+The connector does not accept provider tokens, add HTTP endpoints, or proxy
+arbitrary callbacks. Post-exit verification runs only fixed status commands and
+reports generic success or failure.
+
 ## Future Connectors
 
 The connector interface is designed for additional platforms:


### PR DESCRIPTION
Implements the reviewed Telegram authentication flow for the owner.

- Adds /auth status, /auth claude, /auth codex, and bounded input/cancel handling.
- Prompts only in the owner private chat after provider authentication failures.
- Keeps auth links/codes out of normal sessions and logs.
- Adds the pinned Codex CLI image integration and tests.

Verification: focused Telegram auth tests 40/40 passed; full pnpm typecheck passed.