### PR TITLE
fix(chat): restore mobile new-chat picker and center header chips (ICI-1383)

### DIFF
--- a/packages/web/src/components/chat/__tests__/chat-header-title-center.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-header-title-center.test.tsx
@@ -88,15 +88,43 @@ describe('mobile chat header title centring', () => {
     expect(title.className).toContain('text-center')
   })
 
-  it('lets the mobile working set size against its real neighbouring controls', () => {
+  it('centres the working set on the header when the actions are the wider cluster', () => {
+    const row = renderNavBar({
+      backWidth: BARE_BACK_WIDTH,
+      title: 'Ignored while the working set is present',
+      mobileWorkingSet: true,
+    })
+    expect(sideTracks(row)).toEqual([`${ACTIONS_WIDTH}px`, `${ACTIONS_WIDTH}px`])
+  })
+
+  it('centres the working set on the header when a labelled back is the wider cluster', () => {
     const row = renderNavBar({
       backWidth: LABELLED_BACK_WIDTH,
       title: 'Ignored while the working set is present',
       backTo: 'Parent',
       mobileWorkingSet: true,
     })
+    expect(sideTracks(row)).toEqual([`${LABELLED_BACK_WIDTH}px`, `${LABELLED_BACK_WIDTH}px`])
+  })
 
-    expect(row.style.gridTemplateColumns).toBe('')
-    expect(row.className).toContain('grid-cols-[auto_minmax(0,1fr)_auto]')
+  // Mirroring the back control onto the right track spends its width twice, so a
+  // labelled back keeps a tighter cap while the chips hold the middle — four
+  // 36px chips plus gaps need 156px, and 27vw a side leaves that intact at 390px.
+  it('caps a labelled back control tighter while the working set holds the middle', () => {
+    const withChips = renderNavBar({
+      backWidth: LABELLED_BACK_WIDTH,
+      title: 'Ignored while the working set is present',
+      backTo: 'Parent',
+      mobileWorkingSet: true,
+    })
+    const withTitle = renderNavBar({
+      backWidth: LABELLED_BACK_WIDTH,
+      title: 'Quarterly infrastructure migration planning and rollout review',
+      backTo: 'Parent',
+    })
+    const back = (row: HTMLElement) => (row.firstElementChild as HTMLElement).className
+
+    expect(back(withChips)).toContain('max-w-[27vw]')
+    expect(back(withTitle)).toContain('max-w-[34vw]')
   })
 })

--- a/packages/web/src/components/chat/__tests__/chat-header-title-center.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-header-title-center.test.tsx
@@ -1,7 +1,13 @@
+import { type ReactNode } from 'react'
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { render } from '@testing-library/react'
 
+import { MobileWorkingSetNav } from '@/routes/chat/mobile-working-set-nav'
 import { ChatHeaderPills } from '../chat-tabs'
+
+vi.mock('@/components/ui/employee-avatar', () => ({
+  EmployeeAvatar: ({ name }: { name: string }) => <span data-avatar={name}>{name}</span>,
+}))
 
 // The mobile nav bar centres its title on the HEADER, not on the gap between the
 // controls, by locking both side tracks to the width of the wider cluster. jsdom
@@ -10,19 +16,25 @@ import { ChatHeaderPills } from '../chat-tabs'
 // and read back the grid template the component derives from them.
 
 const ACTIONS_WIDTH = 72
+const ONE_ACTION_WIDTH = 36
 const BARE_BACK_WIDTH = 36
 const LABELLED_BACK_WIDTH = 132
+const HEADER_WIDTH = 390
+const HEADER_PAD_X = 12 // px-1.5 on both sides
+const HEADER_COL_GAPS = 8 // gap-1 between the three tracks
+const CHIP = 36
+const CHIP_GAP = 4
 
 // Stand in for layout: the back control reports `backWidth`, the actions cluster
 // (identified by the compose button it wraps, not by the classes under test)
-// reports ACTIONS_WIDTH, everything else zero.
-function stubClusterWidths(backWidth: number) {
+// reports `actionWidth`, everything else zero.
+function stubClusterWidths(backWidth: number, actionWidth = ACTIONS_WIDTH) {
   const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')!
   Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
     configurable: true,
     get(this: HTMLElement) {
       if (this.matches('button[aria-label^="Back to"]')) return backWidth
-      if (this.querySelector(':scope > button[aria-label="New chat"]')) return ACTIONS_WIDTH
+      if (this.querySelector(':scope > button[aria-label="New chat"]')) return actionWidth
       return 0
     },
   })
