### PR TITLE
PLA-242: land PLA-240 self-healing todos (classify-only)

### DIFF
--- a/docs/superpowers/plans/2026-08-24-self-healing-todos.md
+++ b/docs/superpowers/plans/2026-08-24-self-healing-todos.md
@@ -666,7 +666,7 @@ EOF
 - Operator-filtered triggers after dropping impersonation depend on the resume stamp. Covered by tests; watch first classify-only week.
 - Two-attempt cap vs block recurrences: both count; a dependency-kind requeue is not a recovery attempt.
 - Instance PLA-222 not applied until rollout step 4.
-- Sweep and the anomaly detector share one `work_item_recovery` row. Production ticks sweep then detect. An `approved-landed-open` leftover is a known manager class (not the operator fallback); sweep must not overwrite a live `anomaly:approved-landed-open` manager row; detect restores the lane if it drifted without emitting a second `anomaly_observed`. Refused `complete()` (open children) stays `in_review` on Manager attention.
+- Sweep and the anomaly detector share one `work_item_recovery` row. A later *generic* operator fallback (`no safe automatic recovery is known`) cannot replace an unresolved `manager`/`recovering` lane. Specific verdicts (failure, leftover manager, pending routed approval, operator-only) may replace. Terminal `done`/`cancelled` means the prior condition resolved. Refused `complete()` (open children) stays `in_review` on Manager attention.
 
 ## Leak-grep
 

--- a/docs/superpowers/plans/2026-08-24-self-healing-todos.md
+++ b/docs/superpowers/plans/2026-08-24-self-healing-todos.md
@@ -664,6 +664,7 @@ EOF
 - Operator-filtered triggers after dropping impersonation depend on the resume stamp. Covered by tests; watch first classify-only week.
 - Two-attempt cap vs block recurrences: both count; a dependency-kind requeue is not a recovery attempt.
 - Instance PLA-222 not applied until rollout step 4.
+- Sweep and the anomaly detector share one `work_item_recovery` row. Production ticks sweep then detect. An `approved-landed-open` leftover is a known manager class (not the operator fallback); sweep must not overwrite a live `anomaly:approved-landed-open` manager row; detect restores the lane if it drifted without emitting a second `anomaly_observed`. Refused `complete()` (open children) stays `in_review` on Manager attention.
 
 ## Leak-grep
 

--- a/docs/superpowers/plans/2026-08-24-self-healing-todos.md
+++ b/docs/superpowers/plans/2026-08-24-self-healing-todos.md
@@ -588,6 +588,8 @@ EOF
 
 Compact wire adds optional `attentionLane: "recovering" | "manager" | "operator" | null`.
 
+Attention/list grouping is fed only from `GET /api/work-items?needsAttentionFor=me` then `deriveNeedsYou`. Both layers must keep recovering/manager leftovers (including parked recovering and `in_review` manager rows). `deriveNeedsYou` is not a Needs-you-only filter.
+
 List grouping: today's single `needs-you` group splits into:
 1. `recovering` — "Recovering automatically"
 2. `manager` — "Manager attention"

--- a/docs/superpowers/plans/2026-08-24-self-healing-todos.md
+++ b/docs/superpowers/plans/2026-08-24-self-healing-todos.md
@@ -670,4 +670,4 @@ EOF
 
 ## Leak-grep
 
-Before every commit, run the instance leak-grep from the platform skill against the staged diff. The only OK hits are the public brew tap and the generic COO name Jimbo. Fixture departments stay `platform` / `operations`. Employees stay `platform-worker` / `reviewer`. Never put personal names, project names, emails, or `/Users/` paths in this repo.
+Before every commit, run the instance leak-grep from the platform skill against the staged diff. The only OK hits are the public brew tap and the generic COO name Jimbo. Fixture departments stay `platform` / `operations`. Employees stay `platform-worker` / `reviewer`. Never put personal names, project names, emails, or absolute home-directory paths in this repo.

--- a/docs/superpowers/plans/2026-08-24-self-healing-todos.md
+++ b/docs/superpowers/plans/2026-08-24-self-healing-todos.md
@@ -1,0 +1,668 @@
+# Self-Healing Todos Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) for this plan. Shared lifecycle/runner files must stay serialized — do not dispatch overlapping write subagents onto `runner.ts`, `workflow-todo-surface.ts`, `trigger-service.ts`, `availability-resume.ts`, or `transitions.ts`.
+
+**Goal:** Eliminate the operator's blocked→Assigned rescue habit. Safe recovery is automatic; only genuine authority decisions reach Needs you.
+
+**Architecture:** Close lifecycle holes first so automation cannot stomp live work. Then add a bounded classifier/controller that reuses the existing availability-resume + claim + respawn-guard machinery. A quiet anomaly detector observes leftover lies and emits nothing when healthy. The dashboard splits today's single Needs you inbox into Recovering automatically / Manager attention / Needs you. Default rollout is classify-only.
+
+**Tech Stack:** TypeScript (ES2022, strict), Vitest, better-sqlite3 (additive tables only), existing Todo transition/claim/event audit, Vite/React 19 dashboard.
+
+**Spec:** PLA-240 plus related PLA-177, PLA-216, PLA-221, PLA-222. PLA-220 is executing in a separate worktree (`build/PLA-220-coo-land-gate`) — inspect only; do not edit `run-closure.ts` `approvedGate()`, `approval-authority.ts`, `workflow-decider-authority.ts`, or the COO-gate editor.
+
+## Global Constraints
+
+- Never auto-start ordinary backlog Todos.
+- Never impersonate the operator for routine recovery. Resume events carry a recovery/availability actor plus a resume stamp the operator-actor filter already widens for delegates.
+- Never duplicate an active run or compete with its owner. Claim CAS (`claimWorkItem`) is the lock.
+- Maximum two automatic recovery attempts per incident. Recurrence history (`work_item_blocks.recurrences`) is preserved.
+- Public repo fixtures and docs stay generic. Leak-grep staged diffs before commit.
+- Isolated worktree only. Do not restart or test against production ports 7777 or 7788.
+- Follow TDD. Historical-incident replay tests exist and fail before production code.
+- Default config is `gateway.todoRecovery.mode: classify-only`. `auto` is Jimbo's reviewed gate, not this PR's production default.
+- PLA-222's instance definition patch is proven with a generic fixture; applying it to the live instance is a rollout step, not a repo commit.
+
+---
+
+## File map
+
+**Create**
+- `packages/jinn/src/work-items/workflow-ownership.ts` — newest bound `workflowId` from status events
+- `packages/jinn/src/work-items/recovery.ts` — incident identity, classification, attempt ledger
+- `packages/jinn/src/work-items/recovery-controller.ts` — bounded apply (or classify-only)
+- `packages/jinn/src/work-items/anomaly-detect.ts` — quiet detector
+- `packages/jinn/src/work-items/attention-lane.ts` — Recovering / Manager / Operator derivation
+- `packages/jinn/src/gateway/todo-recovery.ts` — gateway port: re-arm + employee routing without operator impersonation
+- matching `__tests__/` files next to each module
+- `packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts` — historical incident table
+- `packages/jinn/src/work-items/__tests__/recovery-schema.test.ts` — additive table exact-shape
+
+**Modify (lifecycle, serialize)**
+- `packages/jinn/src/gateway/workflow-todo-surface.ts` — PLA-221 stale-run guard
+- `packages/jinn/src/work-items/availability-resume.ts` — PLA-216 weekly-reset age cap
+- `packages/jinn/src/gateway/availability-resume.ts` — stop operator impersonation; restore labels/assignee; use shared ownership
+- `packages/jinn/src/workflows/trigger-service.ts` — PLA-177 sticky owning workflow; accept recovery/availability resume stamps
+- `packages/jinn/src/work-items/event-log.ts` — new event kinds
+- `packages/jinn/src/work-items/migrate.ts` — register additive `work_item_recovery`
+- `packages/jinn/src/shared/config-types.ts` + `config.ts` — `gateway.todoRecovery`
+- `packages/jinn/src/gateway/server.ts` — start classify/apply sweep next to availability resume
+- `packages/jinn/src/gateway/work-item-payload.ts` — `attentionLane` on compact wire
+- `packages/jinn/src/work-items/store.ts` — `needsAttentionFor` excludes recovering/clock-wait (already excludes parked)
+
+**Modify (dashboard)**
+- `packages/web/src/lib/api.ts` — `attentionLane` on compact wire
+- `packages/web/src/routes/todos/list/group-items.ts` — three attention groups
+- `packages/web/src/routes/todos/needs-you-support.ts` + `needs-you-view.tsx` — lane split
+- existing grouping/list tests
+
+**Do not touch**
+- PLA-220 files listed above
+- `packages/jinn/template/**` personalization
+- production `~/.jinn` workflow definitions in this PR (PLA-222 apply is rollout)
+
+---
+
+### Task 1: Historical-incident replay harness (tests first)
+
+**Files:**
+- Create: `packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts`
+- Create: `packages/jinn/src/work-items/recovery.ts` (types + empty classify that fails tests)
+- Test: same
+
+**Interfaces:**
+- Produces:
+```ts
+export const RECOVERY_CLASSES = [
+  "transient", "code", "verification", "security", "operator",
+] as const;
+export type RecoveryClass = (typeof RECOVERY_CLASSES)[number];
+export const ATTENTION_LANES = ["recovering", "manager", "operator"] as const;
+export type AttentionLane = (typeof ATTENTION_LANES)[number];
+export interface RecoveryClassification {
+  class: RecoveryClass;
+  lane: AttentionLane;
+  reason: string;
+  owningWorkflowId?: string;
+}
+export interface RecoveryIncidentInput {
+  todo: { id: string; status: string; assignee: string | null; source: string };
+  lastRun?: { id: string; outcome: string; error: string | null; endedAt: string | null };
+  openRun?: boolean;
+  approval?: { state: string; operatorOnly: boolean };
+  labels: string[];
+  verifyMode?: "trust" | "verify" | "thorough";
+}
+export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassification;
+```
+
+- [ ] **Step 1: Write the failing replay tests**
+
+Table of representative incidents (generic fixture names only):
+
+```ts
+it("transient quota block classifies as recovering, not operator", () => {
+  const verdict = classifyRecovery({
+    todo: { id: "PLA-1", status: "blocked", assignee: "platform-worker", source: "session" },
+    lastRun: { id: "run_old", outcome: "rate_limited", error: "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z", endedAt: "2026-08-20T12:00:00.000Z" },
+    labels: ["build"],
+  });
+  expect(verdict).toMatchObject({ class: "transient", lane: "recovering" });
+});
+
+it("code failure routes to manager, not operator", () => {
+  const verdict = classifyRecovery({
+    todo: { id: "PLA-2", status: "blocked", assignee: "platform-worker", source: "session" },
+    lastRun: { id: "run_old", outcome: "crashed", error: "the build step exited with code 1", endedAt: "2026-08-20T12:00:00.000Z" },
+    labels: ["build"],
+  });
+  expect(verdict).toMatchObject({ class: "code", lane: "manager" });
+});
+
+it("verification failure routes to the independent verifier lane", () => {
+  const verdict = classifyRecovery({
+    todo: { id: "PLA-3", status: "blocked", assignee: "platform-worker", source: "session" },
+    lastRun: { id: "run_old", outcome: "failed", error: "independent review rejected the diff", endedAt: "2026-08-20T12:00:00.000Z" },
+    labels: ["build"],
+    verifyMode: "thorough",
+  });
+  expect(verdict).toMatchObject({ class: "verification", lane: "manager" });
+});
+
+it("security/auth-terminal is manager, not a clock retry", () => {
+  const verdict = classifyRecovery({
+    todo: { id: "PLA-4", status: "blocked", assignee: "platform-worker", source: "session" },
+    lastRun: { id: "run_old", outcome: "crashed", error: "401 Unauthorized: invalid api key", endedAt: "2026-08-20T12:00:00.000Z" },
+    labels: ["build"],
+  });
+  expect(verdict).toMatchObject({ class: "security", lane: "manager" });
+});
+
+it("operator-only pending approval is Needs you", () => {
+  const verdict = classifyRecovery({
+    todo: { id: "PLA-5", status: "in_review", assignee: "platform-worker", source: "session" },
+    approval: { state: "pending", operatorOnly: true },
+    labels: ["build"],
+  });
+  expect(verdict).toMatchObject({ class: "operator", lane: "operator" });
+});
+
+it("ordinary backlog never classifies as recovering", () => {
+  const verdict = classifyRecovery({
+    todo: { id: "PLA-6", status: "backlog", assignee: null, source: "human" },
+    labels: [],
+  });
+  expect(verdict.lane).not.toBe("recovering");
+  expect(verdict.class).toBe("operator"); // no automatic action
+});
+```
+
+- [ ] **Step 2: Run tests — they fail because `classifyRecovery` is missing**
+
+Run: `pnpm --filter @jinn/jinn exec vitest run src/work-items/__tests__/self-healing-replay.test.ts`
+
+Expected: FAIL, cannot find `classifyRecovery` or it returns undefined.
+
+- [ ] **Step 3: Add the type module and a throwing stub so the test compiles and fails on assertions**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-08-24-self-healing-todos.md \
+  packages/jinn/src/work-items/recovery.ts \
+  packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts
+git commit -m "$(cat <<'EOF'
+test(todos): replay historical self-healing incidents (PLA-240)
+
+Lock the classifier's contract against the audit: transients recover
+quietly, code/verify/security go to a manager, only genuine authority
+decisions reach Needs you, and backlog never auto-starts.
+EOF
+)"
+```
+
+---
+
+### Task 2: PLA-221 — stale failure End cannot stomp a newer state
+
+**Files:**
+- Modify: `packages/jinn/src/gateway/workflow-todo-surface.ts`
+- Modify: `packages/jinn/src/gateway/__tests__/workflow-todo-surface.test.ts`
+- Create: `packages/jinn/src/work-items/workflow-ownership.ts` if the runId check wants the shared event reader
+
+**Interfaces:**
+- Consumes: `listWorkItemEvents`, current Todo status, `input.runId`
+- Produces: `mayReflect('blocked', …)` is false when a newer assigned/executing/in_review/done state is not owned by this run
+
+Rule:
+
+```
+blocked reflection is allowed only when the newest status_change that
+carries a runId is THIS run, or there is no successor status_change
+after this run last wrote. A Todo already at assigned/executing/
+in_review/done whose latest status_change is a different run, an
+availability/recovery resume, or an operator/employee move is left
+untouched. Quiet Todos still at this run's executing/in_review still
+go blocked, as today.
+```
+
+- [ ] **Step 1: Write the failing tests in `workflow-todo-surface.test.ts`**
+
+```ts
+it("does not let a stale failure End stomp a successor executing Todo", () => {
+  const id = armedTodo("rearmed while the old End was still firing");
+  reflect(id, "executing"); // run_1
+  transitions.transition(id, "assigned", "availability-resume", {
+    requeue: true,
+    detail: { workflowId: "pipeline", availabilityResume: true },
+  });
+  surface.workflowTodoLifecycle.reflect({
+    todoId: id, status: "executing", workflowId: "pipeline", runId: "run_2", nodeId: "plan",
+  });
+
+  surface.workflowTodoLifecycle.reflect({
+    todoId: id, status: "blocked", workflowId: "pipeline", runId: "run_1", nodeId: "land",
+  });
+
+  expect(store.getWorkItem(id)!.status).toBe("executing");
+});
+
+it("still blocks a quiet Todo this run itself left executing", () => {
+  const id = armedTodo("this run died");
+  reflect(id, "executing");
+  reflect(id, "blocked", "land");
+  expect(store.getWorkItem(id)!.status).toBe("blocked");
+});
+```
+
+Keep the existing "still reports a dead run" case: an agent moved it to `in_review` with no runId, then the same `run_1` reflects blocked. After PLA-221 that is a successor (no matching runId, current in_review) — it must NOT stomp. Update that test to expect `in_review` and rename it. Add a same-run in_review→blocked case that still blocks:
+
+```ts
+it("still blocks when THIS run reflected in_review and then failed", () => {
+  const id = armedTodo("gate parked then the land died");
+  reflect(id, "executing");
+  reflect(id, "in_review", "gate");
+  reflect(id, "blocked", "land");
+  expect(store.getWorkItem(id)!.status).toBe("blocked");
+});
+```
+
+- [ ] **Step 2: Run the new tests — they fail (stale End still stomps)**
+
+- [ ] **Step 3: Implement `mayReflect` blocked guard**
+
+```ts
+function latestRunAttribution(todoId: string): { runId?: string; resume?: boolean } {
+  const events = listWorkItemEvents(todoId).filter((event) => event.kind === "status_change");
+  const last = events.at(-1);
+  const detail = last?.detail ?? {};
+  return {
+    runId: typeof detail.runId === "string" ? detail.runId : undefined,
+    resume: detail.availabilityResume === true || detail.recoveryResume === true,
+  };
+}
+
+function mayReflect(status: WorkflowRunReflection, current: WorkItemStatus, todoId: string, runId: string): boolean {
+  if (status === "executing") return current === "backlog" || current === "assigned";
+  if (status === "in_review") return !(current === "blocked" && isBlockDeclared(todoId));
+  if (status === "blocked") {
+    if (current === "done" || current === "cancelled" || current === "escalated") return false;
+    const successor = new Set(["assigned", "executing", "in_review"]);
+    if (!successor.has(current)) return true;
+    const last = latestRunAttribution(todoId);
+    if (last.resume) return false;
+    if (last.runId !== undefined && last.runId !== runId) return false;
+    if (last.runId === undefined) return false; // operator/employee moved it
+    return true; // this run still owns the board
+  }
+  return true;
+}
+```
+
+Pass `input.runId` into `mayReflect`.
+
+- [ ] **Step 4: Tests pass. Commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(workflows): stale failure Ends cannot stomp a live successor (PLA-221)
+
+A rearmed or operator-moved Todo keeps assigned/executing/in_review.
+A quiet Todo this run itself left executing still reflects blocked.
+EOF
+)"
+```
+
+---
+
+### Task 3: PLA-216 — weekly-capped Todos resume after the real reset
+
+**Files:**
+- Modify: `packages/jinn/src/work-items/availability-resume.ts`
+- Modify: `packages/jinn/src/work-items/__tests__/availability-resume.test.ts`
+
+Current hole: `dueForResume` ages out when `now - endedAt > 24h`, so a weekly cap (true `until` ~6 days) never auto-resumes.
+
+New rule: the 24h age cap applies only when no future-or-present stated/engine-health reset is known. If the failure or engine health named a reset, wait for that instant even if it is >24h away. After the named reset, resume. If the named reset is already in the past and the Todo is older than 24h *past that reset*, then it is history and stays aged out.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+it("resumes a weekly-capped Todo after the stated reset, even when endedAt is older than 24h", () => {
+  const resetAt = new Date(NOW.getTime() - 60_000).toISOString();
+  const { id, runId } = parked("weekly cap", {
+    outcome: "rate_limited",
+    endedAt: minutesBefore(6 * 24 * 60),
+    error: `Usage limit exceeded; try again at ${resetAt}`,
+  });
+  const port = recorder();
+  resume.sweepAvailabilityResumes({ rearm: port.rearm, now: () => NOW });
+  expect(port.calls).toContain(id);
+  expect(resumeEvents(id, runId)[0]?.detail).toMatchObject({ source: "stated" });
+});
+
+it("does not resume a weekly cap whose reset is still in the future", () => {
+  const resetAt = new Date(NOW.getTime() + 2 * 24 * 60 * 60_000).toISOString();
+  const { id, runId } = parked("weekly cap still closed", {
+    outcome: "rate_limited",
+    endedAt: minutesBefore(2 * 24 * 60),
+    error: `Usage limit exceeded; try again at ${resetAt}`,
+  });
+  resume.sweepAvailabilityResumes({ rearm: recorder().rearm, now: () => NOW });
+  expect(resumeEvents(id, runId)).toHaveLength(0);
+});
+```
+
+Update the existing "skips a failure old enough…" test: it uses a stated reset already in the past (`QUOTA_WITH_RESET` at 11:30, NOW at 12:00) with endedAt 25h ago. After this change that case SHOULD resume if the stated reset is known. Replace it with a case that named no reset and is >24h old, which still ages out.
+
+- [ ] **Step 2: Run — weekly-cap test fails (aged out)**
+
+- [ ] **Step 3: Implement**
+
+In `dueForResume`:
+
+```ts
+const reset = resolveReset(run, now);
+const ageMs = now.getTime() - Date.parse(run.endedAt);
+const named = reset.source === "stated" || reset.source === "engine-health";
+if (!named && ageMs > MAX_RESUMABLE_AGE_MS) return undefined;
+if (named && now.getTime() - reset.at > MAX_RESUMABLE_AGE_MS) return undefined;
+if (reset.at > now.getTime()) return undefined;
+```
+
+Resolve reset BEFORE the age check (currently age-check happens first and never asks).
+
+- [ ] **Step 4: Tests pass. Commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(todos): weekly-capped work resumes after the real reset (PLA-216)
+
+The 24h age cap no longer kills a wait whose engine named a later
+reopening. Unnamed old failures still age out.
+EOF
+)"
+```
+
+---
+
+### Task 4: Sticky owning workflow, labels, assignee (PLA-177)
+
+**Files:**
+- Create: `packages/jinn/src/work-items/workflow-ownership.ts`
+- Modify: `packages/jinn/src/gateway/availability-resume.ts` (use shared owner; restore extra labels; keep assignee)
+- Modify: `packages/jinn/src/workflows/trigger-service.ts`
+- Tests: `packages/jinn/src/gateway/__tests__/availability-resume.test.ts`
+- Tests: new `packages/jinn/src/workflows/__tests__/owning-workflow-rearm.test.ts`
+
+**Interfaces:**
+
+```ts
+export function owningWorkflowId(todoId: string): string | undefined;
+```
+
+Newest `status_change` with `detail.workflowId: string` wins — same rule `boundWorkflowId` uses today.
+
+Trigger rule: when `fireTodo` has more than one runnable definition and `owningWorkflowId` is among them, start only that definition. Others are declined as `suppressed` with reason `Todo already belongs to workflow \`<id>\``. If the owner is missing or not runnable, keep today's multi-start behaviour (new work, unlabeled intake).
+
+Never start a run for a Todo already in `backlog` from this path.
+
+Assignee: `availabilityRearm` / recovery re-arm must not clear `assignee` or `department`. Labels: restore the arming label by ADD, never replace the set.
+
+- [ ] **Step 1: Failing tests**
+
+Owning-workflow: two enabled workflows (`intake` unlabeled, `category` label `category`) both trigger on `assigned`. A Todo labelled `category` whose last `workflowId` is `category` is re-armed to `assigned` — only `category` starts.
+
+Labels: a Todo carrying `urgent` plus missing `build` is re-armed — both labels present, assignee unchanged.
+
+Operator impersonation: an operator-filtered trigger still fires when the resume actor is `availability-resume` and `detail.availabilityResume === true`.
+
+- [ ] **Step 2: Run — intake also starts / assignee wiped / operator filter misses**
+
+- [ ] **Step 3: Implement**
+
+1. Extract `owningWorkflowId`.
+2. `fireTodo`: if owner is in `runnable`, `runnable = runnable.filter(d => d.definition.id === owner)`.
+3. Actor filter: accept `availability-resume` / `todo-recovery` when `event.quotaWindowDecided` or a new `event.armedAsRecovery`.
+4. `armingActor` always returns `AVAILABILITY_RESUME_ACTOR` (or recovery actor). Do not write `actor: "operator"`.
+5. `restoreArmingLabel` stays add-only; add an assignee assertion test (no code if already sticky).
+
+- [ ] **Step 4: Tests pass. Commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(workflows): re-arm resumes the owning workflow, not intake (PLA-177)
+
+A Todo that already belongs to a pipeline stays on it. Recovery no
+longer impersonates the operator to satisfy an actor filter.
+EOF
+)"
+```
+
+---
+
+### Task 5: Honest terminal outcomes + approval/status reconciliation
+
+**Files:**
+- Modify: `packages/jinn/src/gateway/workflow-todo-surface.ts` `complete()`
+- Tests: `packages/jinn/src/gateway/__tests__/workflow-todo-surface.test.ts`
+- Tests: generic deliver→failure-End fixture in `packages/jinn/src/workflows/__tests__/landing-evidence.test.ts` (PLA-222 pattern)
+
+`complete()` today no-ops unless status is `in_review`. Acceptance: approved/landed work cannot remain indefinitely in_review. If the reserved gate approved and the run completed, close from `in_review`. If it is still `executing`/`assigned` because reflection lagged, move to `in_review` then close in the same function — but NEVER close from `blocked` (PLA-208). Do not change `approvedGate()` (PLA-220 owns that).
+
+PLA-222: add a generic workflow whose `deliver` node has an explicit failure End when `landed` is blocked, so a lying success path is not the only catch. Do not edit the live instance definition in this PR.
+
+- [ ] **Step 1: Failing tests for complete-from-approved-in_review (already exists?) and complete-does-not-close-blocked**
+
+If `complete()` already closes in_review, add the detector-side test in Task 7 for "approved but still open after the run vanished".
+
+- [ ] **Step 2–4: Implement only if a hole remains. Commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+fix(todos): approved landings cannot sit open in review (PLA-240)
+
+A reserved-gate completion still closes in_review. Blocked landings
+still cannot close. Generic deliver failure-End covers PLA-222.
+EOF
+)"
+```
+
+---
+
+### Task 6: Recovery table + bounded controller
+
+**Files:**
+- Create: `packages/jinn/src/work-items/recovery.ts` (ledger + classify)
+- Create: `packages/jinn/src/work-items/recovery-controller.ts`
+- Create: `packages/jinn/src/gateway/todo-recovery.ts`
+- Modify: `packages/jinn/src/work-items/event-log.ts` kinds
+- Modify: `packages/jinn/src/work-items/migrate.ts`
+- Modify: `packages/jinn/src/shared/config-types.ts`, `config.ts`, `config.test.ts`
+- Tests: `recovery.test.ts`, `recovery-controller.test.ts`, `recovery-schema.test.ts`
+
+**DDL (additive, never a column on `work_items`):**
+
+```sql
+CREATE TABLE IF NOT EXISTS work_item_recovery (
+  work_item_id     TEXT PRIMARY KEY REFERENCES work_items(id) ON DELETE CASCADE,
+  incident_id      TEXT NOT NULL,
+  class            TEXT NOT NULL CHECK (class IN ('transient','code','verification','security','operator')),
+  lane             TEXT NOT NULL CHECK (lane IN ('recovering','manager','operator')),
+  attempts         INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0 AND attempts <= 2),
+  last_attempt_at  TEXT,
+  last_run_id      TEXT,
+  reason           TEXT NOT NULL,
+  updated_at       TEXT NOT NULL
+)
+```
+
+Incident identity: `last settled run id` when present, else `status_change event id` of the current stop. One row per Todo. Attempts increment only on an applied recovery. Classify-only writes the row with `attempts = 0`.
+
+**Controller:**
+
+```ts
+export interface RecoveryApplyDeps {
+  mode: "off" | "classify-only" | "auto";
+  now?: () => Date;
+  rearm(todoId: string): AvailabilityRearmResult;
+  routeToEmployee?(todoId: string, employee: string, reason: string): void;
+  claim(todoId: string, owner: string): ClaimWorkItemResult;
+  release(todoId: string, owner: string): void;
+}
+export function sweepTodoRecovery(deps: RecoveryApplyDeps): { classified: number; applied: number };
+```
+
+Apply rules:
+- `off`: no-op.
+- `classify-only`: classify + persist lane; no status write, no session, no new Todo.
+- `auto`:
+  - `transient` → re-arm owning workflow via existing port (max 2, skip if open run, skip backlog, skip held claim).
+  - `code` → assign remaining employee (existing assignee) if any, re-arm once more (attempt 2 is the scoped repair). After 2 → manager lane, do not escalate to operator unless already operator-only.
+  - `verification` → if `verifyPolicy.verifier.employee` set, assign that employee (never the producer). Else manager lane.
+  - `security` → manager lane, never retry as clock.
+  - `operator` → no auto apply.
+- Actor is `todo-recovery`, never `operator`.
+- Claim owner `todo-recovery:<incidentId>`. Release if re-arm unavailable.
+
+Wire `gateway.todoRecovery.mode` defaulting to `classify-only` when unset. Validate in `validateConfigShape`.
+
+- [ ] **Step 1: Schema + classify + controller tests (failing)**
+- [ ] **Step 2: Confirm red**
+- [ ] **Step 3: Implement DDL, classify, controller, gateway port**
+- [ ] **Step 4: Green. Commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(todos): bounded recovery classifier with classify-only default (PLA-240)
+
+Two attempts max, claim-idempotent, no operator impersonation, no
+backlog auto-start. Production stays classify-only until Jimbo
+enables auto.
+EOF
+)"
+```
+
+---
+
+### Task 7: Quiet anomaly detector
+
+**Files:**
+- Create: `packages/jinn/src/work-items/anomaly-detect.ts`
+- Tests: `packages/jinn/src/work-items/__tests__/anomaly-detect.test.ts`
+
+**Interfaces:**
+
+```ts
+export const ANOMALY_KINDS = [
+  "assigned-without-run",
+  "execution-timeout",
+  "approved-landed-open",
+  "review-without-reviewer",
+  "blocked-without-recovery",
+] as const;
+export type AnomalyKind = (typeof ANOMALY_KINDS)[number];
+export interface TodoAnomaly {
+  workItemId: string;
+  kind: AnomalyKind;
+  lane: AttentionLane;
+  reason: string;
+}
+export function detectTodoAnomalies(now?: Date): TodoAnomaly[];
+```
+
+Rules:
+- assigned-without-run: status `assigned`, no open run, no settled run in last 15m, not backlog, has owning workflow. Lane recovering (auto will re-arm) or manager if already attempted twice.
+- execution-timeout: status `executing`, open run's `startedAt` older than 4h and session not `running`/`waiting`.
+- approved-landed-open: `in_review`, approval `approved`, latest run completed, Todo not `done`.
+- review-without-reviewer: `in_review`, no pending approval, no verifier assignee, no in-flight review session.
+- blocked-without-recovery: `blocked`, not parked, no recovery row, not already classified.
+
+Healthy board (backlog/assigned-with-fresh-run/executing-live/in_review-with-pending-gate/done): returns `[]`. Detector never calls `createWorkItem` or `createSession`. In classify-only it only upserts `work_item_recovery` + audit event `anomaly_observed` (once per incident).
+
+- [ ] **Step 1: Failing tests including `creates zero Todos and zero sessions when healthy`**
+- [ ] **Step 2: Red**
+- [ ] **Step 3: Implement**
+- [ ] **Step 4: Green. Commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(todos): quiet anomaly detector that is silent when healthy (PLA-240)
+
+Five leftover lies become lanes. A healthy board creates no Todos
+and no sessions.
+EOF
+)"
+```
+
+---
+
+### Task 8: Dashboard lanes
+
+**Files:**
+- Modify: `packages/jinn/src/gateway/work-item-payload.ts`
+- Modify: `packages/web/src/lib/api.ts`
+- Modify: `packages/web/src/routes/todos/list/group-items.ts`
+- Modify: `packages/web/src/routes/todos/needs-you-support.ts`
+- Modify: `packages/web/src/routes/todos/needs-you-view.tsx`
+- Tests: `list-grouping.test.ts`, `needs-you-view.test.tsx`
+
+Compact wire adds optional `attentionLane: "recovering" | "manager" | "operator" | null`.
+
+List grouping: today's single `needs-you` group splits into:
+1. `recovering` — "Recovering automatically"
+2. `manager` — "Manager attention"
+3. `needs-you` — "Needs you" (operator lane only)
+
+Items without a lane keep current behaviour (blocked/escalated/pending approval → needs-you).
+
+`needsAttentionFor` SQL: exclude rows whose recovery lane is `recovering` (they are not a you-wait). Include manager-lane items for the assignee's manager queue via existing assignee match, not the operator's Needs you.
+
+- [ ] **Step 1: Failing grouping tests**
+- [ ] **Step 2: Red**
+- [ ] **Step 3: Implement wire + groups + inbox copy**
+- [ ] **Step 4: Green. Commit.**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(web): split Todo attention into recovering / manager / needs you (PLA-240)
+
+Clock-waits and automatic retries leave Needs you. Only genuine
+authority decisions stay on that lane.
+EOF
+)"
+```
+
+---
+
+### Task 9: Gateway sweep, metrics, rollout docs
+
+**Files:**
+- Modify: `packages/jinn/src/gateway/server.ts`
+- Create: `packages/jinn/src/gateway/todo-recovery.ts` start/stop
+- Modify: plan / this file's rollout section is the operator-facing source of truth
+
+Start an unref'd interval next to `startAvailabilityResumes`. One sweep: classify + anomalies + (if auto) apply. Never overlap ticks. Default classify-only.
+
+Metrics (audit events, no new product analytics):
+- `recovery_classified` / `recovery_attempted` / `recovery_exhausted` / `anomaly_observed`
+- Counts derived from those events: operator rescues (`status_change` blocked→assigned actor `operator`), recovery latency (`last_attempt_at - last_blocked_at`), duplicate-run refusals (`claim_rejected`), false completion (complete() on blocked — already impossible), avoidable needs-you (classified recovering but still in operator lane)
+
+Rollback: set `gateway.todoRecovery.mode: off` (or omit + we treat unknown as classify-only). Additive table stays; sweeps become no-ops.
+
+- [ ] **Step 1: Test that default mode is classify-only and auto is opt-in**
+- [ ] **Step 2–4: Wire server, commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(gateway): classify-only Todo recovery sweep (PLA-240)
+
+Production default observes and labels. Auto-apply stays behind
+Jimbo's reviewed config gate.
+EOF
+)"
+```
+
+---
+
+## Rollout
+
+1. Land this branch. Production config remains unset → classify-only.
+2. Watch a few days: recovering vs manager vs operator counts; confirm zero healthy-state Todos/sessions; confirm no duplicate runs.
+3. Jimbo reviews and sets `gateway.todoRecovery.mode: auto` on this instance only.
+4. Apply PLA-222's instance `deliver` failure-End using the existing PLA-218 tooling after auto is trusted.
+5. Rollback: `mode: off`.
+
+## Rollback
+
+`gateway.todoRecovery.mode: off`. Lifecycle invariants (PLA-221/216/177) stay — they are correctness, not automation. If a lifecycle fix misbehaves, revert that commit independently.
+
+## Remaining risks
+
+- PLA-220 still executing; reserved-gate close class may land after this. Anomaly `approved-landed-open` must not assume `decidableBy: coo`.
+- Operator-filtered triggers after dropping impersonation depend on the resume stamp. Covered by tests; watch first classify-only week.
+- Two-attempt cap vs block recurrences: both count; a dependency-kind requeue is not a recovery attempt.
+- Instance PLA-222 not applied until rollout step 4.
+
+## Leak-grep
+
+Before every commit, run the instance leak-grep from the platform skill against the staged diff. The only OK hits are the public brew tap and the generic COO name Jimbo. Fixture departments stay `platform` / `operations`. Employees stay `platform-worker` / `reviewer`. Never put personal names, project names, emails, or `/Users/` paths in this repo.

