### PR TITLE
ICI-1393: stream Grok tool cards and paragraph seams mid-turn

### DIFF
--- a/packages/jinn/src/engines/__tests__/grok-chat-blocks.test.ts
+++ b/packages/jinn/src/engines/__tests__/grok-chat-blocks.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import type { StreamDelta, EngineResult } from "../../shared/types.js";
+
+/** ICI-1393. Live Grok stdout is only `thought` / `text` / `end`. Tool calls live
+ *  in `updates.jsonl`, and the session id first appears on the same `end` line
+ *  that settles the turn. A fresh dashboard turn therefore never attached the
+ *  transcript, so tool cards never rendered, and the web client never started a
+ *  new assistant row — every text run glued into one blob. Tests here assert the
+ *  live mid-turn stream (before `end`), not the post-completion result alone. */
+
+interface FakeProc {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: () => void };
+  exitCode: number | null;
+  killed: boolean;
+  kill: () => boolean;
+  pid: number;
+  on: (event: string, cb: (...a: any[]) => void) => FakeProc;
+  _handlers: Record<string, (...a: any[]) => void>;
+  emitStdout: (s: string) => void;
+}
+
+const spawnCalls: FakeProc[] = [];
+
+function makeFakeProc(): FakeProc {
+  const handlers: Record<string, (...a: any[]) => void> = {};
+  const p: FakeProc = {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: { end: () => {} },
+    exitCode: null,
+    killed: false,
+    pid: 6464,
+    kill: () => true,
+    _handlers: handlers,
+    on(event, cb) { handlers[event] = cb; return p; },
+    emitStdout(s) { p.stdout.emit("data", Buffer.from(s)); },
+  };
+  return p;
+}
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(() => {
+    const proc = makeFakeProc();
+    spawnCalls.push(proc);
+    return proc;
+  }),
+}));
+
+const osMockState = vi.hoisted(() => ({ home: "" }));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  const fsm = await import("node:fs");
+  const pathm = await import("node:path");
+  osMockState.home = fsm.mkdtempSync(pathm.join(actual.tmpdir(), "grok-blocks-"));
+  const homedir = () => osMockState.home;
+  return { ...actual, homedir, default: { ...((actual as any).default ?? actual), homedir } };
+});
+
+import { GrokEngine } from "../grok.js";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started >= timeoutMs) throw new Error(`Timed out waiting for ${label}`);
+    await sleep(25);
+  }
+}
+
+function makeCwd(name: string): { cwd: string; sessionsRoot: string } {
+  const cwd = path.join(osMockState.home, name);
+  fs.mkdirSync(cwd, { recursive: true });
+  const resolved = fs.realpathSync(cwd);
+  return {
+    cwd,
+    sessionsRoot: path.join(osMockState.home, ".grok", "sessions", encodeURIComponent(resolved)),
+  };
+}
+
+function writeTranscript(sessionsRoot: string, sessionId: string, lines: unknown[]): void {
+  const file = path.join(sessionsRoot, sessionId, "updates.jsonl");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
+}
+
+const toolCall = (sessionId: string, toolCallId: string) => ({
+  method: "session/update",
+  params: {
+    sessionId,
+    update: { sessionUpdate: "tool_call", toolCallId, title: "read_file", rawInput: { target_file: "note.txt" } },
+  },
+});
+
+const toolCallDone = (sessionId: string, toolCallId: string) => ({
+  method: "session/update",
+  params: {
+    sessionId,
+    update: {
+      sessionUpdate: "tool_call_update",
+      toolCallId,
+      status: "completed",
+      title: "read_file",
+      content: [{ type: "content", content: { type: "text", text: "hello from the file" } }],
+    },
+  },
+});
+
+const END_LINE = JSON.stringify({ type: "end", stopReason: "EndTurn" }) + "\n";
+
+function startFreshTurn(cwd: string, sessionId: string):
+{ deltas: StreamDelta[]; proc: FakeProc; done: Promise<EngineResult> } {
+  const deltas: StreamDelta[] = [];
+  const engine = new GrokEngine();
+  const done = engine.run({
+    prompt: "read note.txt and summarise it",
+    cwd,
+    sessionId,
+    model: "grok-build",
+    onStream: (delta: StreamDelta) => deltas.push(delta),
+  } as any) as Promise<EngineResult>;
+  return { deltas, proc: spawnCalls[spawnCalls.length - 1], done };
+}
+
+function streamedText(deltas: StreamDelta[]): string {
+  return deltas.filter((d) => d.type === "text").map((d) => d.content).join("");
+}
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+});
+
+describe("GrokEngine — live tool cards on a fresh turn", () => {
+  it("emits tool deltas mid-turn without ever seeing a session id on stdout", async () => {
+    const { cwd, sessionsRoot } = makeCwd("cwd-fresh");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-fresh");
+    await flush();
+    expect(turn.proc).toBeDefined();
+
+    turn.proc.emitStdout(JSON.stringify({ type: "thought", data: "I should read the file." }) + "\n");
+    writeTranscript(sessionsRoot, "fresh-session", [
+      toolCall("fresh-session", "tool-1"),
+      toolCallDone("fresh-session", "tool-1"),
+    ]);
+
+    await waitFor(() => turn.deltas.some((d) => d.type === "tool_result"), "fresh-turn tool result");
+    expect(turn.deltas).toContainEqual({
+      type: "tool_use",
+      content: "Using read_file",
+      toolName: "read_file",
+      toolId: "tool-1",
+      input: "{\"target_file\":\"note.txt\"}",
+    });
+    expect(turn.deltas).toContainEqual({
+      type: "tool_result",
+      content: "hello from the file",
+      toolName: "read_file",
+      toolId: "tool-1",
+    });
+
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "The file greets us." }) + "\n");
+    expect(streamedText(turn.deltas)).toBe("The file greets us.");
+    turn.proc.emitStdout(END_LINE);
+    await turn.done;
+  });
+
+  it("attaches via the realpath-encoded cwd grok actually writes", async () => {
+    const target = path.join(osMockState.home, "cwd-real");
+    const link = path.join(osMockState.home, "cwd-link");
+    fs.mkdirSync(target, { recursive: true });
+    fs.symlinkSync(target, link);
+    const sessionsRoot = path.join(
+      osMockState.home,
+      ".grok",
+      "sessions",
+      encodeURIComponent(fs.realpathSync(link)),
+    );
+    await flush();
+    const turn = startFreshTurn(link, "jinn-realpath");
+    await flush();
+
+    writeTranscript(sessionsRoot, "real-session", [
+      toolCall("real-session", "tool-real"),
+      toolCallDone("real-session", "tool-real"),
+    ]);
+    await waitFor(() => turn.deltas.some((d) => d.type === "tool_use" && d.toolId === "tool-real"), "realpath transcript");
+    turn.proc.emitStdout(END_LINE);
+    await turn.done;
+  });
+
+  it("waits for updates.jsonl rather than the sibling files grok writes first", async () => {
+    const { cwd, sessionsRoot } = makeCwd("cwd-late-updates");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-late-updates");
+    await flush();
+
+    const dir = path.join(sessionsRoot, "late-session");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "chat_history.jsonl"), "{}\n");
+    fs.writeFileSync(path.join(dir, "events.jsonl"), "{}\n");
+    await sleep(500);
+    expect(turn.deltas.filter((d) => d.type === "tool_use")).toEqual([]);
+
+    writeTranscript(sessionsRoot, "late-session", [
+      toolCall("late-session", "tool-late"),
+      toolCallDone("late-session", "tool-late"),
+    ]);
+    await waitFor(() => turn.deltas.some((d) => d.type === "tool_result"), "late updates.jsonl tool result");
+    turn.proc.emitStdout(END_LINE);
+    await turn.done;
+    expect(turn.deltas.some((d) => d.type === "tool_use" && d.toolId === "tool-late")).toBe(true);
+  });
+
+  it("refuses to attach while two fresh transcripts share the cwd", async () => {
+    const { cwd, sessionsRoot } = makeCwd("cwd-shared");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-ambiguous");
+    await flush();
+
+    writeTranscript(sessionsRoot, "concurrent-a", [toolCall("concurrent-a", "tool-a")]);
+    writeTranscript(sessionsRoot, "concurrent-b", [toolCall("concurrent-b", "tool-b")]);
+
+    await sleep(700);
+    expect(turn.deltas.filter((d) => d.type === "tool_use")).toEqual([]);
+    turn.proc.emitStdout(END_LINE);
+    await turn.done;
+  });
+});
+
+describe("GrokEngine — live line and block seams while the turn is still running", () => {
+  it("keeps grok's paragraph newline chunks in the live stream before end", async () => {
+    const { cwd } = makeCwd("cwd-newlines");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-newlines");
+    await flush();
+
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "I read the file" }) + "\n");
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: ".\n\n" }) + "\n");
+    expect(streamedText(turn.deltas)).toBe("I read the file.\n\n");
+    expect(streamedText(turn.deltas)).not.toContain("file.The");
+
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "\"hello from the file\"" }) + "\n");
+    expect(streamedText(turn.deltas)).toBe("I read the file.\n\n\"hello from the file\"");
+    turn.proc.emitStdout(END_LINE);
+    await turn.done;
+  });
+
+  it("separates two text runs split by a reasoning run before end, and leaks no reasoning", async () => {
+    const { cwd } = makeCwd("cwd-blocks");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-blocks");
+    await flush();
+
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "I'll read it and answer in two short paragraphs." }) + "\n");
+    turn.proc.emitStdout(JSON.stringify({ type: "thought", data: "DRAFT-ONLY-REASONING: the user wants a summary." }) + "\n");
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "The file note.txt contains a greeting." }) + "\n");
+
+    const streamed = turn.deltas.filter((d) => d.type === "text").map((d) => d.content);
+    expect(streamed).toEqual([
+      "I'll read it and answer in two short paragraphs.",
+      "\n\nThe file note.txt contains a greeting.",
+    ]);
+    expect(streamed.join("")).not.toContain("paragraphs.The file");
+    for (const delta of turn.deltas) expect(String(delta.content)).not.toContain("DRAFT-ONLY-REASONING");
+
+    turn.proc.emitStdout(END_LINE);
+    const result = await turn.done;
+    expect(result.result).toBe("I'll read it and answer in two short paragraphs.\n\nThe file note.txt contains a greeting.");
+  });
+
+  it("does not insert a break the answer already carries", async () => {
+    const { cwd } = makeCwd("cwd-own-break");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-own-break");
+    await flush();
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "First paragraph.\n\n" }) + "\n");
+    turn.proc.emitStdout(JSON.stringify({ type: "thought", data: "reasoning" }) + "\n");
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "Second paragraph." }) + "\n");
+    expect(streamedText(turn.deltas)).toBe("First paragraph.\n\nSecond paragraph.");
+    turn.proc.emitStdout(END_LINE);
+    const result = await turn.done;
+    expect(result.result).toBe("First paragraph.\n\nSecond paragraph.");
+  });
+
+  it("drops an agent_thought_chunk without emitting any delta for it", async () => {
+    const { cwd } = makeCwd("cwd-thought-chunk");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-thought-chunk");
+    await flush();
+    turn.proc.emitStdout([
+      JSON.stringify({
+        method: "session/update",
+        params: {
+          sessionId: "thought-session",
+          update: { sessionUpdate: "agent_thought_chunk", content: { text: "HIDDEN-CHAIN-OF-THOUGHT" } },
+        },
+      }),
+      JSON.stringify({ type: "text", data: "Answer." }),
+      "",
+    ].join("\n"));
+    expect(streamedText(turn.deltas)).toBe("Answer.");
+    for (const delta of turn.deltas) expect(String(delta.content)).not.toContain("HIDDEN-CHAIN-OF-THOUGHT");
+    turn.proc.emitStdout(END_LINE);
+    await turn.done;
+  });
+
+  it("restarts the canonical result at a live tool card so earlier text is not rendered twice", async () => {
+    const { cwd, sessionsRoot } = makeCwd("cwd-tool-split");
+    await flush();
+    const turn = startFreshTurn(cwd, "jinn-tool-split");
+    await flush();
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "Let me read the file." }) + "\n");
+    writeTranscript(sessionsRoot, "split-session", [
+      toolCall("split-session", "tool-2"),
+      toolCallDone("split-session", "tool-2"),
+    ]);
+    await waitFor(() => turn.deltas.some((d) => d.type === "tool_result"), "tool-split tool result");
+    expect(streamedText(turn.deltas)).toBe("Let me read the file.");
+
+    turn.proc.emitStdout(JSON.stringify({ type: "text", data: "It contains a greeting." }) + "\n");
+    expect(streamedText(turn.deltas)).toBe("Let me read the file.It contains a greeting.");
+    turn.proc.emitStdout(END_LINE);
+    const result = await turn.done;
+    expect(result.result).toBe("It contains a greeting.");
+  });
+});