@@ -38,16 +50,20 @@ function renderNavBar(props: {
   backWidth: number
   title: string
   backTo?: string
-  mobileWorkingSet?: boolean
+  mobileWorkingSet?: boolean | ReactNode
+  actionWidth?: number
 }) {
-  restores.push(stubClusterWidths(props.backWidth))
+  restores.push(stubClusterWidths(props.backWidth, props.actionWidth ?? ACTIONS_WIDTH))
+  const workingSet = props.mobileWorkingSet === true
+    ? <div>Working set</div>
+    : props.mobileWorkingSet || undefined
   const { container } = render(
     <ChatHeaderPills
       title={props.title}
       onBack={vi.fn()}
       onNew={vi.fn()}
       backTo={props.backTo ? { label: props.backTo, onClick: vi.fn() } : undefined}
-      mobileWorkingSet={props.mobileWorkingSet ? <div>Working set</div> : undefined}
+      mobileWorkingSet={workingSet}
     />,
   )
   const bar = container.querySelector<HTMLElement>('.lg\\:hidden')
@@ -60,6 +76,17 @@ function sideTracks(row: HTMLElement): [string, string] {
   const tracks = template.match(/^(\S+)\s+minmax\(0,\s*1fr\)\s+(\S+)$/)
   if (!tracks) throw new Error(`nav bar is not a centred 3-track grid: "${template}"`)
   return [tracks[1], tracks[2]]
+}
+
+function workingSetItems(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: String.fromCharCode(97 + i),
+    title: `Chat ${i + 1}`,
+    employee: `employee-${i + 1}`,
+    preview: `preview ${i + 1}`,
+    revision: 0,
+    moved: false,
+  }))
 }
 
 describe('mobile chat header title centring', () => {
@@ -88,13 +115,18 @@ describe('mobile chat header title centring', () => {
     expect(title.className).toContain('text-center')
   })
 
-  it('centres the working set on the header when the actions are the wider cluster', () => {
+  it.each([
+    { name: '0 action buttons', actionWidth: 0, expected: BARE_BACK_WIDTH },
+    { name: '1 action button', actionWidth: ONE_ACTION_WIDTH, expected: ONE_ACTION_WIDTH },
+    { name: '2 action buttons', actionWidth: ACTIONS_WIDTH, expected: ACTIONS_WIDTH },
+  ])('centres the working set on the header with $name', ({ actionWidth, expected }) => {
     const row = renderNavBar({
       backWidth: BARE_BACK_WIDTH,
       title: 'Ignored while the working set is present',
       mobileWorkingSet: true,
+      actionWidth,
     })
-    expect(sideTracks(row)).toEqual([`${ACTIONS_WIDTH}px`, `${ACTIONS_WIDTH}px`])
+    expect(sideTracks(row)).toEqual([`${expected}px`, `${expected}px`])
   })
 
   it('centres the working set on the header when a labelled back is the wider cluster', () => {
@@ -126,5 +158,36 @@ describe('mobile chat header title centring', () => {
 
     expect(back(withChips)).toContain('max-w-[27vw]')
     expect(back(withTitle)).toContain('max-w-[34vw]')
+  })
+
+  it('leaves room for four compact chips at 390px under the 27vw labelled-back cap', () => {
+    const side = Math.floor(HEADER_WIDTH * 0.27)
+    const middle = HEADER_WIDTH - HEADER_PAD_X - HEADER_COL_GAPS - 2 * side
+    expect(middle).toBeGreaterThanOrEqual(CHIP * 4 + CHIP_GAP * 3)
+  })
+
+  it.each([1, 2, 3, 4])('keeps %i working-set chips centred and shrinkable, with the active chip expanded', (count) => {
+    const row = renderNavBar({
+      backWidth: BARE_BACK_WIDTH,
+      title: 'Ignored while the working set is present',
+      mobileWorkingSet: (
+        <MobileWorkingSetNav
+          items={workingSetItems(count)}
+          activeId="a"
+          onSelect={vi.fn()}
+        />
+      ),
+    })
+    const nav = row.querySelector('[data-mobile-working-set-nav]')
+    expect(nav).toBeTruthy()
+    expect(nav!.className).toContain('justify-center')
+    expect(nav!.className).toContain('min-w-0')
+    expect(row.querySelectorAll('[data-mobile-working-set-chip]')).toHaveLength(count)
+
+    const active = row.querySelector('[data-mobile-working-set-active="true"]')
+    const compact = row.querySelector('[data-mobile-working-set-active="false"]')
+    expect(active?.className).toContain('max-w-[132px]')
+    expect(active?.textContent).toContain('Chat 1')
+    if (count > 1) expect(compact?.className).toContain('w-9')
   })
 })

--- a/packages/web/src/components/chat/chat-tabs.tsx
+++ b/packages/web/src/components/chat/chat-tabs.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, SquarePen } from 'lucide-react'
 import { type ChatTab } from '@/hooks/use-chat-tabs'
 // Frosted pill primitives now live in the shared cross-page pill system.
 import { PILL_CLASS, PillButton } from '@/components/pill-nav'
+import { cn } from '@/lib/utils'
 import { useTitleArrival } from './title-arrival'
 
 export interface ChatHeaderPillsProps {
@@ -151,15 +152,14 @@ export function ChatHeaderPills({
           className="absolute inset-x-0 top-0 z-10 lg:hidden"
           style={{ paddingTop: 'max(var(--safe-top), 0px)' }}
         >
-          {/* The plain title locks both side tracks to the WIDER cluster, so its
-              middle track sits on the header's centre line. The working set
-              instead sizes against its real neighbours: mirroring a labelled
-              back control would take that width from the four mobile chips. */}
+          {/* Both side tracks lock to the WIDER cluster, so whatever occupies the
+              middle track — the plain title or the working-set chips — sits on
+              the header's centre line instead of centred between two asymmetric
+              controls. A labelled back control mirrors its width onto the right,
+              and the chips truncate into what is left rather than overlap. */}
           <div
             className="relative grid h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-1 bg-[var(--material-thick-opaque)] px-1.5 [@media(pointer:fine)]:bg-[var(--material-thick)] [@media(pointer:fine)]:[backdrop-filter:blur(20px)_saturate(1.3)] [@media(pointer:fine)]:[-webkit-backdrop-filter:blur(20px)_saturate(1.3)]"
-            style={mobileWorkingSet
-              ? undefined
-              : { gridTemplateColumns: `${sideTrack}px minmax(0,1fr) ${sideTrack}px` }}
+            style={{ gridTemplateColumns: `${sideTrack}px minmax(0,1fr) ${sideTrack}px` }}
           >
             {/* Back control. A drill-in reads `‹ Parent` and returns to the
                 parent thread (iOS previous-screen-title idiom); otherwise the
@@ -171,7 +171,14 @@ export function ChatHeaderPills({
                 onClick={backTo.onClick}
                 aria-label={`Back to ${backTo.label}`}
                 title={`Back to ${backTo.label}`}
-                className="inline-flex h-9 max-w-[34vw] shrink-0 items-center justify-self-start gap-0.5 rounded-full pl-1 pr-2.5 text-[var(--text-secondary)] transition-colors hover:bg-[var(--fill-secondary)] hover:text-[var(--text-primary)] active:bg-[var(--fill-secondary)]"
+                className={cn(
+                  'inline-flex h-9 shrink-0 items-center justify-self-start gap-0.5 rounded-full pl-1 pr-2.5 text-[var(--text-secondary)] transition-colors hover:bg-[var(--fill-secondary)] hover:text-[var(--text-primary)] active:bg-[var(--fill-secondary)]',
+                  // Mirroring this control onto the right track spends its width
+                  // twice, so the label yields when the chips hold the middle:
+                  // four 36px chips plus their gaps need 156px, which 27vw a side
+                  // leaves intact at 390px. Without the working set it keeps 34vw.
+                  mobileWorkingSet ? 'max-w-[27vw]' : 'max-w-[34vw]',
+                )}
               >
                 <ChevronLeft size={22} className="shrink-0" />
                 <span className="truncate text-[length:var(--text-subheadline)] font-medium">{backTo.label}</span>

--- a/packages/web/src/routes/chat/__tests__/mobile-grid-picker-escape.test.tsx
+++ b/packages/web/src/routes/chat/__tests__/mobile-grid-picker-escape.test.tsx
@@ -112,3 +112,43 @@ describe('the mobile grid picker releases the screen', () => {
     ))
   })
 })
+
+describe('the desktop grid picker stays a pane', () => {
+  let pickerLayout: VirtualLayout | null = null
+
+  beforeEach(() => {
+    sessionIds.splice(0, sessionIds.length, 'a', 'b')
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1440 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 900 })
+    localStorage.clear()
+    gateway.listeners.clear()
+    apiMocks.createSession.mockClear()
+    localStorage.setItem(WORKING_SET_STORAGE_KEY, JSON.stringify({
+      version: 1, sessionIds: ['a'], focusedId: 'a', focusHistory: ['a'],
+    }))
+    pickerLayout = installVirtualLayout(44, 360, {
+      scroller: '[data-testid="session-picker-scroll"]',
+      row: '[data-session-picker-row]',
+      rowId: 'data-session-picker-row',
+    })
+  })
+
+  afterEach(() => {
+    pickerLayout?.release()
+    pickerLayout = null
+  })
+
+  it('leaves the picker open when new chat is tapped', async () => {
+    renderRoute('/?session=a')
+    await screen.findByText('transcript-a')
+
+    const desktopNewChat = screen.getAllByRole('button', { name: 'New chat' })[0]
+    fireEvent.click(within(desktopNewChat.parentElement!).getByRole('button', { name: 'More options' }))
+    fireEvent.click(within(desktopNewChat.parentElement!).getByRole('button', { name: 'Open beside' }))
+    expect(await pickerSearch()).toBeTruthy()
+
+    fireEvent.click(desktopNewChat)
+
+    expect(await screen.findByRole('combobox', { name: 'Search chats' })).toBeTruthy()
+  })
+})

--- a/packages/web/src/routes/chat/__tests__/mobile-grid-picker-escape.test.tsx
+++ b/packages/web/src/routes/chat/__tests__/mobile-grid-picker-escape.test.tsx
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+
+import { installVirtualLayout, type VirtualLayout } from '@/test/virtual-layout'
+import { WORKING_SET_STORAGE_KEY } from '../working-set'
+import { apiMocks, gateway, renderRoute, sessionIds } from './multi-pane-page-harness'
+
+// "Open beside" makes the picker the WHOLE mobile grid, and the mobile grid has
+// no pane title bar to close it from. Nothing but a navigation can release it,
+// so these are the navigations that have to.
+
+// The mobile nav bar is the second actions cluster in the DOM; the first is the
+// desktop chrome, which only CSS hides and jsdom therefore still renders.
+function openChatBeside() {
+  const actions = screen.getAllByRole('button', { name: 'New chat' })[1].parentElement!
+  fireEvent.click(within(actions).getByRole('button', { name: 'More options' }))
+  fireEvent.click(within(actions).getByRole('button', { name: 'Open beside' }))
+}
+
+function tapNewChat() {
+  fireEvent.click(screen.getAllByRole('button', { name: 'New chat' })[1])
+}
+
+const pickerSearch = () => screen.findByRole('combobox', { name: 'Search chats' })
+
+describe('the mobile grid picker releases the screen', () => {
+  let pickerLayout: VirtualLayout | null = null
+
+  beforeEach(() => {
+    sessionIds.splice(0, sessionIds.length, 'a', 'b')
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 390 })
+    Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: 844 })
+    localStorage.clear()
+    gateway.listeners.clear()
+    apiMocks.createSession.mockClear()
+    apiMocks.getOrg.mockResolvedValue({
+      employees: [{
+        name: 'lead-developer',
+        displayName: 'Lead Developer',
+        department: 'platform',
+        rank: 'senior',
+        engine: 'claude',
+        model: 'opus',
+        persona: 'Builds the platform.',
+      }],
+    })
+    localStorage.setItem(WORKING_SET_STORAGE_KEY, JSON.stringify({
+      version: 1, sessionIds: ['a'], focusedId: 'a', focusHistory: ['a'],
+    }))
+    pickerLayout = installVirtualLayout(44, 360, {
+      scroller: '[data-testid="session-picker-scroll"]',
+      row: '[data-session-picker-row]',
+      rowId: 'data-session-picker-row',
+    })
+  })
+
+  afterEach(() => {
+    pickerLayout?.release()
+    pickerLayout = null
+    apiMocks.getOrg.mockReset()
+  })
+
+  it('swaps the picker for the composer when new chat is tapped', async () => {
+    renderRoute('/?session=a')
+    await screen.findByText('transcript-a')
+    openChatBeside()
+    expect(await pickerSearch()).toBeTruthy()
+
+    tapNewChat()
+
+    expect(await screen.findByText('Who do you want to talk to?')).toBeTruthy()
+    expect(screen.queryByRole('combobox', { name: 'Search chats' })).toBeNull()
+  })
+
+  it('swaps the picker for the chat list when back is tapped', async () => {
+    renderRoute('/?session=a')
+    await screen.findByText('transcript-a')
+    openChatBeside()
+    expect(await pickerSearch()).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to chats' }))
+
+    await waitFor(() => expect(screen.queryByRole('combobox', { name: 'Search chats' })).toBeNull())
+  })
+
+  it('swaps the picker for the transcript when another chat is opened from the list', async () => {
+    renderRoute('/?session=a')
+    await screen.findByText('transcript-a')
+    openChatBeside()
+    expect(await pickerSearch()).toBeTruthy()
+
+    fireEvent.click(screen.getByTestId('list-row-b'))
+
+    expect(await screen.findByText('transcript-b')).toBeTruthy()
+    expect(screen.queryByRole('combobox', { name: 'Search chats' })).toBeNull()
+  })
+
+  it('creates the session on first send from the composer it swapped in', async () => {
+    renderRoute('/?session=a')
+    await screen.findByText('transcript-a')
+    openChatBeside()
+    expect(await pickerSearch()).toBeTruthy()
+
+    tapNewChat()
+    fireEvent.click(await screen.findByRole('option', { name: /Lead Developer/ }))
+    const textarea = document.querySelector<HTMLTextAreaElement>('[data-chat-pane-session="new"] [data-chat-textarea]')!
+    fireEvent.change(textarea, { target: { value: 'first message' } })
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter' })
+
+    await waitFor(() => expect(apiMocks.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'first message', employee: 'lead-developer' }),
+    ))
+  })
+})

--- a/packages/web/src/routes/chat/__tests__/multi-pane-page-harness.tsx
+++ b/packages/web/src/routes/chat/__tests__/multi-pane-page-harness.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, render } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 import { vi } from 'vitest'
+import type { OrgData } from '@/lib/api'
 import ChatPageWrapper from '../page'
 import { CHAT_SESSION_DND_MIME } from '../chat-session-dnd'
 
@@ -28,7 +29,9 @@ const apiMocks = vi.hoisted(() => ({
   searchSessions: vi.fn(async (query: string) => sessionIds
     .filter((id) => `Title ${id}`.toLowerCase().includes(query.toLowerCase()))
     .map((id) => ({ id, title: `Title ${id}`, status: 'idle' }))),
-  getOrg: vi.fn(async () => ({ employees: [] })),
+  // Only the employees are read from the org here, and suites that need real
+  // ones override this — so the mock is typed to what it actually supplies.
+  getOrg: vi.fn(async (): Promise<Pick<OrgData, 'employees'>> => ({ employees: [] })),
   getEngines: vi.fn(async () => ({
     engines: {
       claude: { name: 'claude', available: true, defaultModel: 'opus', models: [], supportsPty: true },

--- a/packages/web/src/routes/chat/page.tsx
+++ b/packages/web/src/routes/chat/page.tsx
@@ -119,7 +119,7 @@ function ChatPage() {
   const sessionsQuery = useSessions()
   // Which pane the route shows, when it may show it, and the optimistic bubble handed to the session the pane creates.
   const { paneKey, committedId, awaitingOpen, pendingMessage, paneSlotRef, revealSelection, adoptSession, startComposer } = usePaneIdentity(selectedId, pendingEmployee, { newChatIntent: newChatIntentRef.current, sessionsPending: sessionsQuery.isPending, sessionCount: sessionsQuery.data?.length ?? 0 })
-  const { workingSet, gridPicker, gridState } = useChatGridWorkspace(committedId, sessionsQuery.data, systemPrimedId)
+  const { workingSet, gridPicker, gridState, releaseMobilePicker } = useChatGridWorkspace(committedId, sessionsQuery.data, systemPrimedId)
   const removeWorkingSetPane = workingSet.remove
   const { viewport, focusedSessionId, mountedSessionIds, mobileSessionIds } = gridState
   const paneState = useChatPaneState(committedId, focusedSessionId)
@@ -138,7 +138,7 @@ function ChatPage() {
     })
   }, [])
   // Mobile: pop from the thread back to the chat list (the tab bar's Chat screen).
-  const backToList = useCallback(() => setMobileView('sidebar'), [])
+  const backToList = useCallback(() => { releaseMobilePicker(); setMobileView('sidebar') }, [releaseMobilePicker])
   const [threadPreview, setThreadPreview] = useState<CommsPeekData | null>(() => parseHistoryPreview(location.state))
   const previewHandoffTargetRef = useRef<string | null>(null)
   const previewAbortRef = useRef<AbortController | null>(null)
@@ -278,7 +278,7 @@ function ChatPage() {
       const currentId = selectedIdRef.current
       const currentScroller = document.querySelector<HTMLElement>('.chat-messages-scroll') // display-toggled away on a phone, where it reports scrollTop 0
       if (currentId && currentScroller?.clientHeight) sessionScrollRef.current.set(currentId, currentScroller.scrollTop)
-      newChatIntentRef.current = false; setSystemPrimedId(opts?.system ? id : null)
+      newChatIntentRef.current = false; setSystemPrimedId(opts?.system ? id : null); releaseMobilePicker()
       // On mobile, opening a session pushes from the list into the thread, and the
       // pane arrives with it (see revealSelection). The one exception is the
       // background auto-select of the most-recent session (handleSessionsLoaded):
@@ -299,7 +299,7 @@ function ChatPage() {
         })
       }
     },
-    [chatTabs, navigate, revealSelection]
+    [chatTabs, navigate, releaseMobilePicker, revealSelection]
   )
 
   const handleFocusPane = useCallback((sessionId: string) => {
@@ -364,7 +364,7 @@ function ChatPage() {
   }, [paneState.bumpFocus, selectedId])
 
   const handleNewChat = useCallback(() => {
-    newChatIntentRef.current = true
+    newChatIntentRef.current = true; releaseMobilePicker()
     startComposer()
     setPendingEmployee(null)
     setMobileView('chat')
@@ -376,13 +376,13 @@ function ChatPage() {
       pendingNavRef.current = null
       navigate('/')
     }
-  }, [chatTabs, navigate, startComposer])
+  }, [chatTabs, navigate, releaseMobilePicker, startComposer])
 
   // Start a new chat with a specific employee preselected — used when contacting
   // a session-less employee from the sidebar roster or via an ?employee= deep-link.
   // The actual session is created on first send (ChatPane → buildNewSessionParams).
   const contactEmployee = useCallback((name: string) => {
-    newChatIntentRef.current = true
+    newChatIntentRef.current = true; releaseMobilePicker()
     startComposer()
     setPendingEmployee(name)
     setMobileView('chat')
@@ -393,7 +393,7 @@ function ChatPage() {
       pendingNavRef.current = null
       navigate('/')
     }
-  }, [chatTabs, navigate, startComposer])
+  }, [chatTabs, navigate, releaseMobilePicker, startComposer])
 
   // ?employee=<name> deep-link: an INTENT (compose to that employee), not a
   // location — consumed once so it doesn't re-fire or stick. ?session= is NOT

--- a/packages/web/src/routes/chat/use-chat-grid-workspace.ts
+++ b/packages/web/src/routes/chat/use-chat-grid-workspace.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useChatGridState } from './use-chat-grid-state'
 import { useChatWorkingSet } from './use-chat-working-set'
 import { useGridPickerPane } from './use-grid-picker-pane'
@@ -16,5 +17,15 @@ export function useChatGridWorkspace(
     pickerOpen: Boolean(gridPicker.paneKey),
     systemPrimedId,
   })
-  return { workingSet, gridPicker, gridState }
+  // On a phone the picker pane is the ENTIRE grid (deriveChatGridIds), and the
+  // only control that closes it lives in a multi-pane title bar the mobile grid
+  // never renders — so every navigation away from it has to release it, or the
+  // screen simply does not change. Desktop keeps it open: there it is one pane
+  // beside the others rather than the whole surface.
+  const closePicker = gridPicker.close
+  const { mobile } = gridState.viewport
+  const releaseMobilePicker = useCallback(() => {
+    if (mobile) closePicker()
+  }, [closePicker, mobile])
+  return { workingSet, gridPicker, gridState, releaseMobilePicker }
 }


### PR DESCRIPTION
## Summary
- release the mobile grid picker on new-chat, back, selection, and contact navigation
- center the header chip strip against equal side tracks without changing desktop picker behavior
- add focused mobile/desktop regression coverage

## Verification
- 18 focused tests pass
- @jinn/web typecheck passes
- size ratchet passes
- git diff --check passes

This recovers the two operator-approved ICI-1383 commits from local main onto canonical origin/main without importing the divergent local-main history.