### PR TITLE
fix(ci): restore main's lint, Windows tests, and web budget

### DIFF
--- a/packages/jinn/src/backup/__tests__/snapshot.test.ts
+++ b/packages/jinn/src/backup/__tests__/snapshot.test.ts
@@ -21,7 +21,8 @@ function tempDir(): string {
 function archiveEntries(snapshot: string, codecExtension: string): string[] {
   const archive = path.join(snapshot, `home.${codecExtension}`);
   const listing = execFileSync("tar", ["-tf", archive], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
-  return listing.split("\n").filter(Boolean).map((entry) => entry.replace(/^\.\//, ""));
+  // Windows tar -tf emits CRLF; POSIX tests compare against slash paths without CR.
+  return listing.split("\n").filter(Boolean).map((entry) => entry.replace(/^\.\//, "").replace(/\r$/, ""));
 }
 
 afterEach(() => {

--- a/packages/jinn/src/engines/__tests__/antigravity-headless-process.test.ts
+++ b/packages/jinn/src/engines/__tests__/antigravity-headless-process.test.ts
@@ -102,6 +102,7 @@ describe("AntigravityHeadlessEngine process ownership", () => {
   });
 
   it("terminates and settles a turn at the hard timeout", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     vi.useFakeTimers();
     const processKill = vi.mocked(process.kill);
     const engine = new headless.AntigravityHeadlessEngine();
@@ -125,6 +126,7 @@ describe("AntigravityHeadlessEngine process ownership", () => {
   });
 
   it("reaps the owned process group after an explicit terminal result", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const processKill = vi.mocked(process.kill);
     const engine = new headless.AntigravityHeadlessEngine();
     const resultPromise = engine.run({

--- a/packages/jinn/src/engines/__tests__/antigravity-headless.test.ts
+++ b/packages/jinn/src/engines/__tests__/antigravity-headless.test.ts
@@ -204,6 +204,7 @@ describe("AntigravityHeadlessEngine", () => {
   });
 
   it("reaps descendants and ignores late output when the leader exits with an inherited pipe", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     vi.useFakeTimers();
     const processKill = vi.mocked(process.kill);
     const deltas: unknown[] = [];
@@ -248,6 +249,7 @@ describe("AntigravityHeadlessEngine", () => {
   });
 
   it("interrupts only the tracked process group and reports the reason", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const processKill = vi.mocked(process.kill);
     const engine = new headless.AntigravityHeadlessEngine();
     const resultPromise = engine.run({

--- a/packages/jinn/src/gateway/__tests__/config-revision-api.test.ts
+++ b/packages/jinn/src/gateway/__tests__/config-revision-api.test.ts
@@ -123,8 +123,11 @@ beforeEach(() => {
   emit.mockClear();
 });
 
-afterAll(() => {
-  fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+afterAll(async () => {
+  try { (await import("../../shared/db.js")).__closeDbForTest(); } catch { /* never opened */ }
+  try {
+    fs.rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  } catch { /* Windows can keep a handle past close; the suite already passed. */ }
 });
 
 describe("GET /api/config revision", () => {

--- a/packages/jinn/src/gateway/__tests__/org-api-read-after-write.test.ts
+++ b/packages/jinn/src/gateway/__tests__/org-api-read-after-write.test.ts
@@ -122,8 +122,11 @@ beforeAll(async () => {
   dbModule.initDb();
 });
 
-afterAll(() => {
-  fs.rmSync(home, { recursive: true, force: true });
+afterAll(async () => {
+  dbModule.__closeDbForTest();
+  try {
+    fs.rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  } catch { /* Windows can keep a handle past close; the suite already passed. */ }
 });
 
 describe("PATCH /api/org/employees/:name — read after write", () => {

--- a/packages/web/perf-budgets.json
+++ b/packages/web/perf-budgets.json
@@ -16,7 +16,7 @@
     }
   },
   "initialCriticalPath": {
-    "baselineGzipBytes": 189609,
+    "baselineGzipBytes": 189999,
     "budgetGzipBytes": 195000
   }
 }

--- a/packages/web/src/plugins/sdk/__tests__/plugin-host-bridge.test.tsx
+++ b/packages/web/src/plugins/sdk/__tests__/plugin-host-bridge.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { render } from '@testing-library/react'
 import { RouterProvider, createMemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
@@ -101,6 +102,12 @@ it('leaves every other frame out of the notification sink', () => {
   gateway.emit({ event: 'plugins:changed', payload: {} })
 
   expect(sink).not.toHaveBeenCalled()
+})
+
+it('does not statically import the plugin SDK barrel onto the first paint', () => {
+  // Vitest runs from the package root, so this is the file the host ships as.
+  const source = readFileSync('src/plugins/sdk/plugin-host-bridge.tsx', 'utf8')
+  expect(source).not.toMatch(/\bimport\s+['"]@jinn\/plugin-sdk['"]/)
 })
 
 it('logs a notice it cannot show rather than throwing into the socket', () => {

--- a/packages/web/src/plugins/sdk/__tests__/plugin-notices.test.tsx
+++ b/packages/web/src/plugins/sdk/__tests__/plugin-notices.test.tsx
@@ -48,6 +48,7 @@ vi.mock('@/routes/auth-provider', () => ({ AuthProvider: passThrough, AuthGate: 
 vi.mock('@/routes/settings-provider', () => ({
   SettingsProvider: passThrough,
   DocumentTitle: () => null,
+  useSettings: () => ({ settings: { talkOrb: false } }),
 }))
 vi.mock('@/hooks/use-gateway', () => ({
   GatewayProvider: passThrough,

--- a/packages/web/src/plugins/sdk/__tests__/runtime.test.ts
+++ b/packages/web/src/plugins/sdk/__tests__/runtime.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { installPluginSdk, sdkImportMap, shimSource } from '../runtime'
 
@@ -48,6 +49,12 @@ describe('sdkImportMap before installPluginSdk', () => {
 })
 
 describe('installPluginSdk', () => {
+  it('names the @jinn/plugin-sdk alias dynamically so a broken mapping fails this build', () => {
+    const source = readFileSync('src/plugins/sdk/runtime.ts', 'utf8')
+    expect(source).toMatch(/import\(['"]@jinn\/plugin-sdk['"]\)/)
+    expect(source).not.toMatch(/\bimport\s+['"]@jinn\/plugin-sdk['"]/)
+  })
+
   it('puts the app’s own SDK and React on the globals the shims read', async () => {
     await installPluginSdk()
 

--- a/packages/web/src/plugins/sdk/plugin-host-bridge.tsx
+++ b/packages/web/src/plugins/sdk/plugin-host-bridge.tsx
@@ -6,12 +6,9 @@ import { useGateway } from '@/hooks/use-gateway'
 import { hostNotificationSink } from './host-bridge'
 import { dispatchHostEvent } from './host-events'
 import { publishHostState } from './host-state'
-// The app has no use for the barrel — it exists for plugins to import — so
-// without this nothing in the bundle names `@jinn/plugin-sdk` and `vite build`
-// never resolves it. Naming it here, in the app's half of the host, means a
-// broken or deleted alias fails our own build rather than a stranger's first
-// plugin load.
-import '@jinn/plugin-sdk'
+// The `@jinn/plugin-sdk` barrel is named from `installPluginSdk()` as a
+// dynamic import, not here. A static import put Select/Menu and the floating
+// layer back on every dashboard's first paint.
 
 /**
  * A plugin backend's `host.notify` arrives as a frame, because a backend has no

--- a/packages/web/src/plugins/sdk/runtime.ts
+++ b/packages/web/src/plugins/sdk/runtime.ts
@@ -42,7 +42,11 @@ const BINDING_NAME = /^[A-Za-z_$][\w$]*$/
 /** Install the app's own instances where the shims read them. Idempotent. */
 export async function installPluginSdk(): Promise<void> {
   namespaces ??= {
-    '@jinn/plugin-sdk': await import('./index'),
+    // The alias, not the relative path: a broken `@jinn/plugin-sdk` mapping
+    // must fail this app build rather than a stranger's first plugin load.
+    // Dynamic so the barrel (Select, Menu, the floating layer) stays off
+    // the first paint of a dashboard whose plugins directory is empty.
+    '@jinn/plugin-sdk': await import('@jinn/plugin-sdk'),
     react: React,
     'react/jsx-runtime': jsxRuntime,
   }

--- a/packages/web/src/routes/client-providers.test.tsx
+++ b/packages/web/src/routes/client-providers.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import { act, render } from "@testing-library/react"
 import { useEffect, type ReactNode } from "react"
 import { Outlet, RouterProvider, createMemoryRouter } from "react-router-dom"
@@ -29,6 +30,7 @@ vi.mock("@/routes/auth-provider", () => ({ AuthProvider: passThrough, AuthGate: 
 vi.mock("@/routes/settings-provider", () => ({
   SettingsProvider: passThrough,
   DocumentTitle: () => null,
+  useSettings: () => ({ settings: { talkOrb: false } }),
 }))
 /** Stable identity: the plugin host bridge subscribes in an effect keyed on it. */
 const gateway = vi.hoisted(() => ({ connected: false, subscribe: () => () => {} }))
@@ -88,5 +90,11 @@ describe("ClientProviders mounts the talk orb above the router", () => {
 
     expect(view.container.textContent).toContain("chat")
     expect(orb.mounts).toBe(1)
+  })
+
+  it("keeps the Talk screen-context graph off the first paint", () => {
+    const source = readFileSync("src/routes/client-providers.tsx", "utf8")
+    expect(source).not.toMatch(/\bimport\s+\{[^}]*TalkContextBridge/)
+    expect(source).toMatch(/import\("@\/components\/talk\/context\/talk-context-bridge"\)/)
   })
 })

--- a/packages/web/src/routes/client-providers.tsx
+++ b/packages/web/src/routes/client-providers.tsx
@@ -1,9 +1,9 @@
 
-import type { ReactNode } from "react"
+import { lazy, Suspense, type ReactNode } from "react"
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from '@/lib/query-client'
 import { ThemeProvider } from "@/routes/providers"
-import { SettingsProvider, DocumentTitle } from "@/routes/settings-provider"
+import { SettingsProvider, DocumentTitle, useSettings } from "@/routes/settings-provider"
 import { useQueryInvalidation } from '@/hooks/use-query-invalidation'
 import { BreadcrumbProvider } from '@/context/breadcrumb-context'
 import { EmojiFavicon } from '@/components/emoji-favicon'
@@ -16,11 +16,28 @@ import { useTodoPrefixes } from "@/hooks/use-todo-prefixes"
 import { PluginHostBridge } from "@/plugins/sdk/plugin-host-bridge"
 import { PluginNotices } from "@/plugins/sdk/plugin-notices"
 import { DiskPluginsBridge } from "@/plugins/disk-plugins-bridge"
-import { TalkContextBridge } from "@/components/talk/context/talk-context-bridge"
+
+const TalkContextBridge = lazy(() =>
+  import("@/components/talk/context/talk-context-bridge").then((module) => ({
+    default: module.TalkContextBridge,
+  })),
+)
 
 function QueryInvalidationBridge() {
   useQueryInvalidation()
   return null
+}
+
+/** Off the first paint: the semantic snapshot exists for the Talk session, and
+ *  Talk is off until the operator asks for it. Same gate as TalkOrbOverlay. */
+function DeferredTalkContextBridge() {
+  const { settings } = useSettings()
+  if (!settings.talkOrb) return null
+  return (
+    <Suspense fallback={null}>
+      <TalkContextBridge />
+    </Suspense>
+  )
 }
 
 /** Which 3-letter prefixes name a live board, app-wide: a Todo id reads as a
@@ -42,7 +59,7 @@ export function ClientProviders({ children }: { children: ReactNode }) {
                 <GatewayProvider>
                   <InstanceMigrationGate />
                   <TodoMentionPrefixes>{children}</TodoMentionPrefixes>
-                  <TalkContextBridge />
+                  <DeferredTalkContextBridge />
                   {/* Above the router, so route changes never remount the orb. */}
                   <TalkOrbOverlay />
                   <DocumentTitle />

--- a/scripts/upgrade-lab/assertions.mjs
+++ b/scripts/upgrade-lab/assertions.mjs
@@ -12,6 +12,32 @@ export function assertServiceOwnedRemovalsApplied({ home, serviceOwnedRemovals }
   }
 }
 
+function payloadSha256(materializedBundleDir, payload) {
+  return payload ? sha256(fs.readFileSync(path.join(materializedBundleDir, payload))) : null
+}
+
+function assertStockRecordPresent(home, record, reviewed) {
+  if (!reviewed.has(record.path)) throw new Error(`stock migration did not review manifest path: ${record.path}`)
+  const user = path.join(home, record.path)
+  if (!fs.existsSync(user)) throw new Error(`stock path is missing after migration: ${record.path}`)
+  return user
+}
+
+function assertStockRecordReachedTarget({ home, materializedBundleDir, record, reviewed, preMergeTree }) {
+  const user = assertStockRecordPresent(home, record, reviewed)
+  const actualSha256 = sha256(fs.readFileSync(user))
+  const baseSha256 = payloadSha256(materializedBundleDir, record.basePayload)
+  const targetSha256 = payloadSha256(materializedBundleDir, record.targetPayload)
+  const wasUnmodifiedStock = record.operation === "add" || preMergeTree[record.path] === baseSha256
+  if (wasUnmodifiedStock) {
+    if (actualSha256 !== targetSha256) throw new Error(`stock path did not reach target: ${record.path}`)
+    return
+  }
+  if (baseSha256 !== targetSha256 && actualSha256 === preMergeTree[record.path]) {
+    throw new Error(`personalized stock path did not incorporate target changes: ${record.path}`)
+  }
+}
+
 export function assertStockBundleApplied({ home, materializedBundleDir, manifest, receipt, preMergeTree }) {
   if (receipt.skippedItems.length > 0) throw new Error(`stock migration skipped manifest paths: ${JSON.stringify(receipt.skippedItems)}`)
   const reviewed = new Set(receipt.reviewedFiles)
@@ -19,18 +45,6 @@ export function assertStockBundleApplied({ home, materializedBundleDir, manifest
     // A removal is service-owned and has not happened yet: the service performs it at
     // completion. assertServiceOwnedRemovalsApplied proves it there.
     if (record.operation === "remove") continue
-    if (!reviewed.has(record.path)) throw new Error(`stock migration did not review manifest path: ${record.path}`)
-    const user = path.join(home, record.path)
-    if (!fs.existsSync(user)) throw new Error(`stock path is missing after migration: ${record.path}`)
-    const actualSha256 = sha256(fs.readFileSync(user))
-    const baseSha256 = record.basePayload ? sha256(fs.readFileSync(path.join(materializedBundleDir, record.basePayload))) : null
-    const targetSha256 = record.targetPayload ? sha256(fs.readFileSync(path.join(materializedBundleDir, record.targetPayload))) : null
-    const wasUnmodifiedStock = record.operation === "add" || preMergeTree[record.path] === baseSha256
-    if (wasUnmodifiedStock && actualSha256 !== targetSha256) {
-      throw new Error(`stock path did not reach target: ${record.path}`)
-    }
-    if (!wasUnmodifiedStock && baseSha256 !== targetSha256 && actualSha256 === preMergeTree[record.path]) {
-      throw new Error(`personalized stock path did not incorporate target changes: ${record.path}`)
-    }
+    assertStockRecordReachedTarget({ home, materializedBundleDir, record, reviewed, preMergeTree })
   }
 }


### PR DESCRIPTION
## Why

`origin/main` CI (`32718895422`, merge of #135) is red, which blocks landing a release commit. Ubuntu tests, typecheck, docker, e2e, coverage, footguns, and ratchet are already green.

This is PLA-244. It does **not** cut a version tag, publish npm, or create a GitHub Release.

## What failed

1. **lint** — `assertStockBundleApplied` complexity 14 > 10
2. **build / perf:budget** — initial critical path 205633 B gzip > 195000 B
3. **unit-tests (windows-latest)**
   - tar listings include CR (`config.yaml\r`)
   - antigravity tests assert POSIX `process.kill(-pid, SIGTERM)` on win32
   - config-revision-api and org-api-read-after-write `EPERM` on temp cleanup

v0.31.0 npm publish failed earlier on Linux `glib-2.0` / cargo test. That skip is already on `origin/main`; Ubuntu `unit-tests` is green.

## Fix

- Split the upgrade-lab assertion instead of adding an eslint-baseline exemption
- Strip CR from `tar -tf` listings; mock `process.platform` to `linux` for POSIX process-group tests
- Close sqlite and swallow leftover Windows `EPERM` on temp cleanup (existing pattern)
- Keep the `@jinn/plugin-sdk` barrel as a **dynamic** import, and lazy-load Talk screen-context only when Talk is on

Measured initial path after the Talk-context split: **189999 B gzip** (budget 195000).

## Verify

- `pnpm exec eslint` on the edited files
- targeted vitest for snapshot / antigravity / config-revision / org-api / plugin-sdk / client-providers
- `pnpm --filter @jinn/web perf:budget` after a web build

Do not merge until CI `all-checks-pass` is green on this PR.