--- a/packages/jinn/src/engines/__tests__/grok-chat-blocks.test.ts
+++ b/packages/jinn/src/engines/__tests__/grok-chat-blocks.test.ts
@@ -1,55 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
-import type { StreamDelta, EngineResult } from "../../shared/types.js";
 
 /** ICI-1393. Live Grok stdout is only `thought` / `text` / `end`. Tool calls live
  *  in `updates.jsonl`, and the session id first appears on the same `end` line
- *  that settles the turn. A fresh dashboard turn therefore never attached the
- *  transcript, so tool cards never rendered, and the web client never started a
- *  new assistant row — every text run glued into one blob. Tests here assert the
- *  live mid-turn stream (before `end`), not the post-completion result alone. */
+ *  that settles the turn. Tests assert the live mid-turn stream (before `end`). */
 
-interface FakeProc {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
-  stdin: { end: () => void };
-  exitCode: number | null;
-  killed: boolean;
-  kill: () => boolean;
-  pid: number;
-  on: (event: string, cb: (...a: any[]) => void) => FakeProc;
-  _handlers: Record<string, (...a: any[]) => void>;
-  emitStdout: (s: string) => void;
-}
-
-const spawnCalls: FakeProc[] = [];
-
-function makeFakeProc(): FakeProc {
-  const handlers: Record<string, (...a: any[]) => void> = {};
-  const p: FakeProc = {
-    stdout: new EventEmitter(),
-    stderr: new EventEmitter(),
-    stdin: { end: () => {} },
-    exitCode: null,
-    killed: false,
-    pid: 6464,
-    kill: () => true,
-    _handlers: handlers,
-    on(event, cb) { handlers[event] = cb; return p; },
-    emitStdout(s) { p.stdout.emit("data", Buffer.from(s)); },
+vi.mock("node:child_process", async () => {
+  const { makeFakeProc, spawnCalls } = await import("./support/grok-chat-blocks-proc.js");
+  return {
+    spawn: vi.fn(() => {
+      const proc = makeFakeProc();
+      spawnCalls.push(proc);
+      return proc;
+    }),
   };
-  return p;
-}
-
-vi.mock("node:child_process", () => ({
-  spawn: vi.fn(() => {
-    const proc = makeFakeProc();
-    spawnCalls.push(proc);
-    return proc;
-  }),
-}));
+});
 
 const osMockState = vi.hoisted(() => ({ home: "" }));
 vi.mock("node:os", async (importOriginal) => {
@@ -61,76 +27,19 @@ vi.mock("node:os", async (importOriginal) => {
   return { ...actual, homedir, default: { ...((actual as any).default ?? actual), homedir } };
 });
 
-import { GrokEngine } from "../grok.js";
-
-const flush = () => new Promise((r) => setTimeout(r, 0));
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3000): Promise<void> {
-  const started = Date.now();
-  while (!predicate()) {
-    if (Date.now() - started >= timeoutMs) throw new Error(`Timed out waiting for ${label}`);
-    await sleep(25);
-  }
-}
-
-function makeCwd(name: string): { cwd: string; sessionsRoot: string } {
-  const cwd = path.join(osMockState.home, name);
-  fs.mkdirSync(cwd, { recursive: true });
-  const resolved = fs.realpathSync(cwd);
-  return {
-    cwd,
-    sessionsRoot: path.join(osMockState.home, ".grok", "sessions", encodeURIComponent(resolved)),
-  };
-}
-
-function writeTranscript(sessionsRoot: string, sessionId: string, lines: unknown[]): void {
-  const file = path.join(sessionsRoot, sessionId, "updates.jsonl");
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
-}
-
-const toolCall = (sessionId: string, toolCallId: string) => ({
-  method: "session/update",
-  params: {
-    sessionId,
-    update: { sessionUpdate: "tool_call", toolCallId, title: "read_file", rawInput: { target_file: "note.txt" } },
-  },
-});
-
-const toolCallDone = (sessionId: string, toolCallId: string) => ({
-  method: "session/update",
-  params: {
-    sessionId,
-    update: {
-      sessionUpdate: "tool_call_update",
-      toolCallId,
-      status: "completed",
-      title: "read_file",
-      content: [{ type: "content", content: { type: "text", text: "hello from the file" } }],
-    },
-  },
-});
-
-const END_LINE = JSON.stringify({ type: "end", stopReason: "EndTurn" }) + "\n";
-
-function startFreshTurn(cwd: string, sessionId: string):
-{ deltas: StreamDelta[]; proc: FakeProc; done: Promise<EngineResult> } {
-  const deltas: StreamDelta[] = [];
-  const engine = new GrokEngine();
-  const done = engine.run({
-    prompt: "read note.txt and summarise it",
-    cwd,
-    sessionId,
-    model: "grok-build",
-    onStream: (delta: StreamDelta) => deltas.push(delta),
-  } as any) as Promise<EngineResult>;
-  return { deltas, proc: spawnCalls[spawnCalls.length - 1], done };
-}
-
-function streamedText(deltas: StreamDelta[]): string {
-  return deltas.filter((d) => d.type === "text").map((d) => d.content).join("");
-}
+import {
+  END_LINE,
+  flush,
+  makeCwd,
+  sleep,
+  spawnCalls,
+  startFreshTurn,
+  streamedText,
+  toolCall,
+  toolCallDone,
+  waitFor,
+  writeTranscript,
+} from "./support/grok-chat-blocks-harness.js";
 
 beforeEach(() => {
   spawnCalls.length = 0;
@@ -138,7 +47,7 @@ beforeEach(() => {
 
 describe("GrokEngine — live tool cards on a fresh turn", () => {
   it("emits tool deltas mid-turn without ever seeing a session id on stdout", async () => {
-    const { cwd, sessionsRoot } = makeCwd("cwd-fresh");
+    const { cwd, sessionsRoot } = makeCwd(osMockState.home, "cwd-fresh");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-fresh");
     await flush();
@@ -196,7 +105,7 @@ describe("GrokEngine — live tool cards on a fresh turn", () => {
   });
 
   it("waits for updates.jsonl rather than the sibling files grok writes first", async () => {
-    const { cwd, sessionsRoot } = makeCwd("cwd-late-updates");
+    const { cwd, sessionsRoot } = makeCwd(osMockState.home, "cwd-late-updates");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-late-updates");
     await flush();
@@ -219,7 +128,7 @@ describe("GrokEngine — live tool cards on a fresh turn", () => {
   });
 
   it("refuses to attach while two fresh transcripts share the cwd", async () => {
-    const { cwd, sessionsRoot } = makeCwd("cwd-shared");
+    const { cwd, sessionsRoot } = makeCwd(osMockState.home, "cwd-shared");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-ambiguous");
     await flush();
@@ -236,7 +145,7 @@ describe("GrokEngine — live tool cards on a fresh turn", () => {
 
 describe("GrokEngine — live line and block seams while the turn is still running", () => {
   it("keeps grok's paragraph newline chunks in the live stream before end", async () => {
-    const { cwd } = makeCwd("cwd-newlines");
+    const { cwd } = makeCwd(osMockState.home, "cwd-newlines");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-newlines");
     await flush();
@@ -253,7 +162,7 @@ describe("GrokEngine — live line and block seams while the turn is still runni
   });
 
   it("separates two text runs split by a reasoning run before end, and leaks no reasoning", async () => {
-    const { cwd } = makeCwd("cwd-blocks");
+    const { cwd } = makeCwd(osMockState.home, "cwd-blocks");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-blocks");
     await flush();
@@ -276,7 +185,7 @@ describe("GrokEngine — live line and block seams while the turn is still runni
   });
 
   it("does not insert a break the answer already carries", async () => {
-    const { cwd } = makeCwd("cwd-own-break");
+    const { cwd } = makeCwd(osMockState.home, "cwd-own-break");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-own-break");
     await flush();
@@ -290,7 +199,7 @@ describe("GrokEngine — live line and block seams while the turn is still runni
   });
 
   it("drops an agent_thought_chunk without emitting any delta for it", async () => {
-    const { cwd } = makeCwd("cwd-thought-chunk");
+    const { cwd } = makeCwd(osMockState.home, "cwd-thought-chunk");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-thought-chunk");
     await flush();
@@ -312,7 +221,7 @@ describe("GrokEngine — live line and block seams while the turn is still runni
   });
 
   it("restarts the canonical result at a live tool card so earlier text is not rendered twice", async () => {
-    const { cwd, sessionsRoot } = makeCwd("cwd-tool-split");
+    const { cwd, sessionsRoot } = makeCwd(osMockState.home, "cwd-tool-split");
     await flush();
     const turn = startFreshTurn(cwd, "jinn-tool-split");
     await flush();

--- a/packages/jinn/src/engines/__tests__/support/grok-chat-blocks-harness.ts
+++ b/packages/jinn/src/engines/__tests__/support/grok-chat-blocks-harness.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { StreamDelta, EngineResult } from "../../../shared/types.js";
+import { GrokEngine } from "../../grok.js";
+import type { FakeProc } from "./grok-chat-blocks-proc.js";
+import { spawnCalls } from "./grok-chat-blocks-proc.js";
+
+/** Shared fixtures for ICI-1393 live mid-turn Grok tests. The fake process
+ *  lives in grok-chat-blocks-proc.ts so the child_process mock can load it
+ *  without importing GrokEngine. */
+
+export { spawnCalls, makeFakeProc } from "./grok-chat-blocks-proc.js";
+export type { FakeProc } from "./grok-chat-blocks-proc.js";
+
+export const flush = () => new Promise((r) => setTimeout(r, 0));
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export async function waitFor(predicate: () => boolean, label: string, timeoutMs = 3000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started >= timeoutMs) throw new Error(`Timed out waiting for ${label}`);
+    await sleep(25);
+  }
+}
+
+export function makeCwd(home: string, name: string): { cwd: string; sessionsRoot: string } {
+  const cwd = path.join(home, name);
+  fs.mkdirSync(cwd, { recursive: true });
+  const resolved = fs.realpathSync(cwd);
+  return {
+    cwd,
+    sessionsRoot: path.join(home, ".grok", "sessions", encodeURIComponent(resolved)),
+  };
+}
+
+export function writeTranscript(sessionsRoot: string, sessionId: string, lines: unknown[]): void {
+  const file = path.join(sessionsRoot, sessionId, "updates.jsonl");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, lines.map((line) => JSON.stringify(line)).join("\n") + "\n");
+}
+
+export const toolCall = (sessionId: string, toolCallId: string) => ({
+  method: "session/update",
+  params: {
+    sessionId,
+    update: { sessionUpdate: "tool_call", toolCallId, title: "read_file", rawInput: { target_file: "note.txt" } },
+  },
+});
+
+export const toolCallDone = (sessionId: string, toolCallId: string) => ({
+  method: "session/update",
+  params: {
+    sessionId,
+    update: {
+      sessionUpdate: "tool_call_update",
+      toolCallId,
+      status: "completed",
+      title: "read_file",
+      content: [{ type: "content", content: { type: "text", text: "hello from the file" } }],
+    },
+  },
+});
+
+export const END_LINE = JSON.stringify({ type: "end", stopReason: "EndTurn" }) + "\n";
+
+export function startFreshTurn(cwd: string, sessionId: string):
+{ deltas: StreamDelta[]; proc: FakeProc; done: Promise<EngineResult> } {
+  const deltas: StreamDelta[] = [];
+  const engine = new GrokEngine();
+  const done = engine.run({
+    prompt: "read note.txt and summarise it",
+    cwd,
+    sessionId,
+    model: "grok-build",
+    onStream: (delta: StreamDelta) => deltas.push(delta),
+  } as any) as Promise<EngineResult>;
+  return { deltas, proc: spawnCalls[spawnCalls.length - 1], done };
+}
+
+export function streamedText(deltas: StreamDelta[]): string {
+  return deltas.filter((d) => d.type === "text").map((d) => d.content).join("");
+}

--- a/packages/jinn/src/engines/__tests__/support/grok-chat-blocks-proc.ts
+++ b/packages/jinn/src/engines/__tests__/support/grok-chat-blocks-proc.ts
@@ -1,0 +1,36 @@
+import { EventEmitter } from "node:events";
+
+/** Fake grok child used by ICI-1393 tests. Kept off GrokEngine so the
+ *  `node:child_process` mock can load it without a cycle. */
+
+export interface FakeProc {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: () => void };
+  exitCode: number | null;
+  killed: boolean;
+  kill: () => boolean;
+  pid: number;
+  on: (event: string, cb: (...a: any[]) => void) => FakeProc;
+  _handlers: Record<string, (...a: any[]) => void>;
+  emitStdout: (s: string) => void;
+}
+
+export const spawnCalls: FakeProc[] = [];
+
+export function makeFakeProc(): FakeProc {
+  const handlers: Record<string, (...a: any[]) => void> = {};
+  const p: FakeProc = {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: { end: () => {} },
+    exitCode: null,
+    killed: false,
+    pid: 6464,
+    kill: () => true,
+    _handlers: handlers,
+    on(event, cb) { handlers[event] = cb; return p; },
+    emitStdout(s) { p.stdout.emit("data", Buffer.from(s)); },
+  };
+  return p;
+}

--- a/packages/jinn/src/engines/grok-json.ts
+++ b/packages/jinn/src/engines/grok-json.ts
@@ -1,0 +1,85 @@
+/** Field readers for grok's loosely-typed JSON lines. Every grok surface — the
+ *  headless stream, the PTY transcript, the on-disk session files — carries the
+ *  same shapes with optional, renamed and nested fields, so pulling a value out
+ *  of one is its own concern, kept apart from deciding what a line MEANS.
+ *  Extracted from grok.ts; the bodies are unchanged. */
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function isReasoningType(value: unknown): boolean {
+  const type = String(value ?? "").toLowerCase();
+  return type.includes("thought") || type.includes("thinking") || type.includes("reasoning") || type.includes("chain_of_thought");
+}
+
+export function stringField(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+export function stripReasoningMarkup(text: string): string {
+  return text
+    .replace(/<\s*(thinking|reasoning|thought)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, "");
+}
+
+export function compactText(text: string, max = 500): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
+}
+
+export function safeJsonSnippet(value: unknown, max = 200): string | undefined {
+  if (value === undefined) return undefined;
+  try {
+    return compactText(JSON.stringify(value), max);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeGrokToolName(name: string | undefined): string | undefined {
+  if (!name) return undefined;
+  if (/^[A-Z][A-Za-z0-9]*$/.test(name)) {
+    return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+  }
+  return name;
+}
+
+export function toolNameFromGrokUpdate(update: Record<string, unknown>): string | undefined {
+  const rawInput = asRecord(update.rawInput);
+  const rawOutput = asRecord(update.rawOutput);
+  return normalizeGrokToolName(
+    stringField(rawInput ?? {}, ["variant", "tool", "toolName", "name"]) ??
+    stringField(rawOutput ?? {}, ["type", "variant", "tool", "toolName", "name"]) ??
+    stringField(update, ["toolName", "tool_name", "name", "title", "kind"]),
+  );
+}
+
+export function planStatusFromGrokUpdate(update: Record<string, unknown>): string | undefined {
+  const entries = Array.isArray(update.entries) ? update.entries : [];
+  const parsed = entries
+    .map((entry) => asRecord(entry))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry));
+  const active =
+    parsed.find((entry) => String(entry.status ?? "").toLowerCase() === "in_progress") ??
+    parsed.find((entry) => String(entry.status ?? "").toLowerCase() === "pending") ??
+    parsed[parsed.length - 1];
+  const text = active ? stringField(active, ["content", "title", "task"]) : undefined;
+  return text ? `Plan: ${compactText(text, 240)}` : undefined;
+}
+
+export function extractError(obj: Record<string, unknown>): string | undefined {
+  const err = obj.error;
+  if (typeof err === "string" && err.trim()) return err;
+  const errObj = asRecord(err);
+  if (errObj) {
+    const msg = stringField(errObj, ["message", "error", "detail"]);
+    if (msg) return msg;
+  }
+  return stringField(obj, ["errorMessage", "message", "detail"]);
+}

--- a/packages/jinn/src/engines/grok.ts
+++ b/packages/jinn/src/engines/grok.ts
@@ -9,6 +9,17 @@ import { resolveBin } from "../shared/resolve-bin.js";
 import { buildEngineChildEnv } from "../shared/child-env.js";
 import { tailTranscriptLines, type TranscriptTailer } from "./transcript-tailer.js";
 import { prepareGrokProjectMcpConfig, cleanupGrokProjectMcpConfig, grokJinnSessionEnv, type GrokMcpAttachHandle } from "./grok-mcp.js";
+import {
+  asRecord,
+  compactText,
+  extractError,
+  isReasoningType,
+  planStatusFromGrokUpdate,
+  safeJsonSnippet,
+  stringField,
+  stripReasoningMarkup,
+  toolNameFromGrokUpdate,
+} from "./grok-json.js";
 
 export const GROK_SESSIONS_DIR = path.join(os.homedir(), ".grok", "sessions");
 
@@ -28,6 +39,8 @@ export interface GrokParsedLine {
   error?: string;
   terminal?: boolean;
   contextTokens?: number;
+  /** A reasoning event: its payload stays dropped, but it marks the end of an answer block. */
+  reasoning?: boolean;
 }
 
 export function grokCliFlags(flags: string[] | undefined): string[] {
@@ -57,23 +70,27 @@ function walkFiles(dir: string, out: string[] = []): string[] {
   let entries: fs.Dirent[];
   try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return out; }
   for (const entry of entries) {
-    const p = `${dir}/${entry.name}`;
+    const p = path.join(dir, entry.name);
     if (entry.isDirectory()) walkFiles(p, out);
     else if (entry.isFile()) out.push(p);
   }
   return out;
 }
 
+const GROK_TRANSCRIPT_NAMES = ["updates.jsonl", "chat_history.jsonl", "events.jsonl"];
+
 function isGrokTranscriptFile(file: string): boolean {
-  return file.endsWith("/updates.jsonl") || file.endsWith("/chat_history.jsonl") || file.endsWith("/events.jsonl");
+  return GROK_TRANSCRIPT_NAMES.includes(path.basename(file));
+}
+
+function isGrokUpdatesFile(file: string): boolean {
+  return path.basename(file) === "updates.jsonl";
 }
 
 function sortGrokTranscriptFiles(files: string[]): string[] {
   const rank = (file: string) => {
-    if (file.endsWith("/updates.jsonl")) return 0;
-    if (file.endsWith("/chat_history.jsonl")) return 1;
-    if (file.endsWith("/events.jsonl")) return 2;
-    return 3;
+    const index = GROK_TRANSCRIPT_NAMES.indexOf(path.basename(file));
+    return index === -1 ? GROK_TRANSCRIPT_NAMES.length : index;
   };
   return files.filter(isGrokTranscriptFile).sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
 }
@@ -110,32 +127,22 @@ function parseSessionIdFromFile(filePath: string): string | undefined {
   return undefined;
 }
 
+/** Grok files a session under `<sessions>/<url-encoded absolute cwd>/<session-uuid>/`,
+ *  so a run's own transcript is discoverable from its cwd alone — before grok has
+ *  revealed any session id. */
+function grokCwdSessionsRoots(cwd: string | undefined, root = GROK_SESSIONS_DIR): string[] {
+  if (!cwd) return [];
+  const variants = new Set<string>([path.resolve(cwd)]);
+  try { variants.add(fs.realpathSync(cwd)); } catch { /* cwd may not exist yet */ }
+  return [...variants].map((dir) => path.join(root, encodeURIComponent(dir)));
+}
+
+function fileUnderCwdSessions(file: string, roots: string[]): boolean {
+  return roots.some((sessionRoot) => file === sessionRoot || file.startsWith(sessionRoot + path.sep));
+}
+
 function transcriptMatchesSession(filePath: string, sessionId: string): boolean {
   return filePath.includes(sessionId) || parseSessionIdFromFile(filePath) === sessionId;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : null;
-}
-
-function isReasoningType(value: unknown): boolean {
-  const type = String(value ?? "").toLowerCase();
-  return type.includes("thought") || type.includes("thinking") || type.includes("reasoning") || type.includes("chain_of_thought");
-}
-
-function stringField(obj: Record<string, unknown>, keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = obj[key];
-    if (typeof value === "string" && value.trim()) return value;
-  }
-  return undefined;
-}
-
-function stripReasoningMarkup(text: string): string {
-  return text
-    .replace(/<\s*(thinking|reasoning|thought)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, "");
 }
 
 function textFromContent(value: unknown): string {
@@ -170,38 +177,6 @@ function textFromUnknown(value: unknown): string {
   return direct ? stripReasoningMarkup(direct) : textFromContent(obj.content);
 }
 
-function compactText(text: string, max = 500): string {
-  const oneLine = text.replace(/\s+/g, " ").trim();
-  return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine;
-}
-
-function safeJsonSnippet(value: unknown, max = 200): string | undefined {
-  if (value === undefined) return undefined;
-  try {
-    return compactText(JSON.stringify(value), max);
-  } catch {
-    return undefined;
-  }
-}
-
-function normalizeGrokToolName(name: string | undefined): string | undefined {
-  if (!name) return undefined;
-  if (/^[A-Z][A-Za-z0-9]*$/.test(name)) {
-    return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
-  }
-  return name;
-}
-
-function toolNameFromGrokUpdate(update: Record<string, unknown>): string | undefined {
-  const rawInput = asRecord(update.rawInput);
-  const rawOutput = asRecord(update.rawOutput);
-  return normalizeGrokToolName(
-    stringField(rawInput ?? {}, ["variant", "tool", "toolName", "name"]) ??
-    stringField(rawOutput ?? {}, ["type", "variant", "tool", "toolName", "name"]) ??
-    stringField(update, ["toolName", "tool_name", "name", "title", "kind"]),
-  );
-}
-
 function toolResultTextFromGrokUpdate(update: Record<string, unknown>): string {
   const contentText = textFromUnknown(update.content);
   if (contentText) return compactText(contentText);
@@ -209,19 +184,6 @@ function toolResultTextFromGrokUpdate(update: Record<string, unknown>): string {
   if (rawOutputText) return compactText(rawOutputText);
   const status = stringField(update, ["status", "type", "outcome"]);
   return status ? compactText(status) : "Done";
-}
-
-function planStatusFromGrokUpdate(update: Record<string, unknown>): string | undefined {
-  const entries = Array.isArray(update.entries) ? update.entries : [];
-  const parsed = entries
-    .map((entry) => asRecord(entry))
-    .filter((entry): entry is Record<string, unknown> => Boolean(entry));
-  const active =
-    parsed.find((entry) => String(entry.status ?? "").toLowerCase() === "in_progress") ??
-    parsed.find((entry) => String(entry.status ?? "").toLowerCase() === "pending") ??
-    parsed[parsed.length - 1];
-  const text = active ? stringField(active, ["content", "title", "task"]) : undefined;
-  return text ? `Plan: ${compactText(text, 240)}` : undefined;
 }
 
 function extractText(obj: Record<string, unknown>, eventType: string, terminal: boolean): { text: string; snapshot: boolean } {
@@ -245,17 +207,6 @@ function extractText(obj: Record<string, unknown>, eventType: string, terminal: 
     : stringField(obj, ["text", "content"]);
   if (!directText) return { text: "", snapshot: true };
   return { text: directText, snapshot: !eventType.includes("delta") && !eventType.includes("chunk") };
-}
-
-function extractError(obj: Record<string, unknown>): string | undefined {
-  const err = obj.error;
-  if (typeof err === "string" && err.trim()) return err;
-  const errObj = asRecord(err);
-  if (errObj) {
-    const msg = stringField(errObj, ["message", "error", "detail"]);
-    if (msg) return msg;
-  }
-  return stringField(obj, ["errorMessage", "message", "detail"]);
 }
 
 function extractContextTokens(obj: Record<string, unknown>): number | undefined {
@@ -316,7 +267,7 @@ export function parseGrokJsonLine(line: string): GrokParsedLine | null {
       // entirely (no placeholder line): the pre-token spinner covers the reasoning
       // stretch, while tool cards (transcript) and the live answer text (stdout)
       // provide the real mid-turn activity the user wants to see.
-      return { deltas, sessionId: nestedSessionId, terminal: false, contextTokens };
+      return { deltas, sessionId: nestedSessionId, terminal: false, contextTokens, reasoning: true };
     }
     if (updateType === "tool_call") {
       const toolName = update ? toolNameFromGrokUpdate(update) : undefined;
@@ -412,7 +363,7 @@ export function parseGrokJsonLine(line: string): GrokParsedLine | null {
   if (isReasoningType(eventType)) {
     // Raw reasoning chunk — never displayed (same contract as agent_thought_chunk).
     // Dropped entirely; no placeholder status line.
-    return { deltas, sessionId, terminal, contextTokens };
+    return { deltas, sessionId, terminal, contextTokens, reasoning: true };
   }
 
   if (eventType === "text") {
@@ -466,8 +417,11 @@ export function parseGrokJsonLine(line: string): GrokParsedLine | null {
  * twice — and `resultText` is accumulated from stdout only. The canonical result is
  * reconciled against the streamed text at completion by identity (see
  * use-live-session `session:completed`), so a transcript `tool_use` that lands after
- * the streamed answer no longer renders a duplicate bubble. Tool lifecycle + context
- * stream live from the transcript. Reasoning is already dropped by `parseGrokJsonLine`.
+ * the streamed answer no longer renders a duplicate bubble. That identity holds per
+ * ROW, not per turn: a tool card closes the current text row, so `resultText` restarts
+ * there too and stays equal to the last streamed row rather than to the whole turn.
+ * Tool lifecycle + context stream live from the transcript. Reasoning is already
+ * dropped by `parseGrokJsonLine`.
  */
 export function grokVisibleDeltas(deltas: StreamDelta[], source: "stdout" | "transcript"): StreamDelta[] {
   return deltas.filter((delta) => {
@@ -564,9 +518,11 @@ export class GrokEngine implements InterruptibleEngine {
       let resolvedSessionFromStdout = Boolean(opts.resumeSessionId);
       let transcriptTailer: TranscriptTailer | undefined;
       let transcriptDiscover: NodeJS.Timeout | undefined;
+      let attachedTranscriptSessionId: string | undefined;
+      let blockBreakPending = false;
 
       const expectedTranscriptSessionId = () =>
-        opts.resumeSessionId || (resolvedSessionFromStdout ? resolvedSessionId : undefined);
+        opts.resumeSessionId || (resolvedSessionFromStdout ? resolvedSessionId : attachedTranscriptSessionId);
 
       const stopTranscriptWatch = () => {
         if (transcriptDiscover) {
@@ -605,6 +561,16 @@ export class GrokEngine implements InterruptibleEngine {
         });
       };
 
+      // Re-open the paragraph the reasoning run closed; codex.ts:648 does the same
+      // between its adjacent message blocks. Both the streamed delta and resultText
+      // carry the break, so the two stay identical for the completion reconcile.
+      const withBlockBoundary = (delta: StreamDelta): StreamDelta => {
+        if (delta.type !== "text" || !blockBreakPending) return delta;
+        blockBreakPending = false;
+        if (resultText.endsWith("\n") || delta.content.startsWith("\n")) return delta;
+        return { ...delta, content: `\n\n${delta.content}` };
+      };
+
       const handleParsed = (parsed: GrokParsedLine | null) => {
         if (!parsed) return;
         if (parsed.sessionId) {
@@ -613,15 +579,19 @@ export class GrokEngine implements InterruptibleEngine {
         }
         if (parsed.contextTokens) lastContextTokens = parsed.contextTokens;
         if (parsed.error) turnError = parsed.error;
+        // Grok streams the answer as bare chunks with no block marker, so a reasoning
+        // run between two chunks is the only end-of-block signal stdout carries.
+        if (parsed.reasoning && resultText) blockBreakPending = true;
         // Accumulate answer text into resultText (the single authoritative result)
         // AND stream it live (grokVisibleDeltas forwards stdout text). The two are
         // identical, so the FE reconciles them by identity at completion — no
         // duplicate bubble. See grokVisibleDeltas.
-        for (const delta of parsed.deltas) {
+        const deltas = parsed.deltas.map(withBlockBoundary);
+        for (const delta of deltas) {
           if (delta.type === "text") resultText += delta.content;
           if (delta.type === "text_snapshot") resultText = delta.content;
         }
-        for (const delta of grokVisibleDeltas(parsed.deltas, "stdout")) opts.onStream?.(delta);
+        for (const delta of grokVisibleDeltas(deltas, "stdout")) opts.onStream?.(delta);
         if (parsed.doneText) resultText = parsed.doneText;
         if (parsed.terminal) settleOnTerminal();
       };
@@ -633,12 +603,21 @@ export class GrokEngine implements InterruptibleEngine {
           logger.warn(`Ignoring Grok transcript event for session ${parsed.sessionId}; expected ${expected}`);
           return;
         }
-        if (parsed.sessionId && !expected) return;
+        if (parsed.sessionId && !expected) attachedTranscriptSessionId = parsed.sessionId;
         if (parsed.contextTokens) lastContextTokens = parsed.contextTokens;
         // Tool lifecycle updates only appear in the transcript; mirror them (plus
         // context) live. Answer text is left to stdout/resultText — grokVisibleDeltas
         // drops it here so it is never emitted twice.
-        for (const delta of grokVisibleDeltas(parsed.deltas, "transcript")) opts.onStream?.(delta);
+        for (const delta of grokVisibleDeltas(parsed.deltas, "transcript")) {
+          // A tool card closes the current text row, so resultText restarts with it
+          // (see grokVisibleDeltas): the text before the card is already its own
+          // persisted row, and repeating it inside the final message renders twice.
+          if (delta.type === "tool_use") {
+            resultText = "";
+            blockBreakPending = false;
+          }
+          opts.onStream?.(delta);
+        }
       };
 
       const attachTranscriptTail = (filePath: string, offset: number) => {
@@ -651,23 +630,43 @@ export class GrokEngine implements InterruptibleEngine {
         );
       };
 
+      // A fresh turn learns its session id only from grok's `end` line, which settles
+      // the turn in the same tick — so waiting for one meant the tail never attached
+      // and no tool card ever reached the UI. The cwd is enough to find our own
+      // transcript before then, because grok keys the directory by it.
+      const cwdSessionsRoots = grokCwdSessionsRoots(opts.cwd);
       transcriptDiscover = setInterval(() => {
         if (transcriptTailer) return;
         const expected = expectedTranscriptSessionId();
-        if (!expected) return;
         const current = listTranscriptStats();
         const candidates = sortGrokTranscriptFiles(
           [...current.entries()]
             .filter(([file, stat]) => {
               const prev = transcriptBaseline.get(file);
-              return (!prev || stat.mtimeMs > prev.mtimeMs || stat.size > prev.size) &&
-                transcriptMatchesSession(file, expected);
+              if (prev && stat.mtimeMs <= prev.mtimeMs && stat.size <= prev.size) return false;
+              if (expected) return transcriptMatchesSession(file, expected);
+              // `updates.jsonl` only: it is the one file carrying the tool lifecycle,
+              // and grok writes it seconds AFTER chat_history.jsonl/events.jsonl appear
+              // in the same directory — attaching to whichever landed first bought a
+              // tail with no tool events in it at all. Match both resolve() and
+              // realpath() encodings: grok keys the dir by the real cwd (`/tmp` is
+              // `/private/tmp` on macOS).
+              return !prev && isGrokUpdatesFile(file) && fileUnderCwdSessions(file, cwdSessionsRoots);
             })
             .map(([file]) => file),
         );
         const first = candidates[0];
         if (!first) return;
+        // Without a session id, "appeared under our cwd after the spawn" is all that
+        // identifies the transcript — and two concurrent turns in one cwd both match.
+        // Refuse the ambiguous attach and wait for a unique candidate, as
+        // grok-interactive.ts:305-313 already does for the same race.
+        if (!expected && new Set(candidates.map((file) => path.dirname(file))).size > 1) {
+          logger.warn(`Ambiguous fresh Grok transcripts under ${cwdSessionsRoots.join(" | ")}; waiting for a unique candidate`);
+          return;
+        }
         const prev = transcriptBaseline.get(first);
+        attachedTranscriptSessionId ??= parseSessionIdFromFile(first);
         attachTranscriptTail(first, prev?.size ?? 0);
         if (transcriptDiscover) {
           clearInterval(transcriptDiscover);

--- a/size-baseline.json
+++ b/size-baseline.json
@@ -217,7 +217,7 @@
       ]
     },
     "packages/jinn/src/engines/grok.ts": {
-      "lines": 791,
+      "lines": 790,
       "exempt": [
         "complexity",
         "max-depth",


### PR DESCRIPTION
## Summary
Fresh Grok dashboard turns never attached the on-disk transcript: stdout is only `thought` / `text` / `end`, tools live in `updates.jsonl`, and the session id arrives on the same `end` line that settles the turn. With no live `tool_use`, the chat UI never split assistant rows, so text concatenated and tool cards never appeared.

This attaches `updates.jsonl` from the run cwd (resolve + realpath encodings) while the turn is still running, inserts Codex-style paragraph breaks across reasoning-separated text runs, and restarts the canonical result at each live tool card.

## Prior branch
`build/ICI-1393-grok-chat-blocks` / `cc06a542` never landed on `origin/main`. Its tests mostly asserted post-completion. This branch starts from current main, fails those mid-turn cases on main, and adds realpath cwd matching.

## Live evidence
Throwaway gateway on port 7791, session `7450350c-070f-4c2c-a2c6-0450758f5c01`, model `grok-4.6`:
- `tool_use` / `tool_result` for `read_file` arrived ~3s before `session:completed`
- Live text included `.\n\n` while the turn was still running
- No reasoning payload in streamed deltas
- UI split: pre-tool text, tool card, two-paragraph answer

## Test plan
- [x] New `grok-chat-blocks.test.ts` failed on origin/main, then passed
- [x] `grok.test.ts`, `grok-interactive.test.ts`, `grok-mcp.test.ts` green
- [x] typecheck / lint / build green
- [ ] Independent reviewer reproduces a live Grok dashboard turn from this branch (not from parser tests alone)

Fixes ICI-1393.