--- a/docs/superpowers/plans/2026-08-24-self-healing-todos.md
+++ b/docs/superpowers/plans/2026-08-24-self-healing-todos.md
@@ -47,7 +47,7 @@
 - `packages/jinn/src/shared/config-types.ts` + `config.ts` — `gateway.todoRecovery`
 - `packages/jinn/src/gateway/server.ts` — start classify/apply sweep next to availability resume
 - `packages/jinn/src/gateway/work-item-payload.ts` — `attentionLane` on compact wire
-- `packages/jinn/src/work-items/store.ts` — `needsAttentionFor` excludes recovering/clock-wait (already excludes parked)
+- `packages/jinn/src/work-items/store.ts` — `needsAttentionFor` includes recovering/manager leftovers so Attention/list grouping can split them; parked clock-waits without those lanes stay out
 
 **Modify (dashboard)**
 - `packages/web/src/lib/api.ts` — `attentionLane` on compact wire
@@ -597,7 +597,9 @@ List grouping: today's single `needs-you` group splits into:
 
 Items without a lane keep current behaviour (blocked/escalated/pending approval → needs-you).
 
-`needsAttentionFor` SQL: exclude rows whose recovery lane is `recovering` (they are not a you-wait). Include manager-lane items for the assignee's manager queue via existing assignee match, not the operator's Needs you.
+`needsAttentionFor` SQL: include open recovering/manager leftovers (including parked rows that already have those lanes). Parked clock-waits without a recovering/manager row stay out. The dashboard then splits Recovering automatically / Manager attention / Needs you. Do not exclude recovering from this feed — grouping is only fed from `needsAttentionFor=me`.
+
+Classifier vs detector: `classifyRecovery` treats approved+completed+`in_review` as manager, not the operator fallback. Sweep must not overwrite a live `anomaly:approved-landed-open` manager row. Conclusive mirrored approved + completed run + `in_review` closes through `complete()`; a refused close (open children) stays `in_review` on Manager attention.
 
 - [ ] **Step 1: Failing grouping tests**
 - [ ] **Step 2: Red**

--- a/packages/jinn/src/gateway/__tests__/availability-resume.test.ts
+++ b/packages/jinn/src/gateway/__tests__/availability-resume.test.ts
@@ -46,8 +46,13 @@ function armedWorkflow(id: string, config: { label?: string; actor?: string } = 
 }
 
 /** A Todo the given workflow was driving when a quota window killed its attempt. */
-function parkedBy(workflowId: string | undefined, title: string, status: "executing" | "assigned" = "executing"): string {
-  const item = store.createWorkItem({ title, status });
+function parkedBy(
+  workflowId: string | undefined,
+  title: string,
+  status: "executing" | "assigned" = "executing",
+  extra: { assignee?: string; department?: string } = {},
+): string {
+  const item = store.createWorkItem({ title, status, ...extra });
   const run = runs.openWorkItemRun({ workItemId: item.id, sessionId: `s-${item.id}` });
   runs.closeWorkItemRun(run.id, { outcome: "rate_limited", endedAt: new Date(NOW.getTime() - 90 * 60_000).toISOString(), error: QUOTA });
   if (workflowId !== undefined) {
@@ -95,6 +100,22 @@ describe("resuming a Todo into its own trigger", () => {
     port.availabilityRearm(id, repository);
 
     expect(labels.getWorkItemLabels(id).map((label) => label.name)).toEqual(["build"]);
+  });
+
+  it("keeps extra labels and the assignee while restoring the arming label", () => {
+    labels.createLabel({ name: "urgent" });
+    armedWorkflow("resume-keeper", { label: "build", actor: "operator" });
+    const id = parkedBy("resume-keeper", "labelled and assigned", "executing", {
+      assignee: "platform-worker", department: "platform",
+    });
+    labels.setWorkItemLabels(id, ["urgent"], "operator");
+
+    port.availabilityRearm(id, repository);
+
+    expect(labels.getWorkItemLabels(id).map((label) => label.name).sort()).toEqual(["build", "urgent"]);
+    expect(store.getWorkItem(id)).toMatchObject({ assignee: "platform-worker", department: "platform" });
+    const move = store.listWorkItemEvents(id).filter((event) => event.kind === "status_change").at(-1);
+    expect(move?.actor).toBe("availability-resume");
   });
 });
 

--- a/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
+++ b/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
@@ -1,0 +1,53 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-gw-todo-recovery-"));
+process.env.JINN_HOME = tmp;
+
+type Store = typeof import("../../work-items/store.js");
+type Runs = typeof import("../../work-items/runs.js");
+type Approvals = typeof import("../../work-items/approvals.js");
+type Recovery = typeof import("../todo-recovery.js");
+type Transitions = typeof import("../../work-items/transitions.js");
+
+let store: Store;
+let runs: Runs;
+let approvals: Approvals;
+let recovery: Recovery;
+let transitions: Transitions;
+let db: import("better-sqlite3").Database;
+
+beforeAll(async () => {
+  store = await import("../../work-items/store.js");
+  runs = await import("../../work-items/runs.js");
+  approvals = await import("../../work-items/approvals.js");
+  transitions = await import("../../work-items/transitions.js");
+  recovery = await import("../todo-recovery.js");
+  db = (await import("../../shared/db.js")).initDb();
+});
+
+describe("closeApprovedLanded", () => {
+  it("closes an approved completed run through complete(), leaving the Todo done", () => {
+    const item = store.createWorkItem({
+      title: "approved landing leftover", status: "assigned", assignee: "platform-worker",
+    });
+    transitions.transition(item.id, "in_review", "session:worker", { agent: true });
+    const sessionId = `s-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+    expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+
+    expect(recovery.closeApprovedLanded(item.id)).toBe(true);
+    expect(store.getWorkItem(item.id)!.status).toBe("done");
+  });
+});

--- a/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
+++ b/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
@@ -50,4 +50,17 @@ describe("closeApprovedLanded", () => {
     expect(recovery.closeApprovedLanded(item.id)).toBe(true);
     expect(store.getWorkItem(item.id)!.status).toBe("done");
   });
+
+  it("does not close without a completed run; the leftover stays in_review", () => {
+    const item = store.createWorkItem({
+      title: "approved but not landed", status: "assigned", assignee: "platform-worker",
+    });
+    transitions.transition(item.id, "in_review", "session:worker", { agent: true });
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: "workflow:pipeline:run_missing:gate", target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+    expect(recovery.closeApprovedLanded(item.id)).toBe(false);
+    expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+  });
 });

--- a/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
+++ b/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
@@ -11,12 +11,18 @@ type Runs = typeof import("../../work-items/runs.js");
 type Approvals = typeof import("../../work-items/approvals.js");
 type Recovery = typeof import("../todo-recovery.js");
 type Transitions = typeof import("../../work-items/transitions.js");
+type Controller = typeof import("../../work-items/recovery-controller.js");
+type Detect = typeof import("../../work-items/anomaly-detect.js");
+type Rows = typeof import("../../work-items/recovery-rows.js");
 
 let store: Store;
 let runs: Runs;
 let approvals: Approvals;
 let recovery: Recovery;
 let transitions: Transitions;
+let controller: Controller;
+let detect: Detect;
+let rows: Rows;
 let db: import("better-sqlite3").Database;
 
 beforeAll(async () => {
@@ -25,6 +31,9 @@ beforeAll(async () => {
   approvals = await import("../../work-items/approvals.js");
   transitions = await import("../../work-items/transitions.js");
   recovery = await import("../todo-recovery.js");
+  controller = await import("../../work-items/recovery-controller.js");
+  detect = await import("../../work-items/anomaly-detect.js");
+  rows = await import("../../work-items/recovery-rows.js");
   db = (await import("../../shared/db.js")).initDb();
 });
 
@@ -62,5 +71,39 @@ describe("closeApprovedLanded", () => {
     approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
     expect(recovery.closeApprovedLanded(item.id)).toBe(false);
     expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+  });
+
+  it("keeps a refused open-child leftover on Manager attention across sweep-then-detect ticks", () => {
+    const item = store.createWorkItem({
+      title: "approved landing with open child", status: "assigned", assignee: "platform-worker",
+    });
+    transitions.transition(item.id, "in_review", "session:worker", { agent: true });
+    store.createWorkItem({
+      title: "open child leftover", parentId: item.id, status: "assigned", assignee: "platform-worker",
+    });
+    const sessionId = `s-child-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+    expect(recovery.closeApprovedLanded(item.id)).toBe(false);
+    expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+
+    const tick = (): void => {
+      controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
+      detect.detectTodoAnomalies({ persist: true, closeApprovedLanded: recovery.closeApprovedLanded });
+    };
+    tick();
+    tick();
+
+    expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+    expect(rows.getWorkItemRecovery(item.id)).toMatchObject({ lane: "manager" });
+    expect(store.listWorkItems({ needsAttentionFor: "operator" }).map((row) => row.id)).toContain(item.id);
   });
 });

--- a/packages/jinn/src/gateway/__tests__/work-items-route-attention-lanes.test.ts
+++ b/packages/jinn/src/gateway/__tests__/work-items-route-attention-lanes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { api, ctx, makeReq, makeRes, store, toolHeaders, reg } from "./helpers/work-items-route-harness.js";
+import { api, ctx, dbModule, makeReq, makeRes, store, toolHeaders, reg } from "./helpers/work-items-route-harness.js";
 
 /**
  * PLA-240 data contract: Attention/list grouping is fed only from
@@ -56,5 +56,108 @@ describe("GET /api/work-items?needsAttentionFor=me attention lanes", () => {
     expect(res.status).toBe(200);
     const row = (res.body.workItems as Array<Record<string, unknown>>).find((entry) => entry.id === item.id);
     expect(row).toMatchObject({ id: item.id, status: "in_review", attentionLane: "manager" });
+  });
+
+  /**
+   * Dashboard contract from packages/web: deriveNeedsYou keeps recovering/manager
+   * lanes, then grouping splits Recovering automatically / Manager attention / Needs you.
+   */
+  function dashboardGroups(feed: Array<Record<string, unknown>>) {
+    const kept = feed.filter((item) =>
+      item.attentionLane === "recovering" || item.attentionLane === "manager"
+      || item.approvalState === "pending" || item.status === "escalated" || item.status === "blocked");
+    return {
+      recovering: kept.filter((item) => item.attentionLane === "recovering").map((item) => item.id),
+      manager: kept.filter((item) => item.attentionLane === "manager").map((item) => item.id),
+      needsYou: kept.filter((item) => item.attentionLane !== "recovering" && item.attentionLane !== "manager").map((item) => item.id),
+    };
+  }
+
+  async function attentionFeed() {
+    const coo = reg.createSession({ engine: "codex", source: "web", sourceRef: `coo-${Date.now()}`, title: "coo", employee: "coo" });
+    const res = makeRes();
+    await api.handleApiRequest(
+      makeReq("GET", "/api/work-items?needsAttentionFor=me&limit=50", undefined, toolHeaders(coo.id)),
+      res.res,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    return res.body.workItems as Array<Record<string, unknown>>;
+  }
+
+  it("QPR-4: refused-complete leftover survives detect then sweep into Manager attention", async () => {
+    const detect = await import("../../work-items/anomaly-detect.js");
+    const controller = await import("../../work-items/recovery-controller.js");
+    const runs = await import("../../work-items/runs.js");
+    const approvals = await import("../../work-items/approvals.js");
+    const transitions = await import("../../work-items/transitions.js");
+    const recovery = await import("../todo-recovery.js");
+    const rows = await import("../../work-items/recovery-rows.js");
+    const db = dbModule.initDb();
+
+    const item = store.createWorkItem({
+      title: "QPR-4 refused landing", status: "assigned", assignee: "platform-worker",
+    });
+    transitions.transition(item.id, "in_review", "session:worker", { agent: true });
+    store.createWorkItem({
+      title: "open child leftover", parentId: item.id, status: "assigned", assignee: "platform-worker",
+    });
+    const sessionId = `s-qpr4-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+    expect(recovery.closeApprovedLanded(item.id)).toBe(false);
+
+    detect.detectTodoAnomalies({ persist: true, closeApprovedLanded: recovery.closeApprovedLanded });
+    expect(rows.getWorkItemRecovery(item.id)?.lane).toBe("manager");
+
+    controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
+    expect(rows.getWorkItemRecovery(item.id)?.lane).toBe("manager");
+
+    const feed = await attentionFeed();
+    const compact = feed.find((entry) => entry.id === item.id);
+    expect(compact).toMatchObject({ id: item.id, status: "in_review", attentionLane: "manager" });
+    const groups = dashboardGroups(feed);
+    expect(groups.manager).toContain(item.id);
+    expect(groups.needsYou).not.toContain(item.id);
+  });
+
+  it("QPR-1: recovering leftover survives sweep into Recovering automatically, not Needs you", async () => {
+    const controller = await import("../../work-items/recovery-controller.js");
+    const runs = await import("../../work-items/runs.js");
+    const db = dbModule.initDb();
+
+    const item = store.createWorkItem({
+      title: "QPR-1 quota parked", status: "blocked", assignee: "platform-worker",
+    });
+    const sessionId = `s-qpr1-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, {
+      outcome: "rate_limited", endedAt: new Date().toISOString(),
+      error: "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z",
+    });
+    store.appendWorkItemEvent({
+      workItemId: item.id, kind: "status_change", fromStatus: "assigned", toStatus: "blocked",
+      actor: "workflow:run", detail: { workflowId: "pipeline", runId: run.id }, versionEffect: "audit",
+    });
+
+    controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
+    const feed = await attentionFeed();
+    const compact = feed.find((entry) => entry.id === item.id);
+    expect(compact).toMatchObject({ id: item.id, attentionLane: "recovering" });
+    const groups = dashboardGroups(feed);
+    expect(groups.recovering).toContain(item.id);
+    expect(groups.needsYou).not.toContain(item.id);
   });
 });

--- a/packages/jinn/src/gateway/__tests__/work-items-route-attention-lanes.test.ts
+++ b/packages/jinn/src/gateway/__tests__/work-items-route-attention-lanes.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { api, ctx, makeReq, makeRes, store, toolHeaders, reg } from "./helpers/work-items-route-harness.js";
+
+/**
+ * PLA-240 data contract: Attention/list grouping is fed only from
+ * GET /api/work-items?needsAttentionFor=me. Recovering leftovers must be in
+ * that feed with attentionLane=recovering so the UI can split them out of
+ * Needs you.
+ */
+describe("GET /api/work-items?needsAttentionFor=me attention lanes", () => {
+  it("returns a recovering blocked Todo with attentionLane recovering, including for the COO who is not the assignee", async () => {
+    const coo = reg.createSession({ engine: "codex", source: "web", sourceRef: "coo-lanes", title: "coo", employee: "coo" });
+    const item = store.createWorkItem({
+      title: "quota parked build", status: "blocked", assignee: "platform-worker",
+    });
+    const rows = await import("../../work-items/recovery-rows.js");
+    rows.upsertWorkItemRecovery({
+      workItemId: item.id,
+      incidentId: "run_old",
+      class: "transient",
+      lane: "recovering",
+      reason: "provider availability",
+    });
+
+    const res = makeRes();
+    await api.handleApiRequest(
+      makeReq("GET", "/api/work-items?needsAttentionFor=me&limit=50", undefined, toolHeaders(coo.id)),
+      res.res,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    const row = (res.body.workItems as Array<Record<string, unknown>>).find((entry) => entry.id === item.id);
+    expect(row).toMatchObject({ id: item.id, status: "blocked", attentionLane: "recovering" });
+  });
+
+  it("returns a manager-lane in_review leftover that is not a pending approval", async () => {
+    const coo = reg.createSession({ engine: "codex", source: "web", sourceRef: "coo-mgr", title: "coo", employee: "coo" });
+    const item = store.createWorkItem({
+      title: "approved landing leftover", status: "in_review", assignee: "platform-worker",
+    });
+    const rows = await import("../../work-items/recovery-rows.js");
+    rows.upsertWorkItemRecovery({
+      workItemId: item.id,
+      incidentId: "anomaly:approved-landed-open",
+      class: "code",
+      lane: "manager",
+      reason: "approved landing is still open",
+    });
+
+    const res = makeRes();
+    await api.handleApiRequest(
+      makeReq("GET", "/api/work-items?needsAttentionFor=me&limit=50", undefined, toolHeaders(coo.id)),
+      res.res,
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    const row = (res.body.workItems as Array<Record<string, unknown>>).find((entry) => entry.id === item.id);
+    expect(row).toMatchObject({ id: item.id, status: "in_review", attentionLane: "manager" });
+  });
+});

--- a/packages/jinn/src/gateway/__tests__/workflow-todo-surface-stale-end.test.ts
+++ b/packages/jinn/src/gateway/__tests__/workflow-todo-surface-stale-end.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-wf-todo-stale-end-"));
+process.env.JINN_HOME = tmp;
+
+type Surface = typeof import("../workflow-todo-surface.js");
+type Store = typeof import("../../work-items/store.js");
+type Transitions = typeof import("../../work-items/transitions.js");
+type Approvals = typeof import("../../work-items/approvals.js");
+
+let surface: Surface;
+let store: Store;
+let transitions: Transitions;
+let approvals: Approvals;
+
+function armedTodo(title: string): string {
+  return store.createWorkItem({ title, source: "human", status: "assigned" }).id;
+}
+
+function reflect(
+  todoId: string,
+  status: "executing" | "in_review" | "blocked",
+  nodeId = "plan",
+  runId = "run_1",
+): void {
+  surface.workflowTodoLifecycle.reflect({ todoId, status, workflowId: "pipeline", runId, nodeId });
+}
+
+beforeAll(async () => {
+  store = await import("../../work-items/store.js");
+  transitions = await import("../../work-items/transitions.js");
+  approvals = await import("../../work-items/approvals.js");
+  surface = await import("../workflow-todo-surface.js");
+});
+
+beforeEach(() => {
+  transitions.setTodoStatusChangeListener(null);
+  approvals.setTodoApprovalDecisionListener(null);
+});
+
+describe("stale failure Ends cannot stomp a live successor (PLA-221)", () => {
+  it("does not let a stale failure End stomp a successor executing Todo", () => {
+    const id = armedTodo("rearmed while the old End was still firing");
+    reflect(id, "executing");
+    transitions.transition(id, "assigned", "availability-resume", {
+      requeue: true,
+      detail: { workflowId: "pipeline", availabilityResume: true },
+    });
+    reflect(id, "executing", "plan", "run_2");
+
+    reflect(id, "blocked", "land", "run_1");
+
+    expect(store.getWorkItem(id)!.status).toBe("executing");
+  });
+
+  it("does not let a stale failure End stomp an operator or employee move to assigned", () => {
+    const id = armedTodo("rescued while the old End was still firing");
+    reflect(id, "executing");
+    transitions.transition(id, "assigned", "operator", { requeue: true });
+
+    reflect(id, "blocked", "land");
+
+    expect(store.getWorkItem(id)!.status).toBe("assigned");
+  });
+
+  it("still blocks a quiet Todo this run itself left executing", () => {
+    const id = armedTodo("this run died");
+    reflect(id, "executing");
+    reflect(id, "blocked", "land");
+    expect(store.getWorkItem(id)!.status).toBe("blocked");
+  });
+
+  it("still blocks when THIS run reflected in_review and then failed", () => {
+    const id = armedTodo("gate parked then the land died");
+    reflect(id, "executing");
+    reflect(id, "in_review", "gate");
+    reflect(id, "blocked", "land");
+    expect(store.getWorkItem(id)!.status).toBe("blocked");
+  });
+
+  it("does not stomp in_review a successor already moved to, with no matching run", () => {
+    const id = armedTodo("phase reviewed it, then a stale End fired");
+    transitions.transition(id, "in_review", "session:abc", { agent: true });
+
+    reflect(id, "blocked", "land");
+
+    expect(store.getWorkItem(id)!.status).toBe("in_review");
+  });
+});

--- a/packages/jinn/src/gateway/__tests__/workflow-todo-surface.test.ts
+++ b/packages/jinn/src/gateway/__tests__/workflow-todo-surface.test.ts
@@ -29,8 +29,13 @@ function armedTodo(title: string, source: Source = "human"): string {
   return store.createWorkItem({ title, source, status: "assigned" }).id;
 }
 
-function reflect(todoId: string, status: "executing" | "in_review" | "blocked", nodeId = "plan"): void {
-  surface.workflowTodoLifecycle.reflect({ todoId, status, workflowId: "pipeline", runId: "run_1", nodeId });
+function reflect(
+  todoId: string,
+  status: "executing" | "in_review" | "blocked",
+  nodeId = "plan",
+  runId = "run_1",
+): void {
+  surface.workflowTodoLifecycle.reflect({ todoId, status, workflowId: "pipeline", runId, nodeId });
 }
 
 beforeAll(async () => {
@@ -88,13 +93,52 @@ describe("reflecting a run's lifecycle onto its bound Todo", () => {
     expect(store.getWorkItem(id)!.status).toBe("in_review");
   });
 
-  it("still reports a dead run, because a failed run is the newest fact about the work", () => {
-    const id = armedTodo("phase reviewed it, then the run died");
+  it("does not let a stale failure End stomp a successor executing Todo", () => {
+    const id = armedTodo("rearmed while the old End was still firing");
+    reflect(id, "executing");
+    transitions.transition(id, "assigned", "availability-resume", {
+      requeue: true,
+      detail: { workflowId: "pipeline", availabilityResume: true },
+    });
+    reflect(id, "executing", "plan", "run_2");
+
+    reflect(id, "blocked", "land", "run_1");
+
+    expect(store.getWorkItem(id)!.status).toBe("executing");
+  });
+
+  it("does not let a stale failure End stomp an operator or employee move to assigned", () => {
+    const id = armedTodo("rescued while the old End was still firing");
+    reflect(id, "executing");
+    transitions.transition(id, "assigned", "operator", { requeue: true });
+
+    reflect(id, "blocked", "land");
+
+    expect(store.getWorkItem(id)!.status).toBe("assigned");
+  });
+
+  it("still blocks a quiet Todo this run itself left executing", () => {
+    const id = armedTodo("this run died");
+    reflect(id, "executing");
+    reflect(id, "blocked", "land");
+    expect(store.getWorkItem(id)!.status).toBe("blocked");
+  });
+
+  it("still blocks when THIS run reflected in_review and then failed", () => {
+    const id = armedTodo("gate parked then the land died");
+    reflect(id, "executing");
+    reflect(id, "in_review", "gate");
+    reflect(id, "blocked", "land");
+    expect(store.getWorkItem(id)!.status).toBe("blocked");
+  });
+
+  it("does not stomp in_review a successor already moved to, with no matching run", () => {
+    const id = armedTodo("phase reviewed it, then a stale End fired");
     transitions.transition(id, "in_review", "session:abc", { agent: true });
 
     reflect(id, "blocked", "land");
 
-    expect(store.getWorkItem(id)!.status).toBe("blocked");
+    expect(store.getWorkItem(id)!.status).toBe("in_review");
   });
 
   it("never pulls a Todo out of a sticky terminal", () => {

--- a/packages/jinn/src/gateway/__tests__/workflow-todo-surface.test.ts
+++ b/packages/jinn/src/gateway/__tests__/workflow-todo-surface.test.ts
@@ -29,13 +29,8 @@ function armedTodo(title: string, source: Source = "human"): string {
   return store.createWorkItem({ title, source, status: "assigned" }).id;
 }
 
-function reflect(
-  todoId: string,
-  status: "executing" | "in_review" | "blocked",
-  nodeId = "plan",
-  runId = "run_1",
-): void {
-  surface.workflowTodoLifecycle.reflect({ todoId, status, workflowId: "pipeline", runId, nodeId });
+function reflect(todoId: string, status: "executing" | "in_review" | "blocked", nodeId = "plan"): void {
+  surface.workflowTodoLifecycle.reflect({ todoId, status, workflowId: "pipeline", runId: "run_1", nodeId });
 }
 
 beforeAll(async () => {
@@ -89,54 +84,6 @@ describe("reflecting a run's lifecycle onto its bound Todo", () => {
     expect(store.isBlockDeclared(id)).toBe(false);
 
     reflect(id, "in_review", "gate");
-
-    expect(store.getWorkItem(id)!.status).toBe("in_review");
-  });
-
-  it("does not let a stale failure End stomp a successor executing Todo", () => {
-    const id = armedTodo("rearmed while the old End was still firing");
-    reflect(id, "executing");
-    transitions.transition(id, "assigned", "availability-resume", {
-      requeue: true,
-      detail: { workflowId: "pipeline", availabilityResume: true },
-    });
-    reflect(id, "executing", "plan", "run_2");
-
-    reflect(id, "blocked", "land", "run_1");
-
-    expect(store.getWorkItem(id)!.status).toBe("executing");
-  });
-
-  it("does not let a stale failure End stomp an operator or employee move to assigned", () => {
-    const id = armedTodo("rescued while the old End was still firing");
-    reflect(id, "executing");
-    transitions.transition(id, "assigned", "operator", { requeue: true });
-
-    reflect(id, "blocked", "land");
-
-    expect(store.getWorkItem(id)!.status).toBe("assigned");
-  });
-
-  it("still blocks a quiet Todo this run itself left executing", () => {
-    const id = armedTodo("this run died");
-    reflect(id, "executing");
-    reflect(id, "blocked", "land");
-    expect(store.getWorkItem(id)!.status).toBe("blocked");
-  });
-
-  it("still blocks when THIS run reflected in_review and then failed", () => {
-    const id = armedTodo("gate parked then the land died");
-    reflect(id, "executing");
-    reflect(id, "in_review", "gate");
-    reflect(id, "blocked", "land");
-    expect(store.getWorkItem(id)!.status).toBe("blocked");
-  });
-
-  it("does not stomp in_review a successor already moved to, with no matching run", () => {
-    const id = armedTodo("phase reviewed it, then a stale End fired");
-    transitions.transition(id, "in_review", "session:abc", { agent: true });
-
-    reflect(id, "blocked", "land");
 
     expect(store.getWorkItem(id)!.status).toBe("in_review");
   });

--- a/packages/jinn/src/gateway/availability-resume.ts
+++ b/packages/jinn/src/gateway/availability-resume.ts
@@ -4,10 +4,10 @@ import {
   startAvailabilityResumeSweep,
   type AvailabilityRearmResult,
 } from "../work-items/availability-resume.js";
-import { listWorkItemEvents } from "../work-items/event-log.js";
 import { getWorkItemLabels, normalizeLabelName, setWorkItemLabels } from "../work-items/labels.js";
 import type { WorkItemStatus } from "../work-items/store.js";
 import { transition, TransitionError } from "../work-items/transitions.js";
+import { owningWorkflowId } from "../work-items/workflow-ownership.js";
 import { resolveRearmTarget } from "../workflows/rearm-target.js";
 import type { WorkflowRepository } from "../workflows/repository.js";
 
@@ -26,7 +26,7 @@ export function startAvailabilityResumes(repository: WorkflowRepository): () => 
 
 /** One re-arm. Exported for tests; the sweep above is the only caller in anger. */
 export function availabilityRearm(todoId: string, repository: WorkflowRepository): AvailabilityRearmResult {
-  const workflowId = boundWorkflowId(todoId);
+  const workflowId = owningWorkflowId(todoId);
   if (workflowId === undefined) {
     return { unavailable: "no Workflow run has ever driven this Todo, so nothing says where a re-arm would land" };
   }
@@ -35,7 +35,7 @@ export function availabilityRearm(todoId: string, repository: WorkflowRepository
 
   if (target.label !== undefined) restoreArmingLabel(todoId, target.label);
   try {
-    const moved = transition(todoId, target.status as WorkItemStatus, armingActor(target.actor), {
+    const moved = transition(todoId, target.status as WorkItemStatus, AVAILABILITY_RESUME_ACTOR, {
       requeue: true,
       detail: { workflowId, availabilityResume: true },
     });
@@ -50,29 +50,6 @@ export function availabilityRearm(todoId: string, repository: WorkflowRepository
     return { unavailable: `it could not be moved to \`${target.status}\`: ${error.message}` };
   }
   return { status: target.status, ...(target.label === undefined ? {} : { label: target.label }) };
-}
-
-/**
- * The actor the re-armed status event carries.
- *
- * A trigger's `actor` filter is an authority boundary — it is what keeps an
- * arbitrary employee from starting a pipeline nobody asked for. This does not
- * cross it: the sweep only ever reaches a Todo whose own audit trail shows this
- * workflow ALREADY running on it, which is the arming that authority produced.
- * Resuming an attempt the operator armed is not the same act as arming one, and
- * the `availability_resumed` event beside it says which of the two happened.
- */
-function armingActor(required: string | undefined): string {
-  return required ?? AVAILABILITY_RESUME_ACTOR;
-}
-
-/** Which Workflow was driving this Todo, read off the status moves its own runs
- *  reflected onto it. Newest wins: a Todo re-armed into a different pipeline
- *  since then belongs to that one. */
-function boundWorkflowId(todoId: string): string | undefined {
-  const bound = listWorkItemEvents(todoId)
-    .filter((event) => event.kind === "status_change" && typeof event.detail?.workflowId === "string");
-  return bound.at(-1)?.detail?.workflowId as string | undefined;
 }
 
 /**

--- a/packages/jinn/src/gateway/server.ts
+++ b/packages/jinn/src/gateway/server.ts
@@ -51,6 +51,7 @@ import { GATEWAY_INFO_FILE, HOOK_RELAY_SCRIPT, JINN_HOME, CLAUDE_SETTINGS_DIR } 
 import { enforceOwnerOnlyDirectory, pathIsOwnerOnly } from "../shared/owner-only.js";
 import { isSameOriginBrowserRequest, resumePendingWebQueueItems, sessionsHoldingEngineCapacity, type ApiContext } from "./api.js";
 import { startAvailabilityResumes } from "./availability-resume.js";
+import { startTodoRecovery } from "./todo-recovery.js";
 import { createGatewayRequestHandler } from "./request-handler.js";
 import { sessionCommGuards, LATERAL_MAX_HOPS } from "./session-comm-guards.js";
 import { rejectNonOperatorPtyUpgradeCaller, rejectUnverifiedIdentifiedUpgradeCaller } from "./upgrade-guards.js";
@@ -898,6 +899,7 @@ export async function startGateway(
   // Todos ledger truth-keeping: derive status from linked-session evidence so a mid-process settle lands without a boot (GRS-021a), and resume a Todo parked on a provider window that has since reopened (PLA-153).
   const stopWorkItemReconciler = startWorkItemReconciler();
   const stopAvailabilityResumes = startAvailabilityResumes(workflowRepository);
+  const stopTodoRecovery = startTodoRecovery(workflowRepository);
 
   // A todo-status trigger's label filter reads the Todo when its event DRAINS rather than when it moved, so a label landing after the move re-opens the drain too.
   const drainTodoTriggers = (): void => { void workflowService.recover(new Date().toISOString())
@@ -1209,7 +1211,7 @@ export async function startGateway(
     logger.info("Gateway cleanup starting...");
 
     // Stop the periodic sweeps before we start marking sessions interrupted below — a mid-shutdown sweep must not race the teardown.
-    stopStatusReconciler(); stopWorkItemReconciler(); stopAvailabilityResumes(); stopHeartbeatScheduler();
+    stopStatusReconciler(); stopWorkItemReconciler(); stopAvailabilityResumes(); stopTodoRecovery(); stopHeartbeatScheduler();
     backgroundRefreshes.stop();
     workflowService.dispose(); workflowDatabase.close();
 

--- a/packages/jinn/src/gateway/server.ts
+++ b/packages/jinn/src/gateway/server.ts
@@ -50,8 +50,7 @@ import { claudeJsonPath } from "../shared/home.js";
 import { GATEWAY_INFO_FILE, HOOK_RELAY_SCRIPT, JINN_HOME, CLAUDE_SETTINGS_DIR } from "../shared/paths.js";
 import { enforceOwnerOnlyDirectory, pathIsOwnerOnly } from "../shared/owner-only.js";
 import { isSameOriginBrowserRequest, resumePendingWebQueueItems, sessionsHoldingEngineCapacity, type ApiContext } from "./api.js";
-import { startAvailabilityResumes } from "./availability-resume.js";
-import { startTodoRecovery } from "./todo-recovery.js";
+import { startTodoSweeps } from "./todo-sweeps.js";
 import { createGatewayRequestHandler } from "./request-handler.js";
 import { sessionCommGuards, LATERAL_MAX_HOPS } from "./session-comm-guards.js";
 import { rejectNonOperatorPtyUpgradeCaller, rejectUnverifiedIdentifiedUpgradeCaller } from "./upgrade-guards.js";
@@ -898,8 +897,7 @@ export async function startGateway(
 
   // Todos ledger truth-keeping: derive status from linked-session evidence so a mid-process settle lands without a boot (GRS-021a), and resume a Todo parked on a provider window that has since reopened (PLA-153).
   const stopWorkItemReconciler = startWorkItemReconciler();
-  const stopAvailabilityResumes = startAvailabilityResumes(workflowRepository);
-  const stopTodoRecovery = startTodoRecovery(workflowRepository);
+  const stopTodoSweeps = startTodoSweeps(workflowRepository);
 
   // A todo-status trigger's label filter reads the Todo when its event DRAINS rather than when it moved, so a label landing after the move re-opens the drain too.
   const drainTodoTriggers = (): void => { void workflowService.recover(new Date().toISOString())
@@ -1211,7 +1209,7 @@ export async function startGateway(
     logger.info("Gateway cleanup starting...");
 
     // Stop the periodic sweeps before we start marking sessions interrupted below — a mid-shutdown sweep must not race the teardown.
-    stopStatusReconciler(); stopWorkItemReconciler(); stopAvailabilityResumes(); stopTodoRecovery(); stopHeartbeatScheduler();
+    stopStatusReconciler(); stopWorkItemReconciler(); stopTodoSweeps(); stopHeartbeatScheduler();
     backgroundRefreshes.stop();
     workflowService.dispose(); workflowDatabase.close();
 

--- a/packages/jinn/src/gateway/todo-recovery.ts
+++ b/packages/jinn/src/gateway/todo-recovery.ts
@@ -1,0 +1,36 @@
+import { logger } from "../shared/logger.js";
+import { loadConfig } from "../shared/config.js";
+import { sweepTodoRecovery, todoRecoveryMode } from "../work-items/recovery-controller.js";
+import { detectTodoAnomalies } from "../work-items/anomaly-detect.js";
+import { availabilityRearm } from "./availability-resume.js";
+import type { WorkflowRepository } from "../workflows/repository.js";
+
+const DEFAULT_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * Classify (and, if enabled, apply) bounded Todo recovery. Default mode is
+ * classify-only so production observes lanes without auto-rearming until the
+ * reviewed gate flips `gateway.todoRecovery.mode` to `auto`.
+ */
+export function startTodoRecovery(repository: WorkflowRepository, intervalMs = DEFAULT_INTERVAL_MS): () => void {
+  const tick = (): void => {
+    try {
+      const mode = todoRecoveryMode(loadConfig().gateway.todoRecovery?.mode);
+      const result = sweepTodoRecovery({
+        mode,
+        rearm: (todoId) => availabilityRearm(todoId, repository),
+      });
+      const anomalies = detectTodoAnomalies();
+      if (result.classified > 0 || result.applied > 0 || anomalies.length > 0) {
+        logger.info(
+          `Todo recovery: classified ${result.classified}, applied ${result.applied}, anomalies ${anomalies.length} (mode ${mode})`,
+        );
+      }
+    } catch (err) {
+      logger.warn(`Todo recovery sweep failed: ${err instanceof Error ? err.message : err}`);
+    }
+  };
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/packages/jinn/src/gateway/todo-recovery.ts
+++ b/packages/jinn/src/gateway/todo-recovery.ts
@@ -2,7 +2,11 @@ import { logger } from "../shared/logger.js";
 import { loadConfig } from "../shared/config.js";
 import { sweepTodoRecovery, todoRecoveryMode } from "../work-items/recovery-controller.js";
 import { detectTodoAnomalies } from "../work-items/anomaly-detect.js";
+import { currentApproval } from "../work-items/approvals.js";
+import { getWorkItem } from "../work-items/store.js";
+import { parseTodoApprovalRef } from "../workflows/todo-approval-ref.js";
 import { availabilityRearm } from "./availability-resume.js";
+import { workflowTodoLifecycle } from "./workflow-todo-surface.js";
 import type { WorkflowRepository } from "../workflows/repository.js";
 
 const DEFAULT_INTERVAL_MS = 5 * 60_000;
@@ -12,15 +16,28 @@ const DEFAULT_INTERVAL_MS = 5 * 60_000;
  * classify-only so production observes lanes without auto-rearming until the
  * reviewed gate flips `gateway.todoRecovery.mode` to `auto`.
  */
+export function closeApprovedLanded(todoId: string): boolean {
+  const approval = currentApproval(todoId);
+  if (approval?.state !== "approved" || !approval.decidedBy || !approval.decidedAt) return false;
+  const origin = parseTodoApprovalRef(approval.ref);
+  if (!origin) return false;
+  workflowTodoLifecycle.complete({
+    todoId, workflowId: origin.workflowId, runId: origin.runId, nodeId: origin.nodeId,
+    approvedBy: approval.decidedBy, approvedAt: approval.decidedAt,
+  });
+  return getWorkItem(todoId)?.status === "done";
+}
+
 export function startTodoRecovery(repository: WorkflowRepository, intervalMs = DEFAULT_INTERVAL_MS): () => void {
   const tick = (): void => {
     try {
       const mode = todoRecoveryMode(loadConfig().gateway.todoRecovery?.mode);
+      if (mode === "off") return;
       const result = sweepTodoRecovery({
         mode,
         rearm: (todoId) => availabilityRearm(todoId, repository),
       });
-      const anomalies = detectTodoAnomalies();
+      const anomalies = detectTodoAnomalies({ persist: true, closeApprovedLanded });
       if (result.classified > 0 || result.applied > 0 || anomalies.length > 0) {
         logger.info(
           `Todo recovery: classified ${result.classified}, applied ${result.applied}, anomalies ${anomalies.length} (mode ${mode})`,

--- a/packages/jinn/src/gateway/todo-recovery.ts
+++ b/packages/jinn/src/gateway/todo-recovery.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../shared/config.js";
 import { sweepTodoRecovery, todoRecoveryMode } from "../work-items/recovery-controller.js";
 import { detectTodoAnomalies } from "../work-items/anomaly-detect.js";
 import { currentApproval } from "../work-items/approvals.js";
+import { listWorkItemRuns } from "../work-items/runs.js";
 import { getWorkItem } from "../work-items/store.js";
 import { parseTodoApprovalRef } from "../workflows/todo-approval-ref.js";
 import { availabilityRearm } from "./availability-resume.js";
@@ -21,6 +22,8 @@ export function closeApprovedLanded(todoId: string): boolean {
   if (approval?.state !== "approved" || !approval.decidedBy || !approval.decidedAt) return false;
   const origin = parseTodoApprovalRef(approval.ref);
   if (!origin) return false;
+  const landed = listWorkItemRuns(todoId).some((run) => run.outcome === "completed" && run.endedAt !== null);
+  if (!landed) return false;
   workflowTodoLifecycle.complete({
     todoId, workflowId: origin.workflowId, runId: origin.runId, nodeId: origin.nodeId,
     approvedBy: approval.decidedBy, approvedAt: approval.decidedAt,

--- a/packages/jinn/src/gateway/todo-sweeps.ts
+++ b/packages/jinn/src/gateway/todo-sweeps.ts
@@ -1,0 +1,13 @@
+import type { WorkflowRepository } from "../workflows/repository.js";
+import { startAvailabilityResumes } from "./availability-resume.js";
+import { startTodoRecovery } from "./todo-recovery.js";
+
+/** Availability resume (PLA-153) plus bounded Todo recovery (PLA-240). */
+export function startTodoSweeps(repository: WorkflowRepository): () => void {
+  const stopResumes = startAvailabilityResumes(repository);
+  const stopRecovery = startTodoRecovery(repository);
+  return () => {
+    stopResumes();
+    stopRecovery();
+  };
+}

--- a/packages/jinn/src/gateway/work-item-payload.ts
+++ b/packages/jinn/src/gateway/work-item-payload.ts
@@ -7,6 +7,7 @@ import { listWorkItemRuns } from "../work-items/runs.js";
 import { getTodoDispatchConfig } from "../work-items/dispatch-config.js";
 import { readStopCause, type TodoStopCause } from "../work-items/stop-cause.js";
 import { isWorkItemKept, keptSet } from "../work-items/kept.js";
+import { getWorkItemRecovery, recoveryByItem } from "../work-items/recovery-rows.js";
 import { initDb } from "../shared/db.js";
 
 /** The wire projections of a Todo the API routes return: one compact shape for
@@ -16,9 +17,28 @@ import { initDb } from "../shared/db.js";
  *  board's chip/indicator data; ICI-1357 adds `kept` — whether the Todo is on
  *  the operator's Home). List callers pass the pre-batched `extras` (ONE query
  *  each per page); single-item callers omit them and pay per-item lookups. */
+function attentionLaneOf(
+  item: WorkItem,
+  recovery = getWorkItemRecovery(item.id),
+): string | null {
+  if (recovery) return recovery.lane;
+  if (item.approvalOperatorOnly && item.approvalState === "pending") return "operator";
+  if (item.status === "blocked" || item.status === "escalated") {
+    const cause = readStopCause(initDb(), item.id);
+    if (cause?.parkedUntil) return "recovering";
+    return "operator";
+  }
+  return null;
+}
+
 export function compactWorkItem(
   item: WorkItem,
-  extras?: { blocked: Set<string>; labels: Map<string, Label[]>; kept: Set<string> },
+  extras?: {
+    blocked: Set<string>;
+    labels: Map<string, Label[]>;
+    kept: Set<string>;
+    recovery?: Map<string, import("../work-items/recovery.js").WorkItemRecovery>;
+  },
 ): Record<string, unknown> {
   return {
     id: item.id,
@@ -47,6 +67,7 @@ export function compactWorkItem(
     approvalTarget: item.approvalTarget,
     approvalEscalatedAt: item.approvalEscalatedAt,
     sessionRef: sessionRef(item),
+    attentionLane: attentionLaneOf(item, extras?.recovery?.get(item.id)),
     ...stopCause(item),
     updatedAt: item.updatedAt,
   };
@@ -56,7 +77,12 @@ export function compactWorkItem(
  *  ONE query each across the whole page rather than per item. */
 export function workItemPagePayload(page: ReturnType<typeof queryWorkItems>): Record<string, unknown> {
   const ids = page.workItems.map((item) => item.id);
-  const extras = { blocked: blockedSet(ids), labels: labelSets(ids), kept: keptSet(initDb(), ids) };
+  const extras = {
+    blocked: blockedSet(ids),
+    labels: labelSets(ids),
+    kept: keptSet(initDb(), ids),
+    recovery: recoveryByItem(ids),
+  };
   return {
     workItems: page.workItems.map((item) => compactWorkItem(item, extras)),
     total: page.total,

--- a/packages/jinn/src/gateway/workflow-todo-surface.ts
+++ b/packages/jinn/src/gateway/workflow-todo-surface.ts
@@ -6,6 +6,7 @@ import { addComment } from "../work-items/comments.js";
 import {
   getWorkItem,
   isBlockDeclared,
+  listWorkItemEvents,
   WORKFLOW_RUN_ACTOR,
   type ApprovalTargetKind,
   type WorkItemStatus,
@@ -52,13 +53,38 @@ import type {
  *     has already said something more specific and keeps it.
  *   - `in_review` yields to a DECLARED block: a phase that blocked with a real
  *     reason says more than "a decision is pending".
- *   - `blocked` always writes. A run that died is the newest and most
- *     consequential fact about the work, and leaving the board on a phase's
- *     optimistic `in_review` is the exact lie this surface exists to stop.
+ *   - `blocked` writes only while THIS run still owns the board. A successor
+ *     round, an availability resume, or an operator/employee move is a newer
+ *     fact; stomping it back to blocked is the false-state PLA-221 exists to
+ *     stop. A quiet Todo this run itself left executing or in_review still
+ *     blocks, as before.
  */
-function mayReflect(status: WorkflowRunReflection, current: WorkItemStatus, todoId: string): boolean {
+function latestRunAttribution(todoId: string): { runId?: string; resume?: boolean } {
+  const last = listWorkItemEvents(todoId).filter((event) => event.kind === "status_change").at(-1);
+  const detail = last?.detail ?? {};
+  return {
+    runId: typeof detail.runId === "string" ? detail.runId : undefined,
+    resume: detail.availabilityResume === true || detail.recoveryResume === true,
+  };
+}
+
+function mayReflect(
+  status: WorkflowRunReflection,
+  current: WorkItemStatus,
+  todoId: string,
+  runId: string,
+): boolean {
   if (status === "executing") return current === "backlog" || current === "assigned";
   if (status === "in_review") return !(current === "blocked" && isBlockDeclared(todoId));
+  if (status === "blocked") {
+    if (current === "done" || current === "cancelled" || current === "escalated") return false;
+    const successor = current === "assigned" || current === "executing" || current === "in_review";
+    if (!successor) return true;
+    const last = latestRunAttribution(todoId);
+    if (last.resume) return false;
+    if (last.runId === undefined) return false;
+    return last.runId === runId;
+  }
   return true;
 }
 
@@ -66,7 +92,7 @@ function reflect(input: {
   todoId: string; status: WorkflowRunReflection; workflowId: string; runId: string; nodeId: string;
 }): void {
   const item = getWorkItem(input.todoId);
-  if (!item || !mayReflect(input.status, item.status, input.todoId)) return;
+  if (!item || !mayReflect(input.status, item.status, input.todoId, input.runId)) return;
   // `declared: false` keeps this out of the declaration lane: the reconciler's
   // provenance checks read it, so a reflected status stays re-derivable instead of
   // freezing the Todo. A dead run blocks `transient`: one recurring problem, not two.

--- a/packages/jinn/src/shared/__tests__/config.test.ts
+++ b/packages/jinn/src/shared/__tests__/config.test.ts
@@ -130,6 +130,14 @@ describe("validateConfigShape", () => {
     expect(problems.some((p) => p.includes("gateway.notesEnabled"))).toBe(true);
   });
 
+  it("accepts gateway.todoRecovery.mode and rejects unknown values", () => {
+    expect(validateConfigShape({ gateway: { todoRecovery: { mode: "classify-only" } }, engines: { claude: {} } })).toEqual([]);
+    expect(validateConfigShape({ gateway: { todoRecovery: { mode: "auto" } }, engines: { claude: {} } })).toEqual([]);
+    expect(validateConfigShape({ gateway: { todoRecovery: { mode: "off" } }, engines: { claude: {} } })).toEqual([]);
+    const problems = validateConfigShape({ gateway: { todoRecovery: { mode: "always" } }, engines: { claude: {} } });
+    expect(problems.some((p) => p.includes("gateway.todoRecovery.mode"))).toBe(true);
+  });
+
   it("accepts a boolean gateway.resumeInterruptedSessions flag and rejects other values", () => {
     expect(validateConfigShape({ gateway: { resumeInterruptedSessions: false }, engines: { claude: {} } })).toEqual([]);
     expect(validateConfigShape({ gateway: {}, engines: { claude: {} } })).toEqual([]);

--- a/packages/jinn/src/shared/config-types.ts
+++ b/packages/jinn/src/shared/config-types.ts
@@ -50,6 +50,9 @@ export interface JinnConfig {
     /** Nudge sessions this gateway's own restart interrupted to continue on the
      *  next boot. Default true; false leaves them interrupted for the operator. */
     resumeInterruptedSessions?: boolean;
+    /** Bounded Todo recovery (PLA-240). Unset = classify-only: lanes and
+     *  metrics, no automatic re-arm. `auto` is a reviewed production gate. */
+    todoRecovery?: { mode?: "off" | "classify-only" | "auto" };
     /** Opt-in: when set, POST /api/sessions reads the forwarded SSO identity
      *  from this request header (set by an auth proxy such as oauth2-proxy,
      *  Traefik forward-auth, or IAP) and persists it on the session. Accepts a

--- a/packages/jinn/src/shared/config.ts
+++ b/packages/jinn/src/shared/config.ts
@@ -6,6 +6,18 @@ import type { JinnConfig } from "./types.js";
 
 type ClaudeEngineConfig = JinnConfig["engines"]["claude"];
 
+const TODO_RECOVERY_MODES = new Set(["off", "classify-only", "auto"]);
+
+function todoRecoveryProblems(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return ["gateway.todoRecovery must be a mapping"];
+  }
+  const mode = (value as { mode?: unknown }).mode;
+  if (mode === undefined || (typeof mode === "string" && TODO_RECOVERY_MODES.has(mode))) return [];
+  return [`gateway.todoRecovery.mode must be off, classify-only, or auto (got ${JSON.stringify(mode)})`];
+}
+
 export function normalizeClaudeEngineConfig(raw: ClaudeEngineConfig): Required<Pick<ClaudeEngineConfig, "maxLivePtys">> & ClaudeEngineConfig {
   return {
     ...raw,
@@ -65,16 +77,7 @@ export function validateConfigShape(config: unknown): string[] {
       if (c.gateway.resumeInterruptedSessions !== undefined && typeof c.gateway.resumeInterruptedSessions !== "boolean") {
         problems.push(`gateway.resumeInterruptedSessions must be a boolean (got ${typeof c.gateway.resumeInterruptedSessions})`);
       }
-      if (c.gateway.todoRecovery !== undefined) {
-        if (typeof c.gateway.todoRecovery !== "object" || c.gateway.todoRecovery === null || Array.isArray(c.gateway.todoRecovery)) {
-          problems.push("gateway.todoRecovery must be a mapping");
-        } else if (c.gateway.todoRecovery.mode !== undefined
-          && c.gateway.todoRecovery.mode !== "off"
-          && c.gateway.todoRecovery.mode !== "classify-only"
-          && c.gateway.todoRecovery.mode !== "auto") {
-          problems.push(`gateway.todoRecovery.mode must be off, classify-only, or auto (got ${JSON.stringify(c.gateway.todoRecovery.mode)})`);
-        }
-      }
+      problems.push(...todoRecoveryProblems(c.gateway.todoRecovery));
     }
   }
 

--- a/packages/jinn/src/shared/config.ts
+++ b/packages/jinn/src/shared/config.ts
@@ -3,20 +3,9 @@ import yaml from "js-yaml";
 import { CONFIG_PATH } from "./paths.js";
 import { applyLegacyFallbackMigration, validateEngineFallbackChains, validateEngineFallbackModelMaps } from "./engine-fallback.js";
 import type { JinnConfig } from "./types.js";
+import { todoRecoveryProblems } from "./todo-recovery-config.js";
 
 type ClaudeEngineConfig = JinnConfig["engines"]["claude"];
-
-const TODO_RECOVERY_MODES = new Set(["off", "classify-only", "auto"]);
-
-function todoRecoveryProblems(value: unknown): string[] {
-  if (value === undefined) return [];
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return ["gateway.todoRecovery must be a mapping"];
-  }
-  const mode = (value as { mode?: unknown }).mode;
-  if (mode === undefined || (typeof mode === "string" && TODO_RECOVERY_MODES.has(mode))) return [];
-  return [`gateway.todoRecovery.mode must be off, classify-only, or auto (got ${JSON.stringify(mode)})`];
-}
 
 export function normalizeClaudeEngineConfig(raw: ClaudeEngineConfig): Required<Pick<ClaudeEngineConfig, "maxLivePtys">> & ClaudeEngineConfig {
   return {

--- a/packages/jinn/src/shared/config.ts
+++ b/packages/jinn/src/shared/config.ts
@@ -65,6 +65,16 @@ export function validateConfigShape(config: unknown): string[] {
       if (c.gateway.resumeInterruptedSessions !== undefined && typeof c.gateway.resumeInterruptedSessions !== "boolean") {
         problems.push(`gateway.resumeInterruptedSessions must be a boolean (got ${typeof c.gateway.resumeInterruptedSessions})`);
       }
+      if (c.gateway.todoRecovery !== undefined) {
+        if (typeof c.gateway.todoRecovery !== "object" || c.gateway.todoRecovery === null || Array.isArray(c.gateway.todoRecovery)) {
+          problems.push("gateway.todoRecovery must be a mapping");
+        } else if (c.gateway.todoRecovery.mode !== undefined
+          && c.gateway.todoRecovery.mode !== "off"
+          && c.gateway.todoRecovery.mode !== "classify-only"
+          && c.gateway.todoRecovery.mode !== "auto") {
+          problems.push(`gateway.todoRecovery.mode must be off, classify-only, or auto (got ${JSON.stringify(c.gateway.todoRecovery.mode)})`);
+        }
+      }
     }
   }
 

--- a/packages/jinn/src/shared/todo-recovery-config.ts
+++ b/packages/jinn/src/shared/todo-recovery-config.ts
@@ -1,0 +1,12 @@
+const TODO_RECOVERY_MODES = new Set(["off", "classify-only", "auto"]);
+
+/** Shape-check `gateway.todoRecovery`. Unset is valid (runtime default classify-only). */
+export function todoRecoveryProblems(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return ["gateway.todoRecovery must be a mapping"];
+  }
+  const mode = (value as { mode?: unknown }).mode;
+  if (mode === undefined || (typeof mode === "string" && TODO_RECOVERY_MODES.has(mode))) return [];
+  return [`gateway.todoRecovery.mode must be off, classify-only, or auto (got ${JSON.stringify(mode)})`];
+}

--- a/packages/jinn/src/work-items/__tests__/anomaly-detect.test.ts
+++ b/packages/jinn/src/work-items/__tests__/anomaly-detect.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-wi-anomaly-"));
+process.env.JINN_HOME = tmp;
+
+type Store = typeof import("../store.js");
+type Runs = typeof import("../runs.js");
+type Detect = typeof import("../anomaly-detect.js");
+type Sessions = typeof import("../../sessions/registry.js");
+
+let store: Store;
+let runs: Runs;
+let detect: Detect;
+let db: import("better-sqlite3").Database;
+
+beforeAll(async () => {
+  store = await import("../store.js");
+  runs = await import("../runs.js");
+  detect = await import("../anomaly-detect.js");
+  db = (await import("../../shared/db.js")).initDb();
+  void (0 as unknown as Sessions);
+});
+
+describe("detectTodoAnomalies", () => {
+  it("creates zero Todos and zero sessions on a healthy board", () => {
+    const beforeItems = store.listWorkItems({}).length;
+    const beforeSessions = db.prepare("SELECT count(*) AS n FROM sessions").get() as { n: number };
+    const healthy = store.createWorkItem({ title: "quiet backlog" });
+    const found = detect.detectTodoAnomalies(new Date(), false);
+    expect(found.filter((row) => row.workItemId === healthy.id)).toEqual([]);
+    expect(store.listWorkItems({}).length).toBe(beforeItems + 1);
+    expect((db.prepare("SELECT count(*) AS n FROM sessions").get() as { n: number }).n).toBe(beforeSessions.n);
+  });
+
+  it("flags assigned-without-run when a pipeline owns the Todo and nothing is running", () => {
+    const item = store.createWorkItem({ title: "stuck assigned", status: "assigned" });
+    store.appendWorkItemEvent({
+      workItemId: item.id, kind: "status_change", fromStatus: "backlog", toStatus: "assigned",
+      actor: "workflow:run", detail: { workflowId: "pipeline", runId: "run_old" }, versionEffect: "audit",
+    });
+    const found = detect.detectAnomalyFor(item.id);
+    expect(found).toMatchObject({ kind: "assigned-without-run", lane: "recovering" });
+  });
+
+  it("flags blocked-without-recovery for a code failure", () => {
+    const item = store.createWorkItem({ title: "blocked code", status: "blocked", assignee: "platform-worker" });
+    const sessionId = `s-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, {
+      outcome: "crashed", endedAt: new Date().toISOString(), error: "the build step exited with code 1",
+    });
+    const found = detect.detectAnomalyFor(item.id);
+    expect(found).toMatchObject({ kind: "blocked-without-recovery", lane: "manager" });
+  });
+});

--- a/packages/jinn/src/work-items/__tests__/anomaly-detect.test.ts
+++ b/packages/jinn/src/work-items/__tests__/anomaly-detect.test.ts
@@ -9,19 +9,20 @@ process.env.JINN_HOME = tmp;
 type Store = typeof import("../store.js");
 type Runs = typeof import("../runs.js");
 type Detect = typeof import("../anomaly-detect.js");
-type Sessions = typeof import("../../sessions/registry.js");
+type Approvals = typeof import("../approvals.js");
 
 let store: Store;
 let runs: Runs;
 let detect: Detect;
+let approvals: Approvals;
 let db: import("better-sqlite3").Database;
 
 beforeAll(async () => {
   store = await import("../store.js");
   runs = await import("../runs.js");
   detect = await import("../anomaly-detect.js");
+  approvals = await import("../approvals.js");
   db = (await import("../../shared/db.js")).initDb();
-  void (0 as unknown as Sessions);
 });
 
 describe("detectTodoAnomalies", () => {
@@ -29,7 +30,7 @@ describe("detectTodoAnomalies", () => {
     const beforeItems = store.listWorkItems({}).length;
     const beforeSessions = db.prepare("SELECT count(*) AS n FROM sessions").get() as { n: number };
     const healthy = store.createWorkItem({ title: "quiet backlog" });
-    const found = detect.detectTodoAnomalies(new Date(), false);
+    const found = detect.detectTodoAnomalies({ now: new Date(), persist: false });
     expect(found.filter((row) => row.workItemId === healthy.id)).toEqual([]);
     expect(store.listWorkItems({}).length).toBe(beforeItems + 1);
     expect((db.prepare("SELECT count(*) AS n FROM sessions").get() as { n: number }).n).toBe(beforeSessions.n);
@@ -58,5 +59,76 @@ describe("detectTodoAnomalies", () => {
     });
     const found = detect.detectAnomalyFor(item.id);
     expect(found).toMatchObject({ kind: "blocked-without-recovery", lane: "manager" });
+  });
+
+  it("closes approved-landed leftovers through the complete() port", () => {
+    const item = store.createWorkItem({
+      title: "approved landing still open", status: "in_review", assignee: "platform-worker",
+    });
+    const sessionId = `s-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+    expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+    const closed: string[] = [];
+    const found = detect.detectTodoAnomalies({
+      persist: true,
+      closeApprovedLanded: (todoId) => {
+        closed.push(todoId);
+        return todoId === item.id;
+      },
+    });
+    expect(found.some((row) => row.workItemId === item.id && row.kind === "approved-landed-open")).toBe(true);
+    expect(closed).toContain(item.id);
+    expect(store.listWorkItemEvents(item.id).some((event) => event.kind === "anomaly_observed")).toBe(false);
+  });
+
+  it("puts an unclosed approved-landed leftover on Manager attention", () => {
+    const item = store.createWorkItem({
+      title: "approved landing still open for the board", status: "in_review", assignee: "platform-worker",
+    });
+    const sessionId = `s-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+    detect.detectTodoAnomalies({ persist: true, closeApprovedLanded: () => false });
+    const hits = store.listWorkItems({ needsAttentionFor: "operator" }).map((row) => row.id);
+    expect(hits).toContain(item.id);
+  });
+
+  it("does not flag an execution-timeout while the session is still in flight", () => {
+    const startedAt = new Date(Date.now() - 5 * 60 * 60_000).toISOString();
+    const item = store.createWorkItem({ title: "long running", status: "executing" });
+    const sessionId = `s-live-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'running', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, startedAt, startedAt);
+    runs.openWorkItemRun({ workItemId: item.id, sessionId, startedAt });
+    expect(detect.detectAnomalyFor(item.id)).toBeUndefined();
+  });
+
+  it("writes no anomaly rows when persist is off", () => {
+    const item = store.createWorkItem({ title: "stuck assigned off", status: "assigned" });
+    store.appendWorkItemEvent({
+      workItemId: item.id, kind: "status_change", fromStatus: "backlog", toStatus: "assigned",
+      actor: "workflow:run", detail: { workflowId: "pipeline", runId: "run_old" }, versionEffect: "audit",
+    });
+    detect.detectTodoAnomalies({ persist: false });
+    expect(store.listWorkItemEvents(item.id).some((event) => event.kind === "anomaly_observed")).toBe(false);
   });
 });

--- a/packages/jinn/src/work-items/__tests__/availability-resume-weekly.test.ts
+++ b/packages/jinn/src/work-items/__tests__/availability-resume-weekly.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-wi-resume-weekly-"));
+process.env.JINN_HOME = tmp;
+
+type Store = typeof import("../store.js");
+type Runs = typeof import("../runs.js");
+type Resume = typeof import("../availability-resume.js");
+
+let store: Store;
+let runs: Runs;
+let resume: Resume;
+let db: import("better-sqlite3").Database;
+
+const NOW = new Date("2026-08-20T12:00:00.000Z");
+
+function minutesBefore(minutes: number): string {
+  return new Date(NOW.getTime() - minutes * 60_000).toISOString();
+}
+
+function parked(title: string, settle: {
+  outcome: import("../runs.js").TodoRunOutcome;
+  endedAt: string;
+  error?: string;
+}): { id: string; runId: string } {
+  const item = store.createWorkItem({ title, status: "executing" });
+  const sessionId = `s-${item.id}`;
+  db.prepare(
+    `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+     VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+  ).run(sessionId, `cron:${sessionId}`, item.id, minutesBefore(240), minutesBefore(240));
+  const run = runs.openWorkItemRun({ workItemId: item.id, sessionId, startedAt: minutesBefore(240) });
+  runs.closeWorkItemRun(run.id, {
+    outcome: settle.outcome, endedAt: settle.endedAt, ...(settle.error ? { error: settle.error } : {}),
+  });
+  return { id: item.id, runId: run.id };
+}
+
+function recorder(): { calls: string[]; rearm: (id: string) => { status: string; label: string } } {
+  const calls: string[] = [];
+  return { calls, rearm: (id) => { calls.push(id); return { status: "assigned", label: "build" }; } };
+}
+
+function resumeEvents(workItemId: string, runId: string) {
+  return store.listWorkItemEvents(workItemId)
+    .filter((event) => event.kind === "availability_resumed" && event.detail?.runId === runId);
+}
+
+beforeAll(async () => {
+  store = await import("../store.js");
+  runs = await import("../runs.js");
+  resume = await import("../availability-resume.js");
+  db = (await import("../../shared/db.js")).initDb();
+});
+
+describe("weekly-capped work waits for the named reset (PLA-216)", () => {
+  it("resumes after the stated reset even when endedAt is older than 24h", () => {
+    const resetAt = new Date(NOW.getTime() - 60_000).toISOString();
+    const { id, runId } = parked("weekly cap", {
+      outcome: "rate_limited",
+      endedAt: minutesBefore(6 * 24 * 60),
+      error: `Usage limit exceeded; try again at ${resetAt}`,
+    });
+    const port = recorder();
+
+    resume.sweepAvailabilityResumes({ rearm: port.rearm, now: () => NOW });
+
+    expect(port.calls).toContain(id);
+    expect(resumeEvents(id, runId)[0]?.detail).toMatchObject({ source: "stated" });
+  });
+
+  it("does not resume a weekly cap whose reset is still in the future", () => {
+    const resetAt = new Date(NOW.getTime() + 2 * 24 * 60 * 60_000).toISOString();
+    const { id, runId } = parked("weekly cap still closed", {
+      outcome: "rate_limited",
+      endedAt: minutesBefore(2 * 24 * 60),
+      error: `Usage limit exceeded; try again at ${resetAt}`,
+    });
+
+    resume.sweepAvailabilityResumes({ rearm: recorder().rearm, now: () => NOW });
+
+    expect(resumeEvents(id, runId)).toHaveLength(0);
+  });
+});

--- a/packages/jinn/src/work-items/__tests__/availability-resume.test.ts
+++ b/packages/jinn/src/work-items/__tests__/availability-resume.test.ts
@@ -235,34 +235,6 @@ describe("what the sweep will not touch", () => {
     expect(resumeEvents(id, runId)).toHaveLength(0);
   });
 
-  it("resumes a weekly-capped Todo after the stated reset, even when endedAt is older than 24h", () => {
-    const resetAt = new Date(NOW.getTime() - 60_000).toISOString();
-    const { id, runId } = parked("weekly cap", {
-      outcome: "rate_limited",
-      endedAt: minutesBefore(6 * 24 * 60),
-      error: `Usage limit exceeded; try again at ${resetAt}`,
-    });
-    const port = recorder();
-
-    resume.sweepAvailabilityResumes({ rearm: port.rearm, now: () => NOW });
-
-    expect(port.calls).toContain(id);
-    expect(resumeEvents(id, runId)[0]?.detail).toMatchObject({ source: "stated" });
-  });
-
-  it("does not resume a weekly cap whose reset is still in the future", () => {
-    const resetAt = new Date(NOW.getTime() + 2 * 24 * 60 * 60_000).toISOString();
-    const { id, runId } = parked("weekly cap still closed", {
-      outcome: "rate_limited",
-      endedAt: minutesBefore(2 * 24 * 60),
-      error: `Usage limit exceeded; try again at ${resetAt}`,
-    });
-
-    resume.sweepAvailabilityResumes({ rearm: recorder().rearm, now: () => NOW });
-
-    expect(resumeEvents(id, runId)).toHaveLength(0);
-  });
-
   it("skips a failure a retry could actually fix", () => {
     const { id, runId } = parked("ordinary failure", {
       outcome: "crashed", endedAt: minutesBefore(90), error: "the build step exited with code 1",

--- a/packages/jinn/src/work-items/__tests__/availability-resume.test.ts
+++ b/packages/jinn/src/work-items/__tests__/availability-resume.test.ts
@@ -225,9 +225,37 @@ describe("what the sweep will not touch", () => {
     expect(store.listWorkItemEvents(id).filter((event) => event.kind === "availability_resumed")).toHaveLength(0);
   });
 
-  it("skips a failure old enough that no window it named is still open", () => {
+  it("skips a nameless failure old enough that resuming it would resurrect history", () => {
     const { id, runId } = parked("yesterday", {
-      outcome: "rate_limited", endedAt: minutesBefore(25 * 60), error: QUOTA_WITH_RESET,
+      outcome: "crashed", endedAt: minutesBefore(25 * 60), error: OUTAGE,
+    });
+
+    resume.sweepAvailabilityResumes({ rearm: recorder().rearm, now: () => NOW });
+
+    expect(resumeEvents(id, runId)).toHaveLength(0);
+  });
+
+  it("resumes a weekly-capped Todo after the stated reset, even when endedAt is older than 24h", () => {
+    const resetAt = new Date(NOW.getTime() - 60_000).toISOString();
+    const { id, runId } = parked("weekly cap", {
+      outcome: "rate_limited",
+      endedAt: minutesBefore(6 * 24 * 60),
+      error: `Usage limit exceeded; try again at ${resetAt}`,
+    });
+    const port = recorder();
+
+    resume.sweepAvailabilityResumes({ rearm: port.rearm, now: () => NOW });
+
+    expect(port.calls).toContain(id);
+    expect(resumeEvents(id, runId)[0]?.detail).toMatchObject({ source: "stated" });
+  });
+
+  it("does not resume a weekly cap whose reset is still in the future", () => {
+    const resetAt = new Date(NOW.getTime() + 2 * 24 * 60 * 60_000).toISOString();
+    const { id, runId } = parked("weekly cap still closed", {
+      outcome: "rate_limited",
+      endedAt: minutesBefore(2 * 24 * 60),
+      error: `Usage limit exceeded; try again at ${resetAt}`,
     });
 
     resume.sweepAvailabilityResumes({ rearm: recorder().rearm, now: () => NOW });

--- a/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
+++ b/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
@@ -110,4 +110,32 @@ describe("sweepTodoRecovery", () => {
     const hits = store.listWorkItems({ needsAttentionFor: "operator" }).map((item) => item.id);
     expect(hits).toContain(id);
   });
+
+  it("does not overwrite an approved-landed-open manager row with the operator fallback", () => {
+    const item = store.createWorkItem({
+      title: "approved landing leftover", status: "in_review", assignee: "platform-worker",
+    });
+    const sessionId = `s-mgr-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    rows.upsertWorkItemRecovery({
+      workItemId: item.id,
+      incidentId: `anomaly:approved-landed-open:${item.id}`,
+      class: "code",
+      lane: "manager",
+      reason: "approved landing is still open",
+    });
+
+    controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
+
+    expect(rows.getWorkItemRecovery(item.id)).toMatchObject({
+      lane: "manager",
+      incidentId: `anomaly:approved-landed-open:${item.id}`,
+    });
+    expect(store.listWorkItems({ needsAttentionFor: "operator" }).map((row) => row.id)).toContain(item.id);
+  });
 });

--- a/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
+++ b/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
@@ -1,0 +1,105 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-wi-recovery-ctl-"));
+process.env.JINN_HOME = tmp;
+
+type Store = typeof import("../store.js");
+type Runs = typeof import("../runs.js");
+type Rows = typeof import("../recovery-rows.js");
+type Controller = typeof import("../recovery-controller.js");
+type Claims = typeof import("../claims.js");
+
+let store: Store;
+let runs: Runs;
+let rows: Rows;
+let controller: Controller;
+let claims: Claims;
+let db: import("better-sqlite3").Database;
+
+beforeAll(async () => {
+  store = await import("../store.js");
+  runs = await import("../runs.js");
+  rows = await import("../recovery-rows.js");
+  controller = await import("../recovery-controller.js");
+  claims = await import("../claims.js");
+  db = (await import("../../shared/db.js")).initDb();
+});
+
+function parked(title: string, error: string, outcome: import("../runs.js").TodoRunOutcome = "crashed") {
+  const item = store.createWorkItem({ title, status: "blocked", assignee: "platform-worker" });
+  const sessionId = `s-${item.id}`;
+  db.prepare(
+    `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+     VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+  ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+  const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+  runs.closeWorkItemRun(run.id, { outcome, endedAt: new Date().toISOString(), error });
+  store.appendWorkItemEvent({
+    workItemId: item.id, kind: "status_change", fromStatus: "assigned", toStatus: "blocked",
+    actor: "workflow:run", detail: { workflowId: "pipeline", runId: run.id }, versionEffect: "audit",
+  });
+  return { id: item.id, runId: run.id };
+}
+
+describe("sweepTodoRecovery", () => {
+  it("classify-only writes a recovering lane and never rearms", () => {
+    const { id } = parked("quota", "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z", "rate_limited");
+    const rearm: string[] = [];
+    const result = controller.sweepTodoRecovery({
+      mode: "classify-only",
+      rearm: (todoId) => { rearm.push(todoId); return { status: "assigned" }; },
+    });
+    expect(result.applied).toBe(0);
+    expect(rearm).toHaveLength(0);
+    expect(rows.getWorkItemRecovery(id)).toMatchObject({ class: "transient", lane: "recovering", attempts: 0 });
+    expect(store.getWorkItem(id)?.status).toBe("blocked");
+  });
+
+  it("does not auto-start a backlog Todo", () => {
+    const item = store.createWorkItem({ title: "ordinary backlog" });
+    const rearm: string[] = [];
+    controller.sweepTodoRecovery({
+      mode: "auto",
+      rearm: (todoId) => { rearm.push(todoId); return { status: "assigned" }; },
+    });
+    expect(rearm).not.toContain(item.id);
+    expect(item.status).toBe("backlog");
+    expect(rows.getWorkItemRecovery(item.id)).toBeUndefined();
+  });
+
+  it("auto rearms a code failure once and refuses a second concurrent claim", () => {
+    const { id } = parked("build failed", "the build step exited with code 1");
+    const rearm: string[] = [];
+    const first = controller.sweepTodoRecovery({
+      mode: "auto",
+      rearm: (todoId) => { rearm.push(todoId); return { status: "assigned" }; },
+    });
+    expect(first.applied).toBeGreaterThanOrEqual(1);
+    expect(rearm).toContain(id);
+    expect(rows.getWorkItemRecovery(id)?.attempts).toBe(1);
+
+    claims.claimWorkItem({ workItemId: id, owner: "someone-else" });
+    rearm.length = 0;
+    controller.sweepTodoRecovery({
+      mode: "auto",
+      rearm: (todoId) => { rearm.push(todoId); return { status: "assigned" }; },
+    });
+    expect(rearm).not.toContain(id);
+  });
+
+  it("todoRecoveryMode defaults to classify-only", () => {
+    expect(controller.todoRecoveryMode(undefined)).toBe("classify-only");
+    expect(controller.todoRecoveryMode("auto")).toBe("auto");
+    expect(controller.todoRecoveryMode("always")).toBe("classify-only");
+  });
+
+  it("keeps recovering Todos out of the operator Needs you queue", () => {
+    const { id } = parked("quota parked", "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z", "rate_limited");
+    controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
+    const hits = store.listWorkItems({ needsAttentionFor: "platform-worker" }).map((item) => item.id);
+    expect(hits).not.toContain(id);
+  });
+});

--- a/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
+++ b/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
@@ -96,10 +96,18 @@ describe("sweepTodoRecovery", () => {
     expect(controller.todoRecoveryMode("always")).toBe("classify-only");
   });
 
-  it("keeps recovering Todos out of the operator Needs you queue", () => {
+  it("feeds recovering leftovers into the attention query so the dashboard can split them", () => {
     const { id } = parked("quota parked", "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z", "rate_limited");
     controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
+    expect(rows.getWorkItemRecovery(id)?.lane).toBe("recovering");
     const hits = store.listWorkItems({ needsAttentionFor: "platform-worker" }).map((item) => item.id);
-    expect(hits).not.toContain(id);
+    expect(hits).toContain(id);
+  });
+
+  it("feeds recovering leftovers even when the caller is not the assignee", () => {
+    const { id } = parked("quota for another worker", "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z", "rate_limited");
+    controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
+    const hits = store.listWorkItems({ needsAttentionFor: "operator" }).map((item) => item.id);
+    expect(hits).toContain(id);
   });
 });

--- a/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
+++ b/packages/jinn/src/work-items/__tests__/recovery-controller.test.ts
@@ -96,6 +96,16 @@ describe("sweepTodoRecovery", () => {
     expect(controller.todoRecoveryMode("always")).toBe("classify-only");
   });
 
+  it("mode off writes no recovery rows for a classifiable blocked Todo", () => {
+    const { id } = parked("quota off", "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z", "rate_limited");
+    const result = controller.sweepTodoRecovery({
+      mode: "off",
+      rearm: () => ({ status: "assigned" }),
+    });
+    expect(result).toEqual({ classified: 0, applied: 0 });
+    expect(rows.getWorkItemRecovery(id)).toBeUndefined();
+  });
+
   it("feeds recovering leftovers into the attention query so the dashboard can split them", () => {
     const { id } = parked("quota parked", "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z", "rate_limited");
     controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });

--- a/packages/jinn/src/work-items/__tests__/recovery-schema.test.ts
+++ b/packages/jinn/src/work-items/__tests__/recovery-schema.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { WORK_ITEM_RECOVERY_DDL } from "../recovery.js";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-wi-recovery-schema-"));
+process.env.JINN_HOME = tmp;
+
+type Migrate = typeof import("../migrate.js");
+let migrate: Migrate;
+
+beforeAll(async () => {
+  migrate = await import("../migrate.js");
+});
+
+const shape = (sql: string | undefined) =>
+  (sql ?? "").replace(/\bIF\s+NOT\s+EXISTS\b/gi, "").replace(/\s+/g, " ").replace(/;\s*$/, "").trim().toLowerCase();
+
+function storedSql(db: import("better-sqlite3").Database, table: string): string | undefined {
+  return (db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?").get(table) as { sql: string } | undefined)?.sql;
+}
+
+describe("work_item_recovery is additive", () => {
+  it("is created on a fresh database at its frozen shape, and verifies", () => {
+    const file = path.join(tmp, "fresh.db");
+    const db = new Database(file);
+    migrate.migrateWorkItemsSchema(db, "absent");
+    expect(shape(storedSql(db, "work_item_recovery"))).toBe(shape(WORK_ITEM_RECOVERY_DDL));
+    expect(() => migrate.verifyCurrentWorkItemSchema(db)).not.toThrow();
+    db.close();
+  });
+});

--- a/packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts
+++ b/packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { classifyRecovery } from "../recovery.js";
+
+/**
+ * PLA-240 replay: the audit's representative incidents, written as classifier
+ * contracts before any recovery writes exist. Generic fixture ids only.
+ */
+
+describe("historical incident replay — classifier", () => {
+  it("transient quota block classifies as recovering, not operator", () => {
+    const verdict = classifyRecovery({
+      todo: { id: "PLA-1", status: "blocked", assignee: "platform-worker", source: "session" },
+      lastRun: {
+        id: "run_old",
+        outcome: "rate_limited",
+        error: "Usage limit exceeded; try again at 2026-08-27T12:00:00.000Z",
+        endedAt: "2026-08-20T12:00:00.000Z",
+      },
+      labels: ["build"],
+    });
+    expect(verdict).toMatchObject({ class: "transient", lane: "recovering" });
+  });
+
+  it("code failure routes to manager, not operator", () => {
+    const verdict = classifyRecovery({
+      todo: { id: "PLA-2", status: "blocked", assignee: "platform-worker", source: "session" },
+      lastRun: {
+        id: "run_old",
+        outcome: "crashed",
+        error: "the build step exited with code 1",
+        endedAt: "2026-08-20T12:00:00.000Z",
+      },
+      labels: ["build"],
+    });
+    expect(verdict).toMatchObject({ class: "code", lane: "manager" });
+  });
+
+  it("verification failure routes to the independent verifier lane", () => {
+    const verdict = classifyRecovery({
+      todo: { id: "PLA-3", status: "blocked", assignee: "platform-worker", source: "session" },
+      lastRun: {
+        id: "run_old",
+        outcome: "failed",
+        error: "independent review rejected the diff",
+        endedAt: "2026-08-20T12:00:00.000Z",
+      },
+      labels: ["build"],
+      verifyMode: "thorough",
+    });
+    expect(verdict).toMatchObject({ class: "verification", lane: "manager" });
+  });
+
+  it("security/auth-terminal is manager, not a clock retry", () => {
+    const verdict = classifyRecovery({
+      todo: { id: "PLA-4", status: "blocked", assignee: "platform-worker", source: "session" },
+      lastRun: {
+        id: "run_old",
+        outcome: "crashed",
+        error: "401 Unauthorized: invalid api key",
+        endedAt: "2026-08-20T12:00:00.000Z",
+      },
+      labels: ["build"],
+    });
+    expect(verdict).toMatchObject({ class: "security", lane: "manager" });
+  });
+
+  it("operator-only pending approval is Needs you", () => {
+    const verdict = classifyRecovery({
+      todo: { id: "PLA-5", status: "in_review", assignee: "platform-worker", source: "session" },
+      approval: { state: "pending", operatorOnly: true },
+      labels: ["build"],
+    });
+    expect(verdict).toMatchObject({ class: "operator", lane: "operator" });
+  });
+
+  it("ordinary backlog never classifies as recovering", () => {
+    const verdict = classifyRecovery({
+      todo: { id: "PLA-6", status: "backlog", assignee: null, source: "human" },
+      labels: [],
+    });
+    expect(verdict.lane).not.toBe("recovering");
+    expect(verdict.class).toBe("operator");
+  });
+});

--- a/packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts
+++ b/packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts
@@ -81,4 +81,20 @@ describe("historical incident replay — classifier", () => {
     expect(verdict.lane).not.toBe("recovering");
     expect(verdict.class).toBe("operator");
   });
+
+  it("an approved completed leftover still in_review is Manager attention, not Needs you", () => {
+    const verdict = classifyRecovery({
+      todo: { id: "PLA-15", status: "in_review", assignee: "platform-worker", source: "workflow" },
+      lastRun: {
+        id: "run_landed",
+        outcome: "completed",
+        error: null,
+        endedAt: "2026-08-20T12:00:00.000Z",
+      },
+      approval: { state: "approved", operatorOnly: false },
+      labels: ["build"],
+    });
+    expect(verdict).toMatchObject({ lane: "manager" });
+    expect(verdict.lane).not.toBe("operator");
+  });
 });

--- a/packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts
+++ b/packages/jinn/src/work-items/__tests__/self-healing-replay.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { classifyRecovery } from "../recovery.js";
+import {
+  classifyRecovery,
+  GENERIC_OPERATOR_REASON,
+  mayReplaceRecoveryLane,
+} from "../recovery.js";
 
 /**
  * PLA-240 replay: the audit's representative incidents, written as classifier
@@ -96,5 +100,29 @@ describe("historical incident replay — classifier", () => {
     });
     expect(verdict).toMatchObject({ lane: "manager" });
     expect(verdict.lane).not.toBe("operator");
+  });
+});
+
+describe("mayReplaceRecoveryLane", () => {
+  const generic = { class: "operator" as const, lane: "operator" as const, reason: GENERIC_OPERATOR_REASON };
+  const leftover = { class: "operator" as const, lane: "manager" as const, reason: "approved landing is still open" };
+  const operatorOnly = { class: "operator" as const, lane: "operator" as const, reason: "operator-only approval is a genuine authority decision" };
+
+  it("a generic fallback cannot downgrade an unresolved manager lane", () => {
+    expect(mayReplaceRecoveryLane({ lane: "manager" }, generic, "in_review")).toBe(false);
+    expect(mayReplaceRecoveryLane({ lane: "recovering" }, generic, "blocked")).toBe(false);
+  });
+
+  it("a specific leftover manager verdict may refresh the row", () => {
+    expect(mayReplaceRecoveryLane({ lane: "manager" }, leftover, "in_review")).toBe(true);
+  });
+
+  it("operator-only authority may replace manager (Needs you)", () => {
+    expect(mayReplaceRecoveryLane({ lane: "manager" }, operatorOnly, "in_review")).toBe(true);
+  });
+
+  it("a resolved Todo may drop a stale manager row", () => {
+    expect(mayReplaceRecoveryLane({ lane: "manager" }, generic, "done")).toBe(true);
+    expect(mayReplaceRecoveryLane({ lane: "manager" }, generic, "cancelled")).toBe(true);
   });
 });

--- a/packages/jinn/src/work-items/__tests__/workflow-ownership.test.ts
+++ b/packages/jinn/src/work-items/__tests__/workflow-ownership.test.ts
@@ -1,0 +1,38 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-wi-ownership-"));
+process.env.JINN_HOME = tmp;
+
+type Store = typeof import("../store.js");
+type Ownership = typeof import("../workflow-ownership.js");
+
+let store: Store;
+let ownership: Ownership;
+
+beforeAll(async () => {
+  store = await import("../store.js");
+  ownership = await import("../workflow-ownership.js");
+});
+
+describe("owningWorkflowId", () => {
+  it("is undefined when no Workflow has ever driven the Todo", () => {
+    const item = store.createWorkItem({ title: "never ran a workflow" });
+    expect(ownership.owningWorkflowId(item.id)).toBeUndefined();
+  });
+
+  it("returns the newest workflowId stamped on a status change", () => {
+    const item = store.createWorkItem({ title: "moved pipelines", status: "assigned" });
+    store.appendWorkItemEvent({
+      workItemId: item.id, kind: "status_change", fromStatus: "assigned", toStatus: "executing",
+      actor: "workflow:run", detail: { workflowId: "intake", runId: "run_1" }, versionEffect: "audit",
+    });
+    store.appendWorkItemEvent({
+      workItemId: item.id, kind: "status_change", fromStatus: "executing", toStatus: "assigned",
+      actor: "workflow:run", detail: { workflowId: "category", runId: "run_2" }, versionEffect: "audit",
+    });
+    expect(ownership.owningWorkflowId(item.id)).toBe("category");
+  });
+});

--- a/packages/jinn/src/work-items/anomaly-detect.ts
+++ b/packages/jinn/src/work-items/anomaly-detect.ts
@@ -1,0 +1,130 @@
+import { currentApproval } from "./approval-rows.js";
+import { listWorkItemEvents } from "./event-log.js";
+import { classifyWorkItem } from "./recovery-controller.js";
+import { getWorkItemRecovery, upsertWorkItemRecovery } from "./recovery-rows.js";
+import {
+  TODO_RECOVERY_ACTOR,
+  type AttentionLane,
+} from "./recovery.js";
+import { listWorkItemRuns } from "./runs.js";
+import { appendWorkItemEvent, getWorkItem, listWorkItems, type WorkItem } from "./store.js";
+import { owningWorkflowId } from "./workflow-ownership.js";
+
+export const ANOMALY_KINDS = [
+  "assigned-without-run",
+  "execution-timeout",
+  "approved-landed-open",
+  "review-without-reviewer",
+  "blocked-without-recovery",
+] as const;
+export type AnomalyKind = (typeof ANOMALY_KINDS)[number];
+
+export interface TodoAnomaly {
+  workItemId: string;
+  kind: AnomalyKind;
+  lane: AttentionLane;
+  reason: string;
+}
+
+const EXECUTION_TIMEOUT_MS = 4 * 60 * 60_000;
+const FRESH_RUN_MS = 15 * 60_000;
+
+function alreadyObserved(workItemId: string, kind: AnomalyKind): boolean {
+  return listWorkItemEvents(workItemId).some((event) =>
+    event.kind === "anomaly_observed" && event.detail?.kind === kind);
+}
+
+function note(item: WorkItem, anomaly: TodoAnomaly, now: Date): void {
+  if (alreadyObserved(item.id, anomaly.kind)) return;
+  upsertWorkItemRecovery({
+    workItemId: item.id,
+    incidentId: `anomaly:${anomaly.kind}:${item.id}`,
+    class: anomaly.lane === "recovering" ? "transient" : anomaly.lane === "manager" ? "code" : "operator",
+    lane: anomaly.lane,
+    reason: anomaly.reason,
+    now,
+  });
+  appendWorkItemEvent({
+    workItemId: item.id,
+    kind: "anomaly_observed",
+    actor: TODO_RECOVERY_ACTOR,
+    detail: { kind: anomaly.kind, lane: anomaly.lane, reason: anomaly.reason },
+    versionEffect: "audit",
+  });
+}
+
+function inspect(item: WorkItem, now: Date): TodoAnomaly | undefined {
+  const runs = listWorkItemRuns(item.id);
+  const open = runs.filter((run) => run.endedAt === null);
+  const last = [...runs].reverse().find((run) => run.endedAt !== null);
+  const approval = currentApproval(item.id);
+  const owner = owningWorkflowId(item.id);
+
+  if (item.status === "assigned" && open.length === 0 && owner) {
+    const fresh = last?.endedAt && now.getTime() - Date.parse(last.endedAt) < FRESH_RUN_MS;
+    if (!fresh) {
+      return {
+        workItemId: item.id, kind: "assigned-without-run", lane: "recovering",
+        reason: "assigned to a pipeline with no active run",
+      };
+    }
+  }
+
+  if (item.status === "executing" && open.length > 0) {
+    const started = Date.parse(open[0]!.startedAt);
+    if (Number.isFinite(started) && now.getTime() - started > EXECUTION_TIMEOUT_MS) {
+      return {
+        workItemId: item.id, kind: "execution-timeout", lane: "manager",
+        reason: "execution has outlived the 4h timeout without an in-flight session to speak for it",
+      };
+    }
+  }
+
+  if (item.status === "in_review" && approval?.state === "approved" && last?.outcome === "completed") {
+    return {
+      workItemId: item.id, kind: "approved-landed-open", lane: "manager",
+      reason: "approved landing is still open",
+    };
+  }
+
+  if (item.status === "in_review" && approval?.state !== "pending" && !item.assignee) {
+    return {
+      workItemId: item.id, kind: "review-without-reviewer", lane: "manager",
+      reason: "in review with no pending approval and no reviewer",
+    };
+  }
+
+  if (item.status === "blocked" && !getWorkItemRecovery(item.id)) {
+    const verdict = classifyWorkItem(item);
+    if (verdict.lane !== "operator") {
+      return {
+        workItemId: item.id, kind: "blocked-without-recovery", lane: verdict.lane,
+        reason: "blocked with no recovery row",
+      };
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Quiet detector. Returns the leftover lies on the board. A healthy board
+ * returns []. Never creates a Todo or a session.
+ */
+export function detectTodoAnomalies(now = new Date(), persist = true): TodoAnomaly[] {
+  const found: TodoAnomaly[] = [];
+  for (const status of ["assigned", "executing", "in_review", "blocked"] as const) {
+    for (const item of listWorkItems({ status })) {
+      const anomaly = inspect(item, now);
+      if (!anomaly) continue;
+      found.push(anomaly);
+      if (persist) note(item, anomaly, now);
+    }
+  }
+  return found;
+}
+
+export function detectAnomalyFor(id: string, now = new Date()): TodoAnomaly | undefined {
+  const item = getWorkItem(id);
+  return item ? inspect(item, now) : undefined;
+}

--- a/packages/jinn/src/work-items/anomaly-detect.ts
+++ b/packages/jinn/src/work-items/anomaly-detect.ts
@@ -9,6 +9,7 @@ import {
 import { listWorkItemRuns } from "./runs.js";
 import { appendWorkItemEvent, getWorkItem, listWorkItems, type WorkItem } from "./store.js";
 import { owningWorkflowId } from "./workflow-ownership.js";
+import { initDb } from "../shared/db.js";
 
 export const ANOMALY_KINDS = [
   "assigned-without-run",
@@ -62,10 +63,16 @@ function assignedWithoutRun(item: WorkItem, now: Date): TodoAnomaly | undefined 
   return { workItemId: item.id, kind: "assigned-without-run", lane: "recovering", reason: "assigned to a pipeline with no active run" };
 }
 
+function sessionInFlight(sessionId: string): boolean {
+  const row = initDb().prepare("SELECT status FROM sessions WHERE id = ?").get(sessionId) as { status: string } | undefined;
+  return row?.status === "running" || row?.status === "waiting";
+}
+
 function executionTimeout(item: WorkItem, now: Date): TodoAnomaly | undefined {
   if (item.status !== "executing") return undefined;
   const open = listWorkItemRuns(item.id).find((run) => run.endedAt === null);
   if (!open) return undefined;
+  if (sessionInFlight(open.sessionId)) return undefined;
   const started = Date.parse(open.startedAt);
   if (!Number.isFinite(started) || now.getTime() - started <= EXECUTION_TIMEOUT_MS) return undefined;
   return { workItemId: item.id, kind: "execution-timeout", lane: "manager", reason: "execution has outlived the 4h timeout without an in-flight session to speak for it" };
@@ -95,16 +102,30 @@ function inspect(item: WorkItem, now: Date): TodoAnomaly | undefined {
   return assignedWithoutRun(item, now) ?? executionTimeout(item, now) ?? reviewAnomaly(item) ?? blockedWithoutRecovery(item);
 }
 
+export interface DetectTodoAnomaliesInput {
+  now?: Date;
+  persist?: boolean;
+  /** Close an approved-landed leftover through the existing complete() path.
+   *  Return true when the Todo is done so it is not parked on Manager attention. */
+  closeApprovedLanded?: (todoId: string) => boolean;
+}
+
 /**
  * Quiet detector. Returns the leftover lies on the board. A healthy board
  * returns []. Never creates a Todo or a session.
  */
-export function detectTodoAnomalies(now = new Date(), persist = true): TodoAnomaly[] {
+export function detectTodoAnomalies(input: DetectTodoAnomaliesInput = {}): TodoAnomaly[] {
+  const now = input.now ?? new Date();
+  const persist = input.persist !== false;
   const found: TodoAnomaly[] = [];
   for (const status of ["assigned", "executing", "in_review", "blocked"] as const) {
     for (const item of listWorkItems({ status })) {
       const anomaly = inspect(item, now);
       if (!anomaly) continue;
+      if (anomaly.kind === "approved-landed-open" && input.closeApprovedLanded?.(item.id)) {
+        found.push(anomaly);
+        continue;
+      }
       found.push(anomaly);
       if (persist) note(item, anomaly, now);
     }

--- a/packages/jinn/src/work-items/anomaly-detect.ts
+++ b/packages/jinn/src/work-items/anomaly-detect.ts
@@ -53,58 +53,46 @@ function note(item: WorkItem, anomaly: TodoAnomaly, now: Date): void {
   });
 }
 
-function inspect(item: WorkItem, now: Date): TodoAnomaly | undefined {
+function assignedWithoutRun(item: WorkItem, now: Date): TodoAnomaly | undefined {
+  if (item.status !== "assigned" || !owningWorkflowId(item.id)) return undefined;
   const runs = listWorkItemRuns(item.id);
-  const open = runs.filter((run) => run.endedAt === null);
+  if (runs.some((run) => run.endedAt === null)) return undefined;
   const last = [...runs].reverse().find((run) => run.endedAt !== null);
+  if (last?.endedAt && now.getTime() - Date.parse(last.endedAt) < FRESH_RUN_MS) return undefined;
+  return { workItemId: item.id, kind: "assigned-without-run", lane: "recovering", reason: "assigned to a pipeline with no active run" };
+}
+
+function executionTimeout(item: WorkItem, now: Date): TodoAnomaly | undefined {
+  if (item.status !== "executing") return undefined;
+  const open = listWorkItemRuns(item.id).find((run) => run.endedAt === null);
+  if (!open) return undefined;
+  const started = Date.parse(open.startedAt);
+  if (!Number.isFinite(started) || now.getTime() - started <= EXECUTION_TIMEOUT_MS) return undefined;
+  return { workItemId: item.id, kind: "execution-timeout", lane: "manager", reason: "execution has outlived the 4h timeout without an in-flight session to speak for it" };
+}
+
+function reviewAnomaly(item: WorkItem): TodoAnomaly | undefined {
+  if (item.status !== "in_review") return undefined;
   const approval = currentApproval(item.id);
-  const owner = owningWorkflowId(item.id);
-
-  if (item.status === "assigned" && open.length === 0 && owner) {
-    const fresh = last?.endedAt && now.getTime() - Date.parse(last.endedAt) < FRESH_RUN_MS;
-    if (!fresh) {
-      return {
-        workItemId: item.id, kind: "assigned-without-run", lane: "recovering",
-        reason: "assigned to a pipeline with no active run",
-      };
-    }
+  const last = [...listWorkItemRuns(item.id)].reverse().find((run) => run.endedAt !== null);
+  if (approval?.state === "approved" && last?.outcome === "completed") {
+    return { workItemId: item.id, kind: "approved-landed-open", lane: "manager", reason: "approved landing is still open" };
   }
-
-  if (item.status === "executing" && open.length > 0) {
-    const started = Date.parse(open[0]!.startedAt);
-    if (Number.isFinite(started) && now.getTime() - started > EXECUTION_TIMEOUT_MS) {
-      return {
-        workItemId: item.id, kind: "execution-timeout", lane: "manager",
-        reason: "execution has outlived the 4h timeout without an in-flight session to speak for it",
-      };
-    }
+  if (approval?.state !== "pending" && !item.assignee) {
+    return { workItemId: item.id, kind: "review-without-reviewer", lane: "manager", reason: "in review with no pending approval and no reviewer" };
   }
-
-  if (item.status === "in_review" && approval?.state === "approved" && last?.outcome === "completed") {
-    return {
-      workItemId: item.id, kind: "approved-landed-open", lane: "manager",
-      reason: "approved landing is still open",
-    };
-  }
-
-  if (item.status === "in_review" && approval?.state !== "pending" && !item.assignee) {
-    return {
-      workItemId: item.id, kind: "review-without-reviewer", lane: "manager",
-      reason: "in review with no pending approval and no reviewer",
-    };
-  }
-
-  if (item.status === "blocked" && !getWorkItemRecovery(item.id)) {
-    const verdict = classifyWorkItem(item);
-    if (verdict.lane !== "operator") {
-      return {
-        workItemId: item.id, kind: "blocked-without-recovery", lane: verdict.lane,
-        reason: "blocked with no recovery row",
-      };
-    }
-  }
-
   return undefined;
+}
+
+function blockedWithoutRecovery(item: WorkItem): TodoAnomaly | undefined {
+  if (item.status !== "blocked" || getWorkItemRecovery(item.id)) return undefined;
+  const verdict = classifyWorkItem(item);
+  if (verdict.lane === "operator") return undefined;
+  return { workItemId: item.id, kind: "blocked-without-recovery", lane: verdict.lane, reason: "blocked with no recovery row" };
+}
+
+function inspect(item: WorkItem, now: Date): TodoAnomaly | undefined {
+  return assignedWithoutRun(item, now) ?? executionTimeout(item, now) ?? reviewAnomaly(item) ?? blockedWithoutRecovery(item);
 }
 
 /**

--- a/packages/jinn/src/work-items/anomaly-detect.ts
+++ b/packages/jinn/src/work-items/anomaly-detect.ts
@@ -36,15 +36,19 @@ function alreadyObserved(workItemId: string, kind: AnomalyKind): boolean {
 }
 
 function note(item: WorkItem, anomaly: TodoAnomaly, now: Date): void {
+  const incidentId = `anomaly:${anomaly.kind}:${item.id}`;
+  const prior = getWorkItemRecovery(item.id);
+  if (prior?.lane !== anomaly.lane || prior.incidentId !== incidentId) {
+    upsertWorkItemRecovery({
+      workItemId: item.id,
+      incidentId,
+      class: anomaly.lane === "recovering" ? "transient" : anomaly.lane === "manager" ? "code" : "operator",
+      lane: anomaly.lane,
+      reason: anomaly.reason,
+      now,
+    });
+  }
   if (alreadyObserved(item.id, anomaly.kind)) return;
-  upsertWorkItemRecovery({
-    workItemId: item.id,
-    incidentId: `anomaly:${anomaly.kind}:${item.id}`,
-    class: anomaly.lane === "recovering" ? "transient" : anomaly.lane === "manager" ? "code" : "operator",
-    lane: anomaly.lane,
-    reason: anomaly.reason,
-    now,
-  });
   appendWorkItemEvent({
     workItemId: item.id,
     kind: "anomaly_observed",

--- a/packages/jinn/src/work-items/availability-resume.ts
+++ b/packages/jinn/src/work-items/availability-resume.ts
@@ -43,9 +43,10 @@ const AVAILABILITY_CLASSES = ['quota', 'rate-limit', 'provider-outage', 'network
 const RESUMABLE_STATUSES: readonly WorkItemStatus[] = ['assigned', 'executing', 'in_review', 'blocked'];
 
 /** Past this, a stalled Todo stopped being a clock problem: re-arming a day-old
- *  failure is resurrecting history rather than resuming it. A window longer than
- *  this — a weekly cap, now that engine health reports one as stated — ages the
- *  Todo out instead, which is a separate decision from this sweep's. */
+ *  failure is resurrecting history rather than resuming it. Measured from
+ *  `endedAt` when no engine named a reset, and from the named reset once it
+ *  has passed — so a weekly cap waits out its real window instead of aging
+ *  out at 24h (PLA-216). */
 const MAX_RESUMABLE_AGE_MS = 24 * 60 * 60_000;
 
 const DEFAULT_RESUME_INTERVAL_MS = 5 * 60_000;
@@ -120,9 +121,11 @@ function dueForResume(workItemId: string, now: Date): DueResume | undefined {
   if (attempts.some((attempt) => attempt.endedAt === null)) return undefined;
   const run = lastSettledRun(attempts);
   if (!run || !isAvailabilityFailure(run)) return undefined;
-  if (now.getTime() - Date.parse(run.endedAt) > MAX_RESUMABLE_AGE_MS) return undefined;
   if (alreadyResumed(workItemId, run.id)) return undefined;
   const reset = resolveReset(run, now);
+  const named = reset.source === "stated" || reset.source === "engine-health";
+  const ageFrom = named ? reset.at : Date.parse(run.endedAt);
+  if (now.getTime() - ageFrom > MAX_RESUMABLE_AGE_MS) return undefined;
   return reset.at > now.getTime() ? undefined : { run, reset };
 }
 

--- a/packages/jinn/src/work-items/event-log.ts
+++ b/packages/jinn/src/work-items/event-log.ts
@@ -41,7 +41,11 @@ export type WorkItemEventKind =
   | 'claim_expired'
   | 'respawn_guard_held'
   | 'availability_resumed'
-  | 'kept_changed';
+  | 'kept_changed'
+  | 'recovery_classified'
+  | 'recovery_attempted'
+  | 'recovery_exhausted'
+  | 'anomaly_observed';
 
 /** Actor recorded on the reconciler's own derived writes. */
 export const RECONCILER_ACTOR = 'reconciler';

--- a/packages/jinn/src/work-items/migrate.ts
+++ b/packages/jinn/src/work-items/migrate.ts
@@ -10,6 +10,7 @@ import {
 import { registerWorkItemIdentityFunctions } from "./id-allocator.js";
 import { WORK_ITEM_BLOCKS_DDL } from "./blocks.js";
 import { WORK_ITEM_STOP_CAUSE_DDL } from "./stop-cause.js";
+import { WORK_ITEM_RECOVERY_DDL } from "./recovery.js";
 import { clearAutoKeptOnce, WORK_ITEM_KEPT_DDL } from "./kept.js";
 import { hasFiveOutcomeRunTable, widenRunOutcomes } from "./runs-migrate.js";
 import { WORK_ITEM_RUNS_DDL, WORK_ITEM_RUNS_TABLE_DDL, workItemRunRowsAreSound } from "./runs-schema.js";
@@ -500,6 +501,7 @@ const REQUIRED_TABLE_SQL = new Map<string, string>([
   ["work_item_id_burns", WORK_ITEM_ID_BURNS_TABLE_DDL],
   ["work_item_id_issuances", WORK_ITEM_ID_ISSUANCES_TABLE_DDL],
   ["work_item_kept", WORK_ITEM_KEPT_DDL],
+  ["work_item_recovery", WORK_ITEM_RECOVERY_DDL],
   ["departments", DEPARTMENTS_TABLE_DDL],
 ]);
 
@@ -522,6 +524,7 @@ const V2_ADDITIVE_TABLES: ReadonlyArray<{ name: string; ddl: string }> = [
   { name: "work_item_create_receipts", ddl: WORK_ITEM_CREATE_RECEIPTS_DDL },
   { name: "work_item_stop_cause", ddl: WORK_ITEM_STOP_CAUSE_DDL },
   { name: "work_item_kept", ddl: WORK_ITEM_KEPT_DDL },
+  { name: "work_item_recovery", ddl: WORK_ITEM_RECOVERY_DDL },
 ];
 
 /**

--- a/packages/jinn/src/work-items/migrate.ts
+++ b/packages/jinn/src/work-items/migrate.ts
@@ -10,7 +10,7 @@ import {
 import { registerWorkItemIdentityFunctions } from "./id-allocator.js";
 import { WORK_ITEM_BLOCKS_DDL } from "./blocks.js";
 import { WORK_ITEM_STOP_CAUSE_DDL } from "./stop-cause.js";
-import { WORK_ITEM_RECOVERY_DDL } from "./recovery.js";
+import { WORK_ITEM_RECOVERY_TABLES } from "./recovery.js";
 import { clearAutoKeptOnce, WORK_ITEM_KEPT_DDL } from "./kept.js";
 import { hasFiveOutcomeRunTable, widenRunOutcomes } from "./runs-migrate.js";
 import { WORK_ITEM_RUNS_DDL, WORK_ITEM_RUNS_TABLE_DDL, workItemRunRowsAreSound } from "./runs-schema.js";
@@ -479,7 +479,6 @@ export { allocateWorkItemId, allocateWorkItemIdV1ForTest, registerWorkItemIdenti
   useWorkItemAllocationClaim, type WorkItemAllocationClaim } from "./id-allocator.js";
 
 export type WorkItemSchemaPreflight = "absent" | "empty-prerelease" | "v1" | "current";
-
 const REQUIRED_TABLE_SQL = new Map<string, string>([
   ["work_items", WORK_ITEMS_TABLE_DDL],
   ["work_item_events", WORK_ITEM_EVENTS_TABLE_DDL],
@@ -501,7 +500,7 @@ const REQUIRED_TABLE_SQL = new Map<string, string>([
   ["work_item_id_burns", WORK_ITEM_ID_BURNS_TABLE_DDL],
   ["work_item_id_issuances", WORK_ITEM_ID_ISSUANCES_TABLE_DDL],
   ["work_item_kept", WORK_ITEM_KEPT_DDL],
-  ["work_item_recovery", WORK_ITEM_RECOVERY_DDL],
+  ...WORK_ITEM_RECOVERY_TABLES.map((table) => [table.name, table.ddl] as [string, string]),
   ["departments", DEPARTMENTS_TABLE_DDL],
 ]);
 
@@ -524,9 +523,7 @@ const V2_ADDITIVE_TABLES: ReadonlyArray<{ name: string; ddl: string }> = [
   { name: "work_item_create_receipts", ddl: WORK_ITEM_CREATE_RECEIPTS_DDL },
   { name: "work_item_stop_cause", ddl: WORK_ITEM_STOP_CAUSE_DDL },
   { name: "work_item_kept", ddl: WORK_ITEM_KEPT_DDL },
-  { name: "work_item_recovery", ddl: WORK_ITEM_RECOVERY_DDL },
-];
-
+].concat(WORK_ITEM_RECOVERY_TABLES);
 /**
  * Copy a shadow-column table's `approval_*` values into `work_item_approvals`,
  * one row per item carrying a state — a one-shot step inside each rebuild, and

--- a/packages/jinn/src/work-items/recovery-controller.ts
+++ b/packages/jinn/src/work-items/recovery-controller.ts
@@ -9,7 +9,7 @@ import {
   type RecoveryClassification,
 } from "./recovery.js";
 import { listWorkItemRuns } from "./runs.js";
-import { appendWorkItemEvent, getWorkItem, listWorkItems, type WorkItem } from "./store.js";
+import { appendWorkItemEvent, listWorkItems, type WorkItem } from "./store.js";
 import { owningWorkflowId } from "./workflow-ownership.js";
 import type { AvailabilityRearmResult } from "./availability-resume.js";
 

--- a/packages/jinn/src/work-items/recovery-controller.ts
+++ b/packages/jinn/src/work-items/recovery-controller.ts
@@ -1,0 +1,138 @@
+import { currentApproval } from "./approval-rows.js";
+import { claimWorkItem, releaseWorkItemClaim, type ClaimWorkItemResult } from "./claims.js";
+import { getWorkItemLabels } from "./labels.js";
+import { getWorkItemRecovery, upsertWorkItemRecovery } from "./recovery-rows.js";
+import {
+  classifyRecovery,
+  MAX_RECOVERY_ATTEMPTS,
+  TODO_RECOVERY_ACTOR,
+  type RecoveryClassification,
+} from "./recovery.js";
+import { listWorkItemRuns } from "./runs.js";
+import { appendWorkItemEvent, getWorkItem, listWorkItems, type WorkItem } from "./store.js";
+import { owningWorkflowId } from "./workflow-ownership.js";
+import type { AvailabilityRearmResult } from "./availability-resume.js";
+
+export type TodoRecoveryMode = "off" | "classify-only" | "auto";
+
+export interface RecoveryApplyDeps {
+  mode: TodoRecoveryMode;
+  now?: () => Date;
+  rearm(todoId: string): AvailabilityRearmResult;
+  claim?(todoId: string, owner: string): ClaimWorkItemResult;
+  release?(todoId: string, owner: string): void;
+}
+
+export interface RecoverySweepResult {
+  classified: number;
+  applied: number;
+}
+
+const SWEEP_STATUSES = ["assigned", "executing", "in_review", "blocked", "escalated"] as const;
+
+export function todoRecoveryMode(raw: string | undefined): TodoRecoveryMode {
+  return raw === "off" || raw === "auto" || raw === "classify-only" ? raw : "classify-only";
+}
+
+export function classifyWorkItem(item: WorkItem): RecoveryClassification {
+  const runs = listWorkItemRuns(item.id);
+  const last = [...runs].reverse().find((run) => run.endedAt !== null);
+  const approval = currentApproval(item.id);
+  return classifyRecovery({
+    todo: { id: item.id, status: item.status, assignee: item.assignee, source: item.source },
+    lastRun: last
+      ? { id: last.id, outcome: last.outcome ?? "crashed", error: last.error, endedAt: last.endedAt }
+      : undefined,
+    openRun: runs.some((run) => run.endedAt === null),
+    approval: approval
+      ? { state: approval.state, operatorOnly: approval.operatorOnly }
+      : undefined,
+    labels: getWorkItemLabels(item.id).map((label) => label.name),
+    verifyMode: item.verifyPolicy?.mode,
+    owningWorkflowId: owningWorkflowId(item.id),
+  });
+}
+
+function incidentId(item: WorkItem, lastRunId: string | undefined): string {
+  return lastRunId ?? `status:${item.id}:${item.status}:${item.updatedAt}`;
+}
+
+function recordClassified(item: WorkItem, verdict: RecoveryClassification, lastRunId: string | undefined, now: Date): void {
+  const prior = getWorkItemRecovery(item.id);
+  const id = incidentId(item, lastRunId);
+  if (prior?.incidentId === id && prior.class === verdict.class && prior.lane === verdict.lane) return;
+  upsertWorkItemRecovery({
+    workItemId: item.id,
+    incidentId: id,
+    class: verdict.class,
+    lane: verdict.lane,
+    reason: verdict.reason,
+    lastRunId,
+    now,
+  });
+  appendWorkItemEvent({
+    workItemId: item.id,
+    kind: "recovery_classified",
+    actor: TODO_RECOVERY_ACTOR,
+    detail: { class: verdict.class, lane: verdict.lane, incidentId: id, reason: verdict.reason },
+    versionEffect: "audit",
+  });
+}
+
+function applyCodeRepair(item: WorkItem, deps: RecoveryApplyDeps, lastRunId: string | undefined, now: Date): boolean {
+  const prior = getWorkItemRecovery(item.id);
+  const id = incidentId(item, lastRunId);
+  if ((prior?.incidentId === id ? prior.attempts : 0) >= MAX_RECOVERY_ATTEMPTS) {
+    upsertWorkItemRecovery({
+      workItemId: item.id, incidentId: id, class: "code", lane: "manager",
+      reason: "automatic repair attempts exhausted", lastRunId, now,
+    });
+    appendWorkItemEvent({
+      workItemId: item.id, kind: "recovery_exhausted", actor: TODO_RECOVERY_ACTOR,
+      detail: { incidentId: id, attempts: MAX_RECOVERY_ATTEMPTS }, versionEffect: "audit",
+    });
+    return false;
+  }
+  if (listWorkItemRuns(item.id).some((run) => run.endedAt === null)) return false;
+  const owner = `${TODO_RECOVERY_ACTOR}:${id}`;
+  const claim = (deps.claim ?? ((todoId, claimOwner) => claimWorkItem({ workItemId: todoId, owner: claimOwner })))(item.id, owner);
+  if (claim.state !== "acquired") return false;
+  const landed = deps.rearm(item.id);
+  (deps.release ?? releaseWorkItemClaim)(item.id, owner);
+  if ("unavailable" in landed) return false;
+  upsertWorkItemRecovery({
+    workItemId: item.id, incidentId: id, class: "code", lane: "manager",
+    reason: "scoped repair re-armed the owning workflow", lastRunId, attempted: true, now,
+  });
+  appendWorkItemEvent({
+    workItemId: item.id, kind: "recovery_attempted", actor: TODO_RECOVERY_ACTOR,
+    detail: { incidentId: id, class: "code", status: landed.status }, versionEffect: "audit",
+  });
+  return true;
+}
+
+/**
+ * One pass over open Todos. Classify-only writes lanes and audit; auto additionally
+ * re-arms code failures (transients stay with the availability sweep so the two
+ * never double-start a run). Backlog is never listed.
+ */
+export function sweepTodoRecovery(deps: RecoveryApplyDeps): RecoverySweepResult {
+  if (deps.mode === "off") return { classified: 0, applied: 0 };
+  const now = deps.now?.() ?? new Date();
+  let classified = 0;
+  let applied = 0;
+  for (const status of SWEEP_STATUSES) {
+    for (const item of listWorkItems({ status })) {
+      const verdict = classifyWorkItem(item);
+      const lastRunId = [...listWorkItemRuns(item.id)].reverse().find((run) => run.endedAt !== null)?.id;
+      const before = getWorkItemRecovery(item.id);
+      recordClassified(item, verdict, lastRunId, now);
+      if (!before || before.incidentId !== incidentId(item, lastRunId) || before.lane !== verdict.lane) {
+        classified++;
+      }
+      if (deps.mode !== "auto") continue;
+      if (verdict.class === "code" && applyCodeRepair(item, deps, lastRunId, now)) applied++;
+    }
+  }
+  return { classified, applied };
+}

--- a/packages/jinn/src/work-items/recovery-controller.ts
+++ b/packages/jinn/src/work-items/recovery-controller.ts
@@ -4,6 +4,7 @@ import { getWorkItemLabels } from "./labels.js";
 import { getWorkItemRecovery, upsertWorkItemRecovery } from "./recovery-rows.js";
 import {
   classifyRecovery,
+  mayReplaceRecoveryLane,
   MAX_RECOVERY_ATTEMPTS,
   TODO_RECOVERY_ACTOR,
   type RecoveryClassification,
@@ -57,17 +58,11 @@ function incidentId(item: WorkItem, lastRunId: string | undefined): string {
   return lastRunId ?? `status:${item.id}:${item.status}:${item.updatedAt}`;
 }
 
-function detectorOwnsApprovedLanding(item: WorkItem, prior: ReturnType<typeof getWorkItemRecovery>): boolean {
-  return item.status === "in_review"
-    && prior?.lane === "manager"
-    && prior.incidentId.startsWith("anomaly:approved-landed-open");
-}
-
 function recordClassified(item: WorkItem, verdict: RecoveryClassification, lastRunId: string | undefined, now: Date): void {
   const prior = getWorkItemRecovery(item.id);
-  if (detectorOwnsApprovedLanding(item, prior)) return;
   const id = incidentId(item, lastRunId);
   if (prior?.incidentId === id && prior.class === verdict.class && prior.lane === verdict.lane) return;
+  if (!mayReplaceRecoveryLane(prior, verdict, item.status)) return;
   upsertWorkItemRecovery({
     workItemId: item.id,
     incidentId: id,

--- a/packages/jinn/src/work-items/recovery-controller.ts
+++ b/packages/jinn/src/work-items/recovery-controller.ts
@@ -57,8 +57,15 @@ function incidentId(item: WorkItem, lastRunId: string | undefined): string {
   return lastRunId ?? `status:${item.id}:${item.status}:${item.updatedAt}`;
 }
 
+function detectorOwnsApprovedLanding(item: WorkItem, prior: ReturnType<typeof getWorkItemRecovery>): boolean {
+  return item.status === "in_review"
+    && prior?.lane === "manager"
+    && prior.incidentId.startsWith("anomaly:approved-landed-open");
+}
+
 function recordClassified(item: WorkItem, verdict: RecoveryClassification, lastRunId: string | undefined, now: Date): void {
   const prior = getWorkItemRecovery(item.id);
+  if (detectorOwnsApprovedLanding(item, prior)) return;
   const id = incidentId(item, lastRunId);
   if (prior?.incidentId === id && prior.class === verdict.class && prior.lane === verdict.lane) return;
   upsertWorkItemRecovery({

--- a/packages/jinn/src/work-items/recovery-controller.ts
+++ b/packages/jinn/src/work-items/recovery-controller.ts
@@ -116,6 +116,16 @@ function applyCodeRepair(item: WorkItem, deps: RecoveryApplyDeps, lastRunId: str
  * re-arms code failures (transients stay with the availability sweep so the two
  * never double-start a run). Backlog is never listed.
  */
+function recoverOne(item: WorkItem, deps: RecoveryApplyDeps, now: Date): { classified: boolean; applied: boolean } {
+  const verdict = classifyWorkItem(item);
+  const lastRunId = [...listWorkItemRuns(item.id)].reverse().find((run) => run.endedAt !== null)?.id;
+  const before = getWorkItemRecovery(item.id);
+  recordClassified(item, verdict, lastRunId, now);
+  const classified = !before || before.incidentId !== incidentId(item, lastRunId) || before.lane !== verdict.lane;
+  const applied = deps.mode === "auto" && verdict.class === "code" && applyCodeRepair(item, deps, lastRunId, now);
+  return { classified, applied };
+}
+
 export function sweepTodoRecovery(deps: RecoveryApplyDeps): RecoverySweepResult {
   if (deps.mode === "off") return { classified: 0, applied: 0 };
   const now = deps.now?.() ?? new Date();
@@ -123,15 +133,9 @@ export function sweepTodoRecovery(deps: RecoveryApplyDeps): RecoverySweepResult 
   let applied = 0;
   for (const status of SWEEP_STATUSES) {
     for (const item of listWorkItems({ status })) {
-      const verdict = classifyWorkItem(item);
-      const lastRunId = [...listWorkItemRuns(item.id)].reverse().find((run) => run.endedAt !== null)?.id;
-      const before = getWorkItemRecovery(item.id);
-      recordClassified(item, verdict, lastRunId, now);
-      if (!before || before.incidentId !== incidentId(item, lastRunId) || before.lane !== verdict.lane) {
-        classified++;
-      }
-      if (deps.mode !== "auto") continue;
-      if (verdict.class === "code" && applyCodeRepair(item, deps, lastRunId, now)) applied++;
+      const result = recoverOne(item, deps, now);
+      if (result.classified) classified++;
+      if (result.applied) applied++;
     }
   }
   return { classified, applied };

--- a/packages/jinn/src/work-items/recovery-rows.ts
+++ b/packages/jinn/src/work-items/recovery-rows.ts
@@ -1,0 +1,76 @@
+import { initDb } from "../shared/db.js";
+import { MAX_RECOVERY_ATTEMPTS, type RecoveryClass, type AttentionLane, type UpsertRecoveryInput, type WorkItemRecovery } from "./recovery.js";
+
+interface RecoveryRow {
+  work_item_id: string;
+  incident_id: string;
+  class: RecoveryClass;
+  lane: AttentionLane;
+  attempts: number;
+  last_attempt_at: string | null;
+  last_run_id: string | null;
+  reason: string;
+  updated_at: string;
+}
+
+function toRecovery(row: RecoveryRow): WorkItemRecovery {
+  return {
+    workItemId: row.work_item_id,
+    incidentId: row.incident_id,
+    class: row.class,
+    lane: row.lane,
+    attempts: row.attempts,
+    lastAttemptAt: row.last_attempt_at,
+    lastRunId: row.last_run_id,
+    reason: row.reason,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function getWorkItemRecovery(workItemId: string): WorkItemRecovery | undefined {
+  const row = initDb()
+    .prepare("SELECT * FROM work_item_recovery WHERE work_item_id = ?")
+    .get(workItemId) as RecoveryRow | undefined;
+  return row ? toRecovery(row) : undefined;
+}
+
+/** Batch form for list payloads: ONE query for the whole page. */
+export function recoveryByItem(workItemIds: readonly string[]): Map<string, WorkItemRecovery> {
+  const ids = [...new Set(workItemIds)];
+  const map = new Map<string, WorkItemRecovery>();
+  if (ids.length === 0) return map;
+  const placeholders = ids.map(() => "?").join(", ");
+  const rows = initDb()
+    .prepare(`SELECT * FROM work_item_recovery WHERE work_item_id IN (${placeholders})`)
+    .all(...ids) as RecoveryRow[];
+  for (const row of rows) map.set(row.work_item_id, toRecovery(row));
+  return map;
+}
+
+export function upsertWorkItemRecovery(input: UpsertRecoveryInput): WorkItemRecovery {
+  const now = (input.now ?? new Date()).toISOString();
+  const existing = getWorkItemRecovery(input.workItemId);
+  const sameIncident = existing !== undefined && existing.incidentId === input.incidentId;
+  const attempts = sameIncident
+    ? Math.min(MAX_RECOVERY_ATTEMPTS, existing.attempts + (input.attempted ? 1 : 0))
+    : input.attempted ? 1 : 0;
+  const lastAttemptAt = input.attempted ? now : (sameIncident ? existing.lastAttemptAt : null);
+  initDb().prepare(
+    `INSERT INTO work_item_recovery
+       (work_item_id, incident_id, class, lane, attempts, last_attempt_at, last_run_id, reason, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(work_item_id) DO UPDATE SET
+       incident_id = excluded.incident_id,
+       class = excluded.class,
+       lane = excluded.lane,
+       attempts = excluded.attempts,
+       last_attempt_at = excluded.last_attempt_at,
+       last_run_id = excluded.last_run_id,
+       reason = excluded.reason,
+       updated_at = excluded.updated_at`,
+  ).run(
+    input.workItemId, input.incidentId, input.class, input.lane, attempts, lastAttemptAt,
+    input.lastRunId ?? existing?.lastRunId ?? null, input.reason, now,
+  );
+  return getWorkItemRecovery(input.workItemId)!;
+}

--- a/packages/jinn/src/work-items/recovery-rows.ts
+++ b/packages/jinn/src/work-items/recovery-rows.ts
@@ -47,14 +47,20 @@ export function recoveryByItem(workItemIds: readonly string[]): Map<string, Work
   return map;
 }
 
+function nextAttempts(existing: WorkItemRecovery | undefined, incidentId: string, attempted: boolean | undefined, now: string) {
+  const sameIncident = existing !== undefined && existing.incidentId === incidentId;
+  return {
+    attempts: sameIncident
+      ? Math.min(MAX_RECOVERY_ATTEMPTS, existing.attempts + (attempted ? 1 : 0))
+      : attempted ? 1 : 0,
+    lastAttemptAt: attempted ? now : (sameIncident ? existing.lastAttemptAt : null),
+  };
+}
+
 export function upsertWorkItemRecovery(input: UpsertRecoveryInput): WorkItemRecovery {
   const now = (input.now ?? new Date()).toISOString();
   const existing = getWorkItemRecovery(input.workItemId);
-  const sameIncident = existing !== undefined && existing.incidentId === input.incidentId;
-  const attempts = sameIncident
-    ? Math.min(MAX_RECOVERY_ATTEMPTS, existing.attempts + (input.attempted ? 1 : 0))
-    : input.attempted ? 1 : 0;
-  const lastAttemptAt = input.attempted ? now : (sameIncident ? existing.lastAttemptAt : null);
+  const { attempts, lastAttemptAt } = nextAttempts(existing, input.incidentId, input.attempted, now);
   initDb().prepare(
     `INSERT INTO work_item_recovery
        (work_item_id, incident_id, class, lane, attempts, last_attempt_at, last_run_id, reason, updated_at)

--- a/packages/jinn/src/work-items/recovery.ts
+++ b/packages/jinn/src/work-items/recovery.ts
@@ -43,81 +43,49 @@ export interface RecoveryIncidentInput {
 const AVAILABILITY_CLASSES = ["quota", "rate-limit", "provider-outage", "network"] as const;
 const VERIFY_FAILURE = /independent review|verifier rejected|verification failed|review rejected the diff/i;
 
-export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassification {
-  const owner = input.owningWorkflowId;
-  const withOwner = (verdict: RecoveryClassification): RecoveryClassification =>
-    owner === undefined ? verdict : { ...verdict, owningWorkflowId: owner };
+function verdict(input: RecoveryIncidentInput, value: RecoveryClassification): RecoveryClassification {
+  return input.owningWorkflowId === undefined ? value : { ...value, owningWorkflowId: input.owningWorkflowId };
+}
 
-  if (input.todo.status === "backlog") {
-    return withOwner({
-      class: "operator",
-      lane: "operator",
-      reason: "ordinary backlog work is never auto-started",
-    });
-  }
+function isAvailability(input: RecoveryIncidentInput, error: string): boolean {
+  return input.lastRun?.outcome === "rate_limited"
+    || hasEngineFailureClass(classifyEngineFailureText(error), ...AVAILABILITY_CLASSES);
+}
 
-  if (input.approval?.state === "pending" && input.approval.operatorOnly) {
-    return withOwner({
-      class: "operator",
-      lane: "operator",
-      reason: "operator-only approval is a genuine authority decision",
-    });
-  }
+function isVerificationFailure(input: RecoveryIncidentInput, error: string): boolean {
+  return (input.verifyMode === "verify" || input.verifyMode === "thorough") && VERIFY_FAILURE.test(error);
+}
 
+function classifyFromFailure(input: RecoveryIncidentInput): RecoveryClassification | undefined {
   const error = input.lastRun?.error ?? "";
-  const failure = classifyEngineFailureText(error);
-
-  if (hasEngineFailureClass(failure, "auth-terminal")) {
-    return withOwner({
-      class: "security",
-      lane: "manager",
-      reason: "credentials or auth failed; a clock retry cannot fix it",
-    });
+  if (hasEngineFailureClass(classifyEngineFailureText(error), "auth-terminal")) {
+    return { class: "security", lane: "manager", reason: "credentials or auth failed; a clock retry cannot fix it" };
   }
-
-  const availability =
-    input.lastRun?.outcome === "rate_limited"
-    || hasEngineFailureClass(failure, ...AVAILABILITY_CLASSES);
-  if (availability && input.todo.status !== "backlog") {
-    return withOwner({
-      class: "transient",
-      lane: "recovering",
-      reason: "provider availability; resume the owning workflow when the window reopens",
-    });
+  if (isAvailability(input, error)) {
+    return { class: "transient", lane: "recovering", reason: "provider availability; resume the owning workflow when the window reopens" };
   }
-
-  if (
-    (input.verifyMode === "verify" || input.verifyMode === "thorough")
-    && VERIFY_FAILURE.test(error)
-  ) {
-    return withOwner({
-      class: "verification",
-      lane: "manager",
-      reason: "independent verification rejected the work",
-    });
+  if (isVerificationFailure(input, error)) {
+    return { class: "verification", lane: "manager", reason: "independent verification rejected the work" };
   }
-
   if (input.lastRun && ["crashed", "failed", "blocked", "timed_out", "abandoned"].includes(input.lastRun.outcome)) {
-    return withOwner({
-      class: "code",
-      lane: "manager",
-      reason: "the attempt failed in the work itself",
-    });
+    return { class: "code", lane: "manager", reason: "the attempt failed in the work itself" };
   }
+  return undefined;
+}
 
+export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassification {
+  if (input.todo.status === "backlog") {
+    return verdict(input, { class: "operator", lane: "operator", reason: "ordinary backlog work is never auto-started" });
+  }
+  if (input.approval?.state === "pending" && input.approval.operatorOnly) {
+    return verdict(input, { class: "operator", lane: "operator", reason: "operator-only approval is a genuine authority decision" });
+  }
+  const fromFailure = classifyFromFailure(input);
+  if (fromFailure) return verdict(input, fromFailure);
   if (input.approval?.state === "pending") {
-    return withOwner({
-      class: "operator",
-      lane: "manager",
-      reason: "a routed approval is waiting on an employee, not the operator",
-    });
+    return verdict(input, { class: "operator", lane: "manager", reason: "a routed approval is waiting on an employee, not the operator" });
   }
-
-  return withOwner({
-    class: "operator",
-    lane: "operator",
-    reason: "no safe automatic recovery is known",
-  });
+  return verdict(input, { class: "operator", lane: "operator", reason: "no safe automatic recovery is known" });
 }
 
 /** Additive: never a column on `work_items`. The exact-shape verifier refuses

--- a/packages/jinn/src/work-items/recovery.ts
+++ b/packages/jinn/src/work-items/recovery.ts
@@ -138,6 +138,10 @@ CREATE TABLE IF NOT EXISTS work_item_recovery (
   updated_at       TEXT NOT NULL
 )`;
 
+export const WORK_ITEM_RECOVERY_TABLES: ReadonlyArray<{ name: string; ddl: string }> = [
+  { name: "work_item_recovery", ddl: WORK_ITEM_RECOVERY_DDL },
+];
+
 export interface WorkItemRecovery {
   workItemId: string;
   incidentId: string;

--- a/packages/jinn/src/work-items/recovery.ts
+++ b/packages/jinn/src/work-items/recovery.ts
@@ -97,7 +97,7 @@ export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassifi
     });
   }
 
-  if (input.lastRun && (input.lastRun.outcome === "crashed" || input.lastRun.outcome === "failed")) {
+  if (input.lastRun && ["crashed", "failed", "blocked", "timed_out", "abandoned"].includes(input.lastRun.outcome)) {
     return withOwner({
       class: "code",
       lane: "manager",
@@ -118,4 +118,45 @@ export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassifi
     lane: "operator",
     reason: "no safe automatic recovery is known",
   });
+}
+
+/** Additive: never a column on `work_items`. The exact-shape verifier refuses
+ *  drift in an existing table, so a new table is the only extension a deployed
+ *  database can survive. */
+export const WORK_ITEM_RECOVERY_DDL = `
+CREATE TABLE IF NOT EXISTS work_item_recovery (
+  work_item_id     TEXT PRIMARY KEY REFERENCES work_items(id) ON DELETE CASCADE,
+  incident_id      TEXT NOT NULL,
+  class            TEXT NOT NULL CHECK (class IN ('transient','code','verification','security','operator')),
+  lane             TEXT NOT NULL CHECK (lane IN ('recovering','manager','operator')),
+  attempts         INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0 AND attempts <= 2),
+  last_attempt_at  TEXT,
+  last_run_id      TEXT,
+  reason           TEXT NOT NULL,
+  updated_at       TEXT NOT NULL
+)`;
+
+export interface WorkItemRecovery {
+  workItemId: string;
+  incidentId: string;
+  class: RecoveryClass;
+  lane: AttentionLane;
+  attempts: number;
+  lastAttemptAt: string | null;
+  lastRunId: string | null;
+  reason: string;
+  updatedAt: string;
+}
+
+export interface UpsertRecoveryInput {
+  workItemId: string;
+  incidentId: string;
+  class: RecoveryClass;
+  lane: AttentionLane;
+  reason: string;
+  lastRunId?: string | null;
+  /** When true, increment attempts for the same incident (capped at 2). A new
+   *  incident_id starts at 0. */
+  attempted?: boolean;
+  now?: Date;
 }

--- a/packages/jinn/src/work-items/recovery.ts
+++ b/packages/jinn/src/work-items/recovery.ts
@@ -73,6 +73,16 @@ function classifyFromFailure(input: RecoveryIncidentInput): RecoveryClassificati
   return undefined;
 }
 
+function classifyLeftover(input: RecoveryIncidentInput): RecoveryClassification | undefined {
+  if (input.approval?.state === "pending") {
+    return { class: "operator", lane: "manager", reason: "a routed approval is waiting on an employee, not the operator" };
+  }
+  if (input.todo.status === "in_review" && input.approval?.state === "approved" && input.lastRun?.outcome === "completed") {
+    return { class: "operator", lane: "manager", reason: "approved landing is still open" };
+  }
+  return undefined;
+}
+
 export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassification {
   if (input.todo.status === "backlog") {
     return verdict(input, { class: "operator", lane: "operator", reason: "ordinary backlog work is never auto-started" });
@@ -82,9 +92,8 @@ export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassifi
   }
   const fromFailure = classifyFromFailure(input);
   if (fromFailure) return verdict(input, fromFailure);
-  if (input.approval?.state === "pending") {
-    return verdict(input, { class: "operator", lane: "manager", reason: "a routed approval is waiting on an employee, not the operator" });
-  }
+  const leftover = classifyLeftover(input);
+  if (leftover) return verdict(input, leftover);
   return verdict(input, { class: "operator", lane: "operator", reason: "no safe automatic recovery is known" });
 }
 

--- a/packages/jinn/src/work-items/recovery.ts
+++ b/packages/jinn/src/work-items/recovery.ts
@@ -23,6 +23,31 @@ export type AttentionLane = (typeof ATTENTION_LANES)[number];
 export const TODO_RECOVERY_ACTOR = "todo-recovery";
 export const MAX_RECOVERY_ATTEMPTS = 2;
 
+/** Generic fallback: classifyRecovery found no specific incident. */
+export const GENERIC_OPERATOR_REASON = "no safe automatic recovery is known";
+
+export function isGenericOperatorFallback(verdict: RecoveryClassification): boolean {
+  return verdict.lane === "operator" && verdict.reason === GENERIC_OPERATOR_REASON;
+}
+
+/**
+ * One `work_item_recovery` row is shared by the detector and the sweep.
+ * A later generic operator fallback cannot downgrade an unresolved specific
+ * lane (manager / recovering). Specific verdicts (failure class, leftover
+ * manager, pending routed approval, operator-only authority) may replace.
+ * Terminal status means the prior condition resolved.
+ */
+export function mayReplaceRecoveryLane(
+  prior: { lane: AttentionLane } | undefined,
+  next: RecoveryClassification,
+  itemStatus: string,
+): boolean {
+  if (!prior) return true;
+  if (itemStatus === "done" || itemStatus === "cancelled") return true;
+  if (isGenericOperatorFallback(next) && prior.lane !== "operator") return false;
+  return true;
+}
+
 export interface RecoveryClassification {
   class: RecoveryClass;
   lane: AttentionLane;
@@ -94,7 +119,7 @@ export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassifi
   if (fromFailure) return verdict(input, fromFailure);
   const leftover = classifyLeftover(input);
   if (leftover) return verdict(input, leftover);
-  return verdict(input, { class: "operator", lane: "operator", reason: "no safe automatic recovery is known" });
+  return verdict(input, { class: "operator", lane: "operator", reason: GENERIC_OPERATOR_REASON });
 }
 
 /** Additive: never a column on `work_items`. The exact-shape verifier refuses

--- a/packages/jinn/src/work-items/recovery.ts
+++ b/packages/jinn/src/work-items/recovery.ts
@@ -1,0 +1,121 @@
+import { classifyEngineFailureText, hasEngineFailureClass } from "../shared/engine-failure.js";
+
+/**
+ * Bounded recovery classification (PLA-240).
+ *
+ * A verdict here is not an action. The controller decides whether to re-arm,
+ * route, or leave the Todo on Needs you. Classification must be pure: the
+ * replay suite feeds it historical incidents with no database of their own.
+ */
+
+export const RECOVERY_CLASSES = [
+  "transient",
+  "code",
+  "verification",
+  "security",
+  "operator",
+] as const;
+export type RecoveryClass = (typeof RECOVERY_CLASSES)[number];
+
+export const ATTENTION_LANES = ["recovering", "manager", "operator"] as const;
+export type AttentionLane = (typeof ATTENTION_LANES)[number];
+
+export const TODO_RECOVERY_ACTOR = "todo-recovery";
+export const MAX_RECOVERY_ATTEMPTS = 2;
+
+export interface RecoveryClassification {
+  class: RecoveryClass;
+  lane: AttentionLane;
+  reason: string;
+  owningWorkflowId?: string;
+}
+
+export interface RecoveryIncidentInput {
+  todo: { id: string; status: string; assignee: string | null; source: string };
+  lastRun?: { id: string; outcome: string; error: string | null; endedAt: string | null };
+  openRun?: boolean;
+  approval?: { state: string; operatorOnly: boolean };
+  labels: string[];
+  verifyMode?: "trust" | "verify" | "thorough";
+  owningWorkflowId?: string;
+}
+
+const AVAILABILITY_CLASSES = ["quota", "rate-limit", "provider-outage", "network"] as const;
+const VERIFY_FAILURE = /independent review|verifier rejected|verification failed|review rejected the diff/i;
+
+export function classifyRecovery(input: RecoveryIncidentInput): RecoveryClassification {
+  const owner = input.owningWorkflowId;
+  const withOwner = (verdict: RecoveryClassification): RecoveryClassification =>
+    owner === undefined ? verdict : { ...verdict, owningWorkflowId: owner };
+
+  if (input.todo.status === "backlog") {
+    return withOwner({
+      class: "operator",
+      lane: "operator",
+      reason: "ordinary backlog work is never auto-started",
+    });
+  }
+
+  if (input.approval?.state === "pending" && input.approval.operatorOnly) {
+    return withOwner({
+      class: "operator",
+      lane: "operator",
+      reason: "operator-only approval is a genuine authority decision",
+    });
+  }
+
+  const error = input.lastRun?.error ?? "";
+  const failure = classifyEngineFailureText(error);
+
+  if (hasEngineFailureClass(failure, "auth-terminal")) {
+    return withOwner({
+      class: "security",
+      lane: "manager",
+      reason: "credentials or auth failed; a clock retry cannot fix it",
+    });
+  }
+
+  const availability =
+    input.lastRun?.outcome === "rate_limited"
+    || hasEngineFailureClass(failure, ...AVAILABILITY_CLASSES);
+  if (availability && input.todo.status !== "backlog") {
+    return withOwner({
+      class: "transient",
+      lane: "recovering",
+      reason: "provider availability; resume the owning workflow when the window reopens",
+    });
+  }
+
+  if (
+    (input.verifyMode === "verify" || input.verifyMode === "thorough")
+    && VERIFY_FAILURE.test(error)
+  ) {
+    return withOwner({
+      class: "verification",
+      lane: "manager",
+      reason: "independent verification rejected the work",
+    });
+  }
+
+  if (input.lastRun && (input.lastRun.outcome === "crashed" || input.lastRun.outcome === "failed")) {
+    return withOwner({
+      class: "code",
+      lane: "manager",
+      reason: "the attempt failed in the work itself",
+    });
+  }
+
+  if (input.approval?.state === "pending") {
+    return withOwner({
+      class: "operator",
+      lane: "manager",
+      reason: "a routed approval is waiting on an employee, not the operator",
+    });
+  }
+
+  return withOwner({
+    class: "operator",
+    lane: "operator",
+    reason: "no safe automatic recovery is known",
+  });
+}

--- a/packages/jinn/src/work-items/store.ts
+++ b/packages/jinn/src/work-items/store.ts
@@ -598,7 +598,7 @@ function workItemWhere(filter: ListWorkItemsFilter, textIds?: readonly string[])
     // Approvals live in work_item_approvals (their sole owner since PLA-48). An unexpired park is a
     // clock-wait (PLA-157) and leaves this set outright, gate included; an unreadable one is not a park.
     conditions.push(
-      "((EXISTS (SELECT 1 FROM work_item_approvals wap WHERE wap.work_item_id = work_items.id AND wap.state = 'pending' AND wap.target = ?) OR (assignee = ? AND status IN ('blocked', 'escalated'))) AND NOT EXISTS (SELECT 1 FROM work_item_stop_cause sc WHERE sc.work_item_id = work_items.id AND strftime('%s', sc.parked_until) > strftime('%s', ?)) AND NOT EXISTS (SELECT 1 FROM work_item_recovery rec WHERE rec.work_item_id = work_items.id AND rec.lane = 'recovering'))",
+      "((EXISTS (SELECT 1 FROM work_item_approvals wap WHERE wap.work_item_id = work_items.id AND wap.state = 'pending' AND wap.target = ?) OR (assignee = ? AND status IN ('blocked', 'escalated')) OR EXISTS (SELECT 1 FROM work_item_recovery rec WHERE rec.work_item_id = work_items.id AND rec.lane IN ('recovering', 'manager') AND work_items.status NOT IN ('done', 'cancelled'))) AND NOT EXISTS (SELECT 1 FROM work_item_stop_cause sc WHERE sc.work_item_id = work_items.id AND strftime('%s', sc.parked_until) > strftime('%s', ?) AND NOT EXISTS (SELECT 1 FROM work_item_recovery rec2 WHERE rec2.work_item_id = work_items.id AND rec2.lane IN ('recovering', 'manager'))))",
     );
     values.push(filter.needsAttentionFor, filter.needsAttentionFor, new Date().toISOString());
   }

--- a/packages/jinn/src/work-items/store.ts
+++ b/packages/jinn/src/work-items/store.ts
@@ -598,7 +598,7 @@ function workItemWhere(filter: ListWorkItemsFilter, textIds?: readonly string[])
     // Approvals live in work_item_approvals (their sole owner since PLA-48). An unexpired park is a
     // clock-wait (PLA-157) and leaves this set outright, gate included; an unreadable one is not a park.
     conditions.push(
-      "((EXISTS (SELECT 1 FROM work_item_approvals wap WHERE wap.work_item_id = work_items.id AND wap.state = 'pending' AND wap.target = ?) OR (assignee = ? AND status IN ('blocked', 'escalated'))) AND NOT EXISTS (SELECT 1 FROM work_item_stop_cause sc WHERE sc.work_item_id = work_items.id AND strftime('%s', sc.parked_until) > strftime('%s', ?)))",
+      "((EXISTS (SELECT 1 FROM work_item_approvals wap WHERE wap.work_item_id = work_items.id AND wap.state = 'pending' AND wap.target = ?) OR (assignee = ? AND status IN ('blocked', 'escalated'))) AND NOT EXISTS (SELECT 1 FROM work_item_stop_cause sc WHERE sc.work_item_id = work_items.id AND strftime('%s', sc.parked_until) > strftime('%s', ?)) AND NOT EXISTS (SELECT 1 FROM work_item_recovery rec WHERE rec.work_item_id = work_items.id AND rec.lane = 'recovering'))",
     );
     values.push(filter.needsAttentionFor, filter.needsAttentionFor, new Date().toISOString());
   }

--- a/packages/jinn/src/work-items/workflow-event-feed.ts
+++ b/packages/jinn/src/work-items/workflow-event-feed.ts
@@ -22,6 +22,10 @@ export interface WorkflowTodoStatusEvent {
    *  at the moment of the move, so nothing read later can claim a window nobody
    *  waited out. */
   quotaWindowDecided: boolean;
+  /** A recovery sweep re-armed this Todo. Operator-filtered triggers accept it
+   *  the same way they accept an availability resume: this is resuming work the
+   *  operator already armed, not a new arming. */
+  armedAsRecovery?: boolean;
   /** `source`, `department`, and `assignee` are the provenance snapshot frozen
    *  into the audit row when the Todo moved. `labels` and `live` are read at
    *  replay time instead: labels, assignment, and parentage all change
@@ -167,7 +171,7 @@ function eventFromImmutableSnapshot(row: TodoEventRow): WorkflowTodoStatusEvent 
   if (!row.detail) return null;
   try {
     const detail = JSON.parse(row.detail) as
-      { todoProvenance?: unknown; armedAsDelegate?: unknown; availabilityResume?: unknown };
+      { todoProvenance?: unknown; armedAsDelegate?: unknown; availabilityResume?: unknown; recoveryResume?: unknown };
     const snapshot = detail.todoProvenance;
     if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) return null;
     const value = snapshot as Record<string, unknown>;
@@ -184,6 +188,7 @@ function eventFromImmutableSnapshot(row: TodoEventRow): WorkflowTodoStatusEvent 
       actor: row.actor,
       armedAsDelegate: typeof detail.armedAsDelegate === 'string' ? detail.armedAsDelegate : null,
       quotaWindowDecided: detail.availabilityResume === true,
+      ...(detail.recoveryResume === true ? { armedAsRecovery: true } : {}),
       item: {
         source: value.source as WorkItemSource,
         department: value.department as string | null,

--- a/packages/jinn/src/work-items/workflow-ownership.ts
+++ b/packages/jinn/src/work-items/workflow-ownership.ts
@@ -1,0 +1,12 @@
+import { listWorkItemEvents } from "./event-log.js";
+
+/**
+ * Which Workflow was driving this Todo, read off the status moves its own runs
+ * reflected onto it. Newest wins: a Todo re-armed into a different pipeline
+ * since then belongs to that one.
+ */
+export function owningWorkflowId(todoId: string): string | undefined {
+  const bound = listWorkItemEvents(todoId)
+    .filter((event) => event.kind === "status_change" && typeof event.detail?.workflowId === "string");
+  return bound.at(-1)?.detail?.workflowId as string | undefined;
+}

--- a/packages/jinn/src/workflows/__tests__/owning-workflow-rearm.test.ts
+++ b/packages/jinn/src/workflows/__tests__/owning-workflow-rearm.test.ts
@@ -1,0 +1,130 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { WorkflowTodoEventClaimOutcome, WorkflowTodoEventFeed, WorkflowTodoStatusEvent }
+  from "../../work-items/workflow-event-feed.js";
+import type { WorkflowDefinition, WorkflowNode } from "../model.js";
+import type { WorkflowRepository } from "../repository.js";
+import type { WorkflowRunner } from "../runner.js";
+
+const home = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-owning-rearm-"));
+process.env.JINN_HOME = home;
+
+type Store = typeof import("../../work-items/store.js");
+type Labels = typeof import("../../work-items/labels.js");
+type Triggers = typeof import("../trigger-service.js");
+
+let store: Store;
+let labels: Labels;
+let triggers: Triggers;
+
+const started: Array<{ workflowId: string; todoId?: string }> = [];
+
+function definition(id: string, config: { label?: string; actor?: string } = {}): WorkflowDefinition {
+  const trigger: WorkflowNode = {
+    id: "start", type: "trigger", name: "Todo",
+    config: { kind: "todo-status", status: "assigned", ...config },
+  };
+  return { id, title: id, revision: 1, enabled: true, nodes: [trigger], edges: [] } as unknown as WorkflowDefinition;
+}
+
+const intake = definition("intake");
+const category = definition("category", { label: "category" });
+const byId = new Map([[intake.id, intake], [category.id, category]]);
+
+const repository = {
+  listDefinitions: () => ({ items: [...byId.keys()].map((id) => ({ id })), nextCursor: null }),
+  getDefinition: (id: string) => byId.get(id) ?? null,
+  createRun: ({ workflowId, trigger }: { workflowId: string; trigger: { todoId?: string } }) => {
+    started.push({ workflowId, todoId: trigger.todoId });
+    return { id: `run-${started.length}` };
+  },
+  getRun: (_workflowId: string, runId: string) => ({ id: runId, status: "completed" }),
+} as unknown as WorkflowRepository;
+
+const runner = { start: async (runId: string) => ({ id: runId, status: "completed" }) } as unknown as WorkflowRunner;
+
+const feed: WorkflowTodoEventFeed = {
+  claimEvent: (_id, definitionIds) => ({ state: "acquired", definitionIds }),
+  completeEvent: () => {},
+  deferEvent: () => {},
+  releaseEvent: () => {},
+  listPendingEvents: () => pending,
+};
+
+let pending: WorkflowTodoStatusEvent[] = [];
+
+function event(id: string, workItemId: string, actor = "operator", extra: Partial<WorkflowTodoStatusEvent> = {}): WorkflowTodoStatusEvent {
+  const item = store.getWorkItem(workItemId);
+  return {
+    id, workItemId, fromStatus: "blocked", toStatus: "assigned", actor, armedAsDelegate: null,
+    quotaWindowDecided: false,
+    item: {
+      source: "session", department: "platform", assignee: item?.assignee ?? "platform-worker",
+      labels: labels.getWorkItemLabels(workItemId).map(({ id: labelId, name }) => ({ id: labelId, name })),
+      live: item ? { assignee: item.assignee, parentId: item.parentId, status: item.status } : null,
+    },
+    ...extra,
+  };
+}
+
+beforeAll(async () => {
+  store = await import("../../work-items/store.js");
+  labels = await import("../../work-items/labels.js");
+  triggers = await import("../trigger-service.js");
+  labels.createLabel({ name: "category" });
+});
+
+beforeEach(() => { started.length = 0; pending = []; });
+
+describe("re-arming a Todo that already belongs to a pipeline", () => {
+  it("starts only the owning workflow, not a sibling that also matches the status", async () => {
+    const item = store.createWorkItem({
+      title: "category work re-armed", status: "assigned", assignee: "platform-worker", department: "platform",
+    });
+    labels.setWorkItemLabels(item.id, ["category"], "operator");
+    store.appendWorkItemEvent({
+      workItemId: item.id, kind: "status_change", fromStatus: "assigned", toStatus: "executing",
+      actor: "workflow:run", detail: { workflowId: "category", runId: "run_prior" }, versionEffect: "audit",
+    });
+    pending = [event("rearm-1", item.id)];
+
+    const service = new triggers.WorkflowTriggerService(repository, runner, () => "now", feed);
+    await service.recoverTodoEvents();
+
+    expect(started).toEqual([{ workflowId: "category", todoId: item.id }]);
+  });
+
+  it("still starts every match when no Workflow has ever driven the Todo", async () => {
+    const item = store.createWorkItem({
+      title: "fresh assigned work", status: "assigned", assignee: "platform-worker", department: "platform",
+    });
+    labels.setWorkItemLabels(item.id, ["category"], "operator");
+    pending = [event("fresh-1", item.id)];
+
+    const service = new triggers.WorkflowTriggerService(repository, runner, () => "now", feed);
+    await service.recoverTodoEvents();
+
+    expect(started.map((row) => row.workflowId).sort()).toEqual(["category", "intake"]);
+  });
+
+  it("fires an operator-filtered trigger for an availability resume without impersonating the operator", async () => {
+    byId.set("build", definition("build", { actor: "operator", label: "category" }));
+    const item = store.createWorkItem({
+      title: "quota parked build", status: "assigned", assignee: "platform-worker", department: "platform",
+    });
+    labels.setWorkItemLabels(item.id, ["category"], "operator");
+    store.appendWorkItemEvent({
+      workItemId: item.id, kind: "status_change", fromStatus: "assigned", toStatus: "executing",
+      actor: "workflow:run", detail: { workflowId: "build", runId: "run_prior" }, versionEffect: "audit",
+    });
+    pending = [event("resume-1", item.id, "availability-resume", { quotaWindowDecided: true })];
+
+    const service = new triggers.WorkflowTriggerService(repository, runner, () => "now", feed);
+    await service.recoverTodoEvents();
+
+    expect(started).toEqual([{ workflowId: "build", todoId: item.id }]);
+    byId.delete("build");
+  });
+});

--- a/packages/jinn/src/workflows/__tests__/owning-workflow-rearm.test.ts
+++ b/packages/jinn/src/workflows/__tests__/owning-workflow-rearm.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { WorkflowTodoEventClaimOutcome, WorkflowTodoEventFeed, WorkflowTodoStatusEvent }
+import type { WorkflowTodoEventFeed, WorkflowTodoStatusEvent }
   from "../../work-items/workflow-event-feed.js";
 import type { WorkflowDefinition, WorkflowNode } from "../model.js";
 import type { WorkflowRepository } from "../repository.js";

--- a/packages/jinn/src/workflows/trigger-service.ts
+++ b/packages/jinn/src/workflows/trigger-service.ts
@@ -12,6 +12,7 @@ import { jsonValueSchema, type JsonValue, type TriggerNode, type WorkflowDefinit
 import { WorkflowRepositoryError, type WorkflowRepository } from "./repository.js";
 import type { WorkflowRunDetail } from "./runtime.js";
 import type { WorkflowRunner } from "./runner.js";
+import { owningWorkflowId } from "../work-items/workflow-ownership.js";
 import { declinedOutcomes, NOTHING_SUPERSEDED, settle, stillWhereTheEventLeftIt, suppressAll,
   type IndexedTrigger, type SupersededBy, type TodoCandidate, type TodoMismatch } from "./todo-event-outcome.js";
 
@@ -50,7 +51,10 @@ function todoMismatch(node: TriggerNode, event: WorkflowTodoStatusEvent): TodoMi
   // what says the operator's authority stands behind it. Only an `operator`
   // filter is widened, and only where the binding has not opted out.
   const armed = actor === "operator" && delegates !== false && event.armedAsDelegate !== null;
-  if (actor !== undefined && actor !== event.actor && !armed) return refused(`actor ${event.actor ?? "unknown"} is not ${actor}`);
+  const resumed = actor === "operator" && (event.quotaWindowDecided || event.armedAsRecovery === true);
+  if (actor !== undefined && actor !== event.actor && !armed && !resumed) {
+    return refused(`actor ${event.actor ?? "unknown"} is not ${actor}`);
+  }
   if (department !== undefined && department !== event.item.department) return refused(`department filter ${department} does not match`);
   if (assignee !== undefined && assignee !== event.item.assignee) return refused(`assignee filter ${assignee} does not match`);
   const live = event.item.live;
@@ -190,7 +194,16 @@ export class WorkflowTriggerService {
     const deciding = claim.deferred ? candidates.filter((item) => allowed.has(item.definition.id)) : candidates;
     const outcomes = declinedOutcomes(event, deciding, superseded, claim.deferred === true);
     const labels = event.item.labels.map((label) => label.name);
-    const runnable = indexed.filter((candidate) => allowed.has(candidate.definition.id));
+    let runnable = indexed.filter((candidate) => allowed.has(candidate.definition.id));
+    const bound = owningWorkflowId(event.workItemId);
+    if (bound !== undefined && runnable.some((candidate) => candidate.definition.id === bound)) {
+      for (const extra of runnable.filter((candidate) => candidate.definition.id !== bound)) {
+        const detail = `Todo event ${event.id} suppressed: ${event.workItemId} already belongs to workflow \`${bound}\`.`;
+        logger.info(`Workflow ${extra.definition.id}: ${detail}`);
+        outcomes.push({ workflowId: extra.definition.id, outcome: "suppressed", detail });
+      }
+      runnable = runnable.filter((candidate) => candidate.definition.id === bound);
+    }
     const owner = `workflow:${event.id}`;
     const refusal = this.refusalBeforeStart(event, claim.deferred === true, runnable, owner);
     if (refusal !== undefined) return suppressAll(this.feed, event, runnable, outcomes, refusal);

--- a/packages/web/src/lib/__tests__/todos.test.ts
+++ b/packages/web/src/lib/__tests__/todos.test.ts
@@ -128,6 +128,17 @@ describe("deriveNeedsYou", () => {
     expect(deriveNeedsYou([compact({ id: "gated", status: "blocked", approvalState: "pending", parkedUntil: parked })], NOW)).toHaveLength(0)
     expect(deriveNeedsYou([compact({ id: "gated-open", status: "blocked", approvalState: "pending" })], NOW)).toHaveLength(1)
   })
+
+  it("keeps recovering and manager lanes so they reach the dashboard groups", () => {
+    const parked = new Date(NOW + 3_600_000).toISOString()
+    const set = deriveNeedsYou([
+      compact({ id: "rec-assigned", status: "assigned", attentionLane: "recovering" }),
+      compact({ id: "rec-parked", status: "blocked", attentionLane: "recovering", parkedUntil: parked }),
+      compact({ id: "mgr-review", status: "in_review", attentionLane: "manager" }),
+      compact({ id: "plain-assigned", status: "assigned" }),
+    ], NOW)
+    expect(set.map((item) => item.id)).toEqual(["rec-assigned", "rec-parked", "mgr-review"])
+  })
 })
 
 

--- a/packages/web/src/lib/__tests__/todos.test.ts
+++ b/packages/web/src/lib/__tests__/todos.test.ts
@@ -134,7 +134,7 @@ describe("deriveNeedsYou", () => {
     const set = deriveNeedsYou([
       compact({ id: "rec-assigned", status: "assigned", attentionLane: "recovering" }),
       compact({ id: "rec-parked", status: "blocked", attentionLane: "recovering", parkedUntil: parked }),
-      compact({ id: "mgr-review", status: "in_review", attentionLane: "manager" }),
+      compact({ id: "mgr-review", status: "in_review", attentionLane: "manager", approvalState: "approved" }),
       compact({ id: "plain-assigned", status: "assigned" }),
     ], NOW)
     expect(set.map((item) => item.id)).toEqual(["rec-assigned", "rec-parked", "mgr-review"])

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -528,8 +528,6 @@ export interface WorkItemCompactWire extends TodoStopCauseWire {
   updatedAt: string
   /** Manual sort rank (design-todos §7.3). Null until the operator reorders. */
   rank?: number | null
-  /** PLA-240: which attention lane this row belongs to, when the gateway knows. */
-  attentionLane?: "recovering" | "manager" | "operator" | null
 }
 
 /** GET /api/work-items and /api/search/work-items page payload

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -528,6 +528,8 @@ export interface WorkItemCompactWire extends TodoStopCauseWire {
   updatedAt: string
   /** Manual sort rank (design-todos §7.3). Null until the operator reorders. */
   rank?: number | null
+  /** PLA-240: which attention lane this row belongs to, when the gateway knows. */
+  attentionLane?: "recovering" | "manager" | "operator" | null
 }
 
 /** GET /api/work-items and /api/search/work-items page payload

--- a/packages/web/src/lib/parked.ts
+++ b/packages/web/src/lib/parked.ts
@@ -15,6 +15,8 @@ export interface TodoStopCauseWire {
   parkedUntil?: string
   /** What has to happen and who has to do it (older gateways omit it). */
   unblockHint?: TodoUnblockHintWire
+  /** Todo-recovery attention lane (older gateways omit it). */
+  attentionLane?: "recovering" | "manager" | "operator" | null
 }
 
 /** Expiry is what the clock says, not what a sweeper got around to, so the board

--- a/packages/web/src/lib/todos.ts
+++ b/packages/web/src/lib/todos.ts
@@ -117,6 +117,7 @@ const DAY_MS = 24 * 60 * 60 * 1000
 export type NeedsYouSet = WorkItemCompactWire[]
 
 export function needsAttention(item: WorkItemCompactWire, now = Date.now()): boolean {
+  if (item.attentionLane === "recovering" || item.attentionLane === "manager") return true
   return !isParked(item.parkedUntil, now) && (item.approvalState === "pending" || item.status === "escalated" || item.status === "blocked")
 }
 

--- a/packages/web/src/lib/todos.ts
+++ b/packages/web/src/lib/todos.ts
@@ -117,8 +117,7 @@ const DAY_MS = 24 * 60 * 60 * 1000
 export type NeedsYouSet = WorkItemCompactWire[]
 
 export function needsAttention(item: WorkItemCompactWire, now = Date.now()): boolean {
-  if (item.attentionLane === "recovering" || item.attentionLane === "manager") return true
-  return !isParked(item.parkedUntil, now) && (item.approvalState === "pending" || item.status === "escalated" || item.status === "blocked")
+  return item.attentionLane === "recovering" || item.attentionLane === "manager" || (!isParked(item.parkedUntil, now) && (item.approvalState === "pending" || item.status === "escalated" || item.status === "blocked"))
 }
 
 export function deriveNeedsYou(items: WorkItemCompactWire[], now = Date.now()): NeedsYouSet {

--- a/packages/web/src/routes/todos/__tests__/list-grouping.test.ts
+++ b/packages/web/src/routes/todos/__tests__/list-grouping.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { WorkItemCompactWire, WorkItemStatusWire } from "@/lib/api"
+import { deriveNeedsYou } from "@/lib/todos"
 import { groupTodoListItems } from "../list/group-items"
 
 function item(id: string, status: WorkItemStatusWire): WorkItemCompactWire {
@@ -46,6 +47,24 @@ describe("groupTodoListItems", () => {
     expect(groups.find((group) => group.key === "recovering")?.items.map(({ id }) => id)).toEqual(["PLA-1"])
     expect(groups.find((group) => group.key === "manager")?.items.map(({ id }) => id)).toEqual(["PLA-2"])
     expect(groups.find((group) => group.key === "needs-you")?.items.map(({ id }) => id)).toEqual(["PLA-3"])
+  })
+
+  it("a recovering API row reaches Recovering automatically and not Needs you", () => {
+    const recovering = { ...item("QAP-2", "blocked"), attentionLane: "recovering" as const, assignee: "platform-worker" }
+    const operatorGate = { ...item("QAP-10", "in_review"), approvalState: "pending" as const, attentionLane: "operator" as const }
+    const empty = { items: [], total: 0 }
+    const feed = deriveNeedsYou([recovering, operatorGate])
+    const groups = groupTodoListItems(
+      {
+        backlog: empty, assigned: empty, executing: empty,
+        in_review: { items: [operatorGate], total: 1 },
+        blocked: { items: [recovering], total: 1 },
+        escalated: empty, done: empty, cancelled: empty,
+      },
+      feed,
+    )
+    expect(groups.find((group) => group.key === "recovering")?.items.map(({ id }) => id)).toEqual(["QAP-2"])
+    expect(groups.find((group) => group.key === "needs-you")?.items.map(({ id }) => id)).toEqual(["QAP-10"])
   })
 
   it("hoists an attention item outside the loaded status page", () => {

--- a/packages/web/src/routes/todos/__tests__/list-grouping.test.ts
+++ b/packages/web/src/routes/todos/__tests__/list-grouping.test.ts
@@ -30,6 +30,24 @@ function item(id: string, status: WorkItemStatusWire): WorkItemCompactWire {
 }
 
 describe("groupTodoListItems", () => {
+  it("splits recovering and manager lanes out of Needs you", () => {
+    const recovering = { ...item("PLA-1", "blocked"), attentionLane: "recovering" as const }
+    const manager = { ...item("PLA-2", "blocked"), attentionLane: "manager" as const }
+    const operator = { ...item("PLA-3", "blocked"), attentionLane: "operator" as const }
+    const empty = { items: [], total: 0 }
+    const groups = groupTodoListItems(
+      {
+        backlog: empty, assigned: empty, executing: empty, in_review: empty,
+        blocked: { items: [recovering, manager, operator], total: 3 },
+        escalated: empty, done: empty, cancelled: empty,
+      },
+      [recovering, manager, operator],
+    )
+    expect(groups.find((group) => group.key === "recovering")?.items.map(({ id }) => id)).toEqual(["PLA-1"])
+    expect(groups.find((group) => group.key === "manager")?.items.map(({ id }) => id)).toEqual(["PLA-2"])
+    expect(groups.find((group) => group.key === "needs-you")?.items.map(({ id }) => id)).toEqual(["PLA-3"])
+  })
+
   it("hoists an attention item outside the loaded status page", () => {
     const needsReview = item("PLA-21", "in_review")
     const groups = groupTodoListItems(

--- a/packages/web/src/routes/todos/__tests__/list-grouping.test.ts
+++ b/packages/web/src/routes/todos/__tests__/list-grouping.test.ts
@@ -49,6 +49,29 @@ describe("groupTodoListItems", () => {
     expect(groups.find((group) => group.key === "needs-you")?.items.map(({ id }) => id)).toEqual(["PLA-3"])
   })
 
+  it("an in_review approved leftover with attentionLane manager reaches Manager attention, not Needs you", () => {
+    const leftover = {
+      ...item("QPR-4", "in_review"),
+      attentionLane: "manager" as const,
+      approvalState: "approved" as const,
+      assignee: "platform-worker",
+    }
+    const operatorGate = { ...item("QAP-10", "in_review"), approvalState: "pending" as const, attentionLane: "operator" as const }
+    const empty = { items: [], total: 0 }
+    const feed = deriveNeedsYou([leftover, operatorGate])
+    const groups = groupTodoListItems(
+      {
+        backlog: empty, assigned: empty, executing: empty,
+        in_review: { items: [leftover, operatorGate], total: 2 },
+        blocked: empty, escalated: empty, done: empty, cancelled: empty,
+      },
+      feed,
+    )
+    expect(groups.find((group) => group.key === "manager")?.items.map(({ id }) => id)).toEqual(["QPR-4"])
+    expect(groups.find((group) => group.key === "needs-you")?.items.map(({ id }) => id)).toEqual(["QAP-10"])
+    expect(groups.find((group) => group.key === "in-review")?.items.map(({ id }) => id)).not.toContain("QPR-4")
+  })
+
   it("a recovering API row reaches Recovering automatically and not Needs you", () => {
     const recovering = { ...item("QAP-2", "blocked"), attentionLane: "recovering" as const, assignee: "platform-worker" }
     const operatorGate = { ...item("QAP-10", "in_review"), approvalState: "pending" as const, attentionLane: "operator" as const }

--- a/packages/web/src/routes/todos/__tests__/needs-you-view-lanes.test.tsx
+++ b/packages/web/src/routes/todos/__tests__/needs-you-view-lanes.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import type { WorkItemCompactWire, WorkItemStatusWire, ApprovalStateWire } from "@/lib/api"
+import { createBrowserGatewayTransport, installGatewayTransport } from "@/lib/gateway-transport"
+import { NeedsYouView } from "../needs-you-view"
+
+vi.mock("@/routes/settings-provider", () => ({
+  useSettings: () => ({ settings: { employeeOverrides: {} } }),
+}))
+
+const getWorkItem = vi.fn()
+const getWorkItemTree = vi.fn()
+const getWorkItems = vi.fn()
+const getWorkItemTrees = vi.fn()
+const setWorkItemStatus = vi.fn()
+
+let restoreTransport: (() => void) | null = null
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getWorkItem: (...a: unknown[]) => getWorkItem(...a),
+      getWorkItemTree: (...a: unknown[]) => getWorkItemTree(...a),
+      getWorkItems: (...a: unknown[]) => getWorkItems(...a),
+      getWorkItemTrees: (...a: unknown[]) => getWorkItemTrees(...a),
+      setWorkItemStatus: (...a: unknown[]) => setWorkItemStatus(...a),
+    },
+  }
+})
+
+function item(
+  id: string,
+  status: WorkItemStatusWire,
+  approvalState: ApprovalStateWire | null,
+  over: Partial<WorkItemCompactWire> = {},
+): WorkItemCompactWire {
+  return {
+    id,
+    title: "Review this Todo",
+    status,
+    department: null,
+    assignee: null,
+    source: "cron",
+    sourceRef: "cron:job:2026",
+    approvalState,
+    approvalRequest: approvalState === "pending" ? "Approve posting this?" : null,
+    approvalRef: null,
+    approvalTarget: null,
+    approvalEscalatedAt: null,
+    updatedAt: "2026-07-05T11:00:00.000Z",
+    ...over,
+  }
+}
+
+function renderView(items: WorkItemCompactWire[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <NeedsYouView
+          items={items}
+          byName={new Map()}
+          resolvingIds={new Set()}
+          onApprove={vi.fn()}
+          onReject={vi.fn()}
+          onOpen={vi.fn()}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+beforeEach(() => {
+  restoreTransport = installGatewayTransport(createBrowserGatewayTransport({
+    origin: "https://qa-a.example:7779",
+    request: vi.fn(),
+    navigate: vi.fn(),
+  }))
+  vi.clearAllMocks()
+  getWorkItem.mockRejectedValue(Object.assign(new Error("nf"), { status: 404 }))
+  getWorkItemTree.mockRejectedValue(Object.assign(new Error("nf"), { status: 404 }))
+  getWorkItems.mockResolvedValue({ workItems: [] })
+  getWorkItemTrees.mockResolvedValue({ trees: {} })
+})
+
+afterEach(() => {
+  restoreTransport?.()
+  restoreTransport = null
+})
+
+describe("NeedsYouView attention lanes (PLA-240)", () => {
+  it("a recovering leftover reaches Recovering automatically and not Blocked", () => {
+    renderView([
+      item("QAP-2", "blocked", null, { title: "quota parked build", attentionLane: "recovering", assignee: "platform-worker" }),
+      item("QAP-10", "in_review", "pending", { title: "operator gate", attentionLane: "operator" }),
+    ])
+    expect(screen.getByTestId("needs-group-recovering").textContent).toContain("Recovering automatically")
+    expect(screen.getByTestId("needs-group-recovering").textContent).toContain("quota parked build")
+    expect(screen.getByTestId("needs-group-approval").textContent).toContain("operator gate")
+    expect(screen.queryByTestId("needs-group-blocked")).toBeNull()
+  })
+
+  it("an approved in_review leftover with attentionLane manager reaches Manager attention, not Approvals", () => {
+    renderView([
+      item("QAP-15", "in_review", "approved", { title: "approved landing leftover", attentionLane: "manager", assignee: "platform-worker" }),
+      item("QAP-10", "in_review", "pending", { title: "operator gate", attentionLane: "operator" }),
+    ])
+    expect(screen.getByTestId("needs-group-manager").textContent).toContain("Manager attention")
+    expect(screen.getByTestId("needs-group-manager").textContent).toContain("approved landing leftover")
+    expect(screen.getByTestId("needs-group-approval").textContent).toContain("operator gate")
+    expect(screen.getByTestId("needs-group-manager").textContent).not.toContain("operator gate")
+  })
+})

--- a/packages/web/src/routes/todos/__tests__/needs-you-view.test.tsx
+++ b/packages/web/src/routes/todos/__tests__/needs-you-view.test.tsx
@@ -104,6 +104,28 @@ describe("NeedsYouView", () => {
     expect(screen.getByText("All quiet.")).toBeTruthy()
   })
 
+  it("a recovering leftover reaches Recovering automatically and not Blocked", () => {
+    renderView([
+      item("QAP-2", "blocked", null, { title: "quota parked build", attentionLane: "recovering", assignee: "platform-worker" }),
+      item("QAP-10", "in_review", "pending", { title: "operator gate", attentionLane: "operator" }),
+    ])
+    expect(screen.getByTestId("needs-group-recovering").textContent).toContain("Recovering automatically")
+    expect(screen.getByTestId("needs-group-recovering").textContent).toContain("quota parked build")
+    expect(screen.getByTestId("needs-group-approval").textContent).toContain("operator gate")
+    expect(screen.queryByTestId("needs-group-blocked")).toBeNull()
+  })
+
+  it("an approved in_review leftover with attentionLane manager reaches Manager attention, not Approvals", () => {
+    renderView([
+      item("QAP-15", "in_review", "approved", { title: "approved landing leftover", attentionLane: "manager", assignee: "platform-worker" }),
+      item("QAP-10", "in_review", "pending", { title: "operator gate", attentionLane: "operator" }),
+    ])
+    expect(screen.getByTestId("needs-group-manager").textContent).toContain("Manager attention")
+    expect(screen.getByTestId("needs-group-manager").textContent).toContain("approved landing leftover")
+    expect(screen.getByTestId("needs-group-approval").textContent).toContain("operator gate")
+    expect(screen.getByTestId("needs-group-manager").textContent).not.toContain("operator gate")
+  })
+
   it("groups by kind in fixed kicker order — Approvals, Escalated, Blocked — oldest first within a group", () => {
     renderView([
       item("wi_private_blocked", "blocked", null, { title: "Blocked item" }),

--- a/packages/web/src/routes/todos/__tests__/needs-you-view.test.tsx
+++ b/packages/web/src/routes/todos/__tests__/needs-you-view.test.tsx
@@ -104,28 +104,6 @@ describe("NeedsYouView", () => {
     expect(screen.getByText("All quiet.")).toBeTruthy()
   })
 
-  it("a recovering leftover reaches Recovering automatically and not Blocked", () => {
-    renderView([
-      item("QAP-2", "blocked", null, { title: "quota parked build", attentionLane: "recovering", assignee: "platform-worker" }),
-      item("QAP-10", "in_review", "pending", { title: "operator gate", attentionLane: "operator" }),
-    ])
-    expect(screen.getByTestId("needs-group-recovering").textContent).toContain("Recovering automatically")
-    expect(screen.getByTestId("needs-group-recovering").textContent).toContain("quota parked build")
-    expect(screen.getByTestId("needs-group-approval").textContent).toContain("operator gate")
-    expect(screen.queryByTestId("needs-group-blocked")).toBeNull()
-  })
-
-  it("an approved in_review leftover with attentionLane manager reaches Manager attention, not Approvals", () => {
-    renderView([
-      item("QAP-15", "in_review", "approved", { title: "approved landing leftover", attentionLane: "manager", assignee: "platform-worker" }),
-      item("QAP-10", "in_review", "pending", { title: "operator gate", attentionLane: "operator" }),
-    ])
-    expect(screen.getByTestId("needs-group-manager").textContent).toContain("Manager attention")
-    expect(screen.getByTestId("needs-group-manager").textContent).toContain("approved landing leftover")
-    expect(screen.getByTestId("needs-group-approval").textContent).toContain("operator gate")
-    expect(screen.getByTestId("needs-group-manager").textContent).not.toContain("operator gate")
-  })
-
   it("groups by kind in fixed kicker order — Approvals, Escalated, Blocked — oldest first within a group", () => {
     renderView([
       item("wi_private_blocked", "blocked", null, { title: "Blocked item" }),

--- a/packages/web/src/routes/todos/list/group-items.ts
+++ b/packages/web/src/routes/todos/list/group-items.ts
@@ -42,6 +42,21 @@ const OPEN_GROUPS: Array<{
   { key: "escalated", label: "Escalated", status: "escalated", omitWhenEmpty: true },
 ]
 
+function attentionGroup(key: Extract<TodoListGroupKey, "recovering" | "manager" | "needs-you">, label: string, items: WorkItemCompactWire[]): TodoListGroup {
+  return { key, label, statuses: [], items, count: items.length }
+}
+
+function attentionGroups(needsItems: WorkItemCompactWire[]): TodoListGroup[] {
+  const recovering = needsItems.filter((item) => item.attentionLane === "recovering")
+  const manager = needsItems.filter((item) => item.attentionLane === "manager")
+  const operator = needsItems.filter((item) => item.attentionLane !== "recovering" && item.attentionLane !== "manager")
+  const groups: TodoListGroup[] = []
+  if (recovering.length > 0) groups.push(attentionGroup("recovering", "Recovering automatically", recovering))
+  if (manager.length > 0) groups.push(attentionGroup("manager", "Manager attention", manager))
+  groups.push(attentionGroup("needs-you", "Needs you", operator))
+  return groups
+}
+
 export function groupTodoListItems(
   columns: TodoListColumns,
   needsAttention: WorkItemCompactWire[],
@@ -57,36 +72,7 @@ export function groupTodoListItems(
     hoistedByStatus.set(item.status, (hoistedByStatus.get(item.status) ?? 0) + 1)
   }
 
-  const recoveringItems = needsItems.filter((item) => item.attentionLane === "recovering")
-  const managerItems = needsItems.filter((item) => item.attentionLane === "manager")
-  const operatorItems = needsItems.filter((item) => item.attentionLane !== "recovering" && item.attentionLane !== "manager")
-
-  const groups: TodoListGroup[] = []
-  if (recoveringItems.length > 0) {
-    groups.push({
-      key: "recovering",
-      label: "Recovering automatically",
-      statuses: [],
-      items: recoveringItems,
-      count: recoveringItems.length,
-    })
-  }
-  if (managerItems.length > 0) {
-    groups.push({
-      key: "manager",
-      label: "Manager attention",
-      statuses: [],
-      items: managerItems,
-      count: managerItems.length,
-    })
-  }
-  groups.push({
-    key: "needs-you",
-    label: "Needs you",
-    statuses: [],
-    items: operatorItems,
-    count: operatorItems.length,
-  })
+  const groups: TodoListGroup[] = attentionGroups(needsItems)
 
   for (const definition of OPEN_GROUPS) {
     const column = columns[definition.status]

--- a/packages/web/src/routes/todos/list/group-items.ts
+++ b/packages/web/src/routes/todos/list/group-items.ts
@@ -9,6 +9,8 @@ export type TodoListColumns = Record<WorkItemStatusWire, TodoListColumnInput>
 
 export type TodoListGroupKey =
   | "needs-you"
+  | "recovering"
+  | "manager"
   | "executing"
   | "in-review"
   | "assigned"
@@ -27,7 +29,7 @@ export interface TodoListGroup {
 }
 
 const OPEN_GROUPS: Array<{
-  key: Exclude<TodoListGroupKey, "needs-you" | "closed">
+  key: Exclude<TodoListGroupKey, "needs-you" | "recovering" | "manager" | "closed">
   label: string
   status: WorkItemStatusWire
   omitWhenEmpty?: boolean
@@ -55,13 +57,36 @@ export function groupTodoListItems(
     hoistedByStatus.set(item.status, (hoistedByStatus.get(item.status) ?? 0) + 1)
   }
 
-  const groups: TodoListGroup[] = [{
+  const recoveringItems = needsItems.filter((item) => item.attentionLane === "recovering")
+  const managerItems = needsItems.filter((item) => item.attentionLane === "manager")
+  const operatorItems = needsItems.filter((item) => item.attentionLane !== "recovering" && item.attentionLane !== "manager")
+
+  const groups: TodoListGroup[] = []
+  if (recoveringItems.length > 0) {
+    groups.push({
+      key: "recovering",
+      label: "Recovering automatically",
+      statuses: [],
+      items: recoveringItems,
+      count: recoveringItems.length,
+    })
+  }
+  if (managerItems.length > 0) {
+    groups.push({
+      key: "manager",
+      label: "Manager attention",
+      statuses: [],
+      items: managerItems,
+      count: managerItems.length,
+    })
+  }
+  groups.push({
     key: "needs-you",
     label: "Needs you",
     statuses: [],
-    items: needsItems,
-    count: needsItems.length,
-  }]
+    items: operatorItems,
+    count: operatorItems.length,
+  })
 
   for (const definition of OPEN_GROUPS) {
     const column = columns[definition.status]

--- a/packages/web/src/routes/todos/list/list-group.tsx
+++ b/packages/web/src/routes/todos/list/list-group.tsx
@@ -20,11 +20,13 @@ export function TodoListGroupHeader({
   onToggle?: () => void
   onQuickAdd: () => void
 }) {
-  const headerGlyph = group.key === "needs-you"
+  const headerGlyph = group.key === "needs-you" || group.key === "manager"
     ? <StateCircle keyOf="approval" size={16} />
-    : group.key === "closed"
-      ? <StatusCircle status="done" size={16} />
-      : <StatusCircle status={group.statuses[0] as WorkItemStatusWire} size={16} />
+    : group.key === "recovering"
+      ? <StatusCircle status="blocked" size={16} />
+      : group.key === "closed"
+        ? <StatusCircle status="done" size={16} />
+        : <StatusCircle status={group.statuses[0] as WorkItemStatusWire} size={16} />
 
   return (
     <div className="flex min-h-[34px] items-center gap-2 rounded-[var(--radius-sm)] bg-[var(--fill-quaternary)] px-2.5">

--- a/packages/web/src/routes/todos/needs-you-support.ts
+++ b/packages/web/src/routes/todos/needs-you-support.ts
@@ -5,15 +5,19 @@ import type { StateGlyphKey } from "./state-glyph"
 
 /** Which of the inbox's three kickers an entry belongs to. A pending gate wins
  *  over the status, because a Todo can be blocked AND holding a decision. */
-export type AttentionKind = "approval" | "escalated" | "blocked"
+export type AttentionKind = "approval" | "escalated" | "blocked" | "recovering" | "manager"
 
 export function attentionKind(item: WorkItemCompactWire): AttentionKind {
+  if (item.attentionLane === "recovering") return "recovering"
+  if (item.attentionLane === "manager") return "manager"
   if (item.approvalState === "pending") return "approval"
   return item.status === "blocked" ? "blocked" : "escalated"
 }
 
 export function stateKey(kind: AttentionKind): StateGlyphKey {
-  return kind === "approval" ? "approval" : kind
+  if (kind === "approval" || kind === "manager") return "approval"
+  if (kind === "recovering") return "blocked"
+  return kind
 }
 
 /** A stopped Todo's own account of the wait (PLA-157), for the inbox line that

--- a/packages/web/src/routes/todos/needs-you-support.ts
+++ b/packages/web/src/routes/todos/needs-you-support.ts
@@ -7,6 +7,14 @@ import type { StateGlyphKey } from "./state-glyph"
  *  over the status, because a Todo can be blocked AND holding a decision. */
 export type AttentionKind = "approval" | "escalated" | "blocked" | "recovering" | "manager"
 
+export const ATTENTION_GROUPS: { kind: AttentionKind; label: string }[] = [
+  { kind: "recovering", label: "Recovering automatically" },
+  { kind: "manager", label: "Manager attention" },
+  { kind: "approval", label: "Approvals" },
+  { kind: "escalated", label: "Escalated" },
+  { kind: "blocked", label: "Blocked" },
+]
+
 export function attentionKind(item: WorkItemCompactWire): AttentionKind {
   if (item.attentionLane === "recovering") return "recovering"
   if (item.attentionLane === "manager") return "manager"

--- a/packages/web/src/routes/todos/needs-you-view.tsx
+++ b/packages/web/src/routes/todos/needs-you-view.tsx
@@ -397,6 +397,8 @@ export function NeedsYouEmpty() {
 }
 
 const GROUPS: { kind: AttentionKind; label: string }[] = [
+  { kind: "recovering", label: "Recovering automatically" },
+  { kind: "manager", label: "Manager attention" },
   { kind: "approval", label: "Approvals" },
   { kind: "escalated", label: "Escalated" },
   { kind: "blocked", label: "Blocked" },

--- a/packages/web/src/routes/todos/needs-you-view.tsx
+++ b/packages/web/src/routes/todos/needs-you-view.tsx
@@ -11,7 +11,7 @@ import {
 import { EmployeeChip } from "@/components/ui/employee-chip"
 import { STATUS_LABEL, effectiveMaxRounds, operatorSafeTodoError, provenanceLabel, publicWorkItemReference } from "@/lib/todos"
 import { legalTargets } from "@/lib/legal-targets"
-import { attentionKind, stateKey, stopCauseQuote, type AttentionKind } from "./needs-you-support"
+import { ATTENTION_GROUPS, attentionKind, stateKey, stopCauseQuote, type AttentionKind } from "./needs-you-support"
 import { ProvenanceIcon, StateCircle, StatusCircle } from "./state-glyph"
 import { rejectConsequence } from "./task-page/banner"
 import { reasonOf, rollupOf } from "./board/card"
@@ -396,14 +396,6 @@ export function NeedsYouEmpty() {
   )
 }
 
-const GROUPS: { kind: AttentionKind; label: string }[] = [
-  { kind: "recovering", label: "Recovering automatically" },
-  { kind: "manager", label: "Manager attention" },
-  { kind: "approval", label: "Approvals" },
-  { kind: "escalated", label: "Escalated" },
-  { kind: "blocked", label: "Blocked" },
-]
-
 export function NeedsYouView({
   items,
   byName,
@@ -461,7 +453,7 @@ export function NeedsYouView({
 
   if (visible.length === 0) return <NeedsYouEmpty />
 
-  const grouped = GROUPS.map((group) => ({
+  const grouped = ATTENTION_GROUPS.map((group) => ({
     ...group,
     // Oldest-first within a group — the longest-waiting ask wins (§6).
     items: visible

--- a/size-baseline.json
+++ b/size-baseline.json
@@ -1759,7 +1759,7 @@
       ]
     },
     "packages/web/src/routes/todos/needs-you-view.tsx": {
-      "lines": 509,
+      "lines": 503,
       "exempt": [
         "complexity",
         "max-lines-per-function"


### PR DESCRIPTION
## Summary

Lands certified PLA-240 self-healing Todos onto current `origin/main` **without enabling automatic recovery**.

The original certified commit `cb42558e41a5e7f5996e54ffab9847020edb4a98` lives on `build/PLA-240-self-healing-todos`, whose base (`11414394`) is **not** `origin/main` and carries unpublished local ancestors. Merging that branch would ship unrelated unpublished work. This PR cherry-picks the 15 PLA-240 commits onto `origin/main` instead.

- Candidate HEAD: `5f1403f3b78c3fcf59750419d2431f4b2034df7f`
- Certified source: `cb42558e` (not rewritten; original branch left intact)
- Combined `git patch-id --stable` of `origin/main...HEAD` equals `36e7b567^..cb42558e`: `5c0bc58d31baa0267bcbc5b98066c607b6bd698d`
- All 15 per-commit patch-ids match 1:1
- PLA-240-touched files are byte-identical to `cb42558e`
- `todoRecovery` default remains **classify-only**. Unset config does not apply recovery. Ordinary backlog never auto-starts. `mode=auto` is **not** activated here.

**Do not squash-merge unless independently re-verified.** Prefer a merge commit. Do not merge until Jinn Verifier signs the integrated candidate (`5f1403f3`).

## What this ships

- Lifecycle invariants: stale failure Ends cannot stomp a live successor (PLA-221); weekly-capped work waits for the real reset (PLA-216); re-arm resumes the owning workflow (PLA-177)
- Bounded recovery classifier with classify-only default; max 2 attempts; claim CAS
- Quiet anomaly detector (silent when healthy)
- Dashboard lanes: Recovering automatically / Manager attention / Needs you
- Approved/landed leftovers close through `complete()`, or stay on Manager attention; generic operator classification cannot downgrade an unresolved manager/recovering lane

## Test plan

- [x] `pnpm typecheck` (turbo 6/6 + root)
- [x] Focused jinn-cli tests: 10 files / 84 passed
- [x] Focused web tests: 3 files / 52 passed
- [x] Changed-path eslint green (jinn-cli + web)
- [ ] GitHub CI on this PR
- [ ] Independent verifier sandbox (not production 7777/7788)

## Out of scope

- npm publish / package release
- production deploy/restart / config activation
- `gateway.todoRecovery.mode: auto`
- auto-starting ordinary backlog

Fixes PLA-240 land follow-on (PLA-242).