### PR TITLE
fix(workflows): require canonical delivery before Todo closure

### DIFF
--- a/packages/jinn/src/gateway/__tests__/config-known-keys.test.ts
+++ b/packages/jinn/src/gateway/__tests__/config-known-keys.test.ts
@@ -104,11 +104,17 @@ afterAll(() => {
 describe("PUT /api/config top-level key allowlist", () => {
   it("accepts and persists the workflows block", async () => {
     const response = await call("PUT", "/api/config", {
-      workflows: { armingDelegates: ["platform-delegate"] },
+      workflows: {
+        armingDelegates: ["platform-delegate"],
+        delivery: { remote: "upstream", branch: "stable" },
+      },
     });
 
     expect(response.status).toBe(200);
-    expect(savedConfig().workflows).toEqual({ armingDelegates: ["platform-delegate"] });
+    expect(savedConfig().workflows).toEqual({
+      armingDelegates: ["platform-delegate"],
+      delivery: { remote: "upstream", branch: "stable" },
+    });
   });
 
   it("round-trips a gateway configured with arming delegates", async () => {

--- a/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
+++ b/packages/jinn/src/gateway/__tests__/todo-recovery.test.ts
@@ -2,6 +2,9 @@ import { beforeAll, describe, expect, it } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { openWorkflowDatabase } from "../../workflows/repository-migrations.js";
+import { WorkflowRepository } from "../../workflows/repository.js";
+import type { WorkflowDefinition, WorkflowNode } from "../../workflows/model.js";
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-gw-todo-recovery-"));
 process.env.JINN_HOME = tmp;
@@ -24,6 +27,8 @@ let controller: Controller;
 let detect: Detect;
 let rows: Rows;
 let db: import("better-sqlite3").Database;
+let workflowDb: import("better-sqlite3").Database;
+let workflowRepository: WorkflowRepository;
 
 beforeAll(async () => {
   store = await import("../../work-items/store.js");
@@ -35,10 +40,56 @@ beforeAll(async () => {
   detect = await import("../../work-items/anomaly-detect.js");
   rows = await import("../../work-items/recovery-rows.js");
   db = (await import("../../shared/db.js")).initDb();
+  workflowDb = openWorkflowDatabase(path.join(tmp, "workflows.db"));
+  workflowRepository = new WorkflowRepository(workflowDb);
 });
 
+function edge(id: string, from: string, port: string, to: string) {
+  return { id, from: { nodeId: from, port }, to: { nodeId: to, port: "input" as const } };
+}
+
+function createWorkflowRun(todoId: string, state: "running" | "completed" | "failed"): { workflowId: string; runId: string } {
+  const workflowId = `recovery-${todoId.toLowerCase()}`;
+  const created = workflowRepository.createDefinition({ id: workflowId, title: workflowId });
+  const nodes: WorkflowNode[] = [
+    { id: "start", type: "trigger", name: "Start", config: { kind: "manual" } },
+    { id: "gate", type: "approval", name: "Gate", config: { description: "Land?", operatorOnly: true } },
+    { id: "land", type: "employee", name: "Land", config: {
+      employee: { source: "fixed", value: "platform-worker" }, prompt: "Land.",
+      output: { fields: {}, allowAdditionalFields: true },
+    } },
+    { id: "done", type: "end", name: "Done", config: { result: "success" } },
+  ];
+  const definition = workflowRepository.saveDefinition({ ...created, inputs: [], nodes, edges: [
+    edge("start-gate", "start", "success", "gate"),
+    edge("gate-land", "gate", "approved", "land"),
+    edge("land-done", "land", "success", "done"),
+  ] } as WorkflowDefinition, created.revision);
+  const run = workflowRepository.createRun({ workflowId, input: {}, trigger: {
+    nodeId: "start", kind: "manual", payload: {}, ...{ todoId },
+  } });
+  const at = new Date().toISOString();
+  workflowRepository.mutateRun(run.id, run.revision, (tx) => {
+    tx.setNodeStatus("start", "completed", { activated: true, endedAt: at });
+    tx.setNodeStatus("gate", "completed", { activated: true, endedAt: at });
+    tx.putApproval({ nodeId: "gate", status: "approved", requestedAt: at,
+      decidedAt: at, decidedBy: "operator", decision: "approve" });
+    if (state === "completed") {
+      tx.setNodeStatus("land", "completed", { activated: true, endedAt: at });
+      tx.setNodeStatus("done", "completed", { activated: true, endedAt: at });
+      tx.setRunStatus("completed", { endedAt: at });
+    } else if (state === "failed") {
+      tx.setNodeStatus("land", "failed", { activated: true, endedAt: at });
+      tx.setRunStatus("failed", { endedAt: at });
+    } else {
+      tx.setRunStatus("running");
+    }
+  });
+  return { workflowId: definition.id, runId: run.id };
+}
+
 describe("closeApprovedLanded", () => {
-  it("closes an approved completed run through complete(), leaving the Todo done", () => {
+  it("closes only when the exact approved Workflow run completed its success End", () => {
     const item = store.createWorkItem({
       title: "approved landing leftover", status: "assigned", assignee: "platform-worker",
     });
@@ -48,29 +99,74 @@ describe("closeApprovedLanded", () => {
       `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
        VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
     ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
-    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
-    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    const attempt = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(attempt.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    const run = createWorkflowRun(item.id, "completed");
     approvals.requestApproval(item.id, {
-      request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
+      request: "Land?", ref: `workflow:${run.workflowId}:${run.runId}:gate`, target: "operator",
     });
     approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
     expect(store.getWorkItem(item.id)!.status).toBe("in_review");
 
-    expect(recovery.closeApprovedLanded(item.id)).toBe(true);
+    expect(recovery.closeApprovedLanded(item.id, workflowRepository)).toBe(true);
     expect(store.getWorkItem(item.id)!.status).toBe("done");
   });
 
-  it("does not close without a completed run; the leftover stays in_review", () => {
+  it("does not let an unrelated completed Todo attempt stand in for a pending Workflow LAND", () => {
     const item = store.createWorkItem({
       title: "approved but not landed", status: "assigned", assignee: "platform-worker",
     });
     transitions.transition(item.id, "in_review", "session:worker", { agent: true });
+    const sessionId = `s-pending-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const attempt = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(attempt.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    const run = createWorkflowRun(item.id, "running");
     approvals.requestApproval(item.id, {
-      request: "Land?", ref: "workflow:pipeline:run_missing:gate", target: "operator",
+      request: "Land?", ref: `workflow:${run.workflowId}:${run.runId}:gate`, target: "operator",
     });
     approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
-    expect(recovery.closeApprovedLanded(item.id)).toBe(false);
+    expect(recovery.closeApprovedLanded(item.id, workflowRepository)).toBe(false);
     expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+  });
+
+  it("does not interpret a failed Workflow plus an agent review claim as delivery", () => {
+    const item = store.createWorkItem({
+      title: "failed workflow claimed for review", status: "assigned", assignee: "platform-worker",
+    });
+    transitions.transition(item.id, "in_review", "session:worker", { agent: true });
+    const sessionId = `s-failed-${item.id}`;
+    db.prepare(
+      `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
+       VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
+    ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
+    const attempt = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(attempt.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    const run = createWorkflowRun(item.id, "failed");
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: `workflow:${run.workflowId}:${run.runId}:gate`, target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+
+    expect(recovery.approvedLandingComplete(item.id, workflowRepository)).toBe(false);
+    expect(recovery.closeApprovedLanded(item.id, workflowRepository)).toBe(false);
+    expect(store.getWorkItem(item.id)!.status).toBe("in_review");
+  });
+
+  it("treats a malformed legacy Workflow approval reference as unproven", () => {
+    const item = store.createWorkItem({
+      title: "legacy malformed approval", status: "in_review", assignee: "platform-worker",
+    });
+    approvals.requestApproval(item.id, {
+      request: "Land?", ref: "workflow:pipeline:not-a-run-id:gate", target: "operator",
+    });
+    approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
+
+    expect(recovery.approvedLandingComplete(item.id, workflowRepository)).toBe(false);
+    expect(recovery.closeApprovedLanded(item.id, workflowRepository)).toBe(false);
   });
 
   it("keeps a refused open-child leftover on Manager attention across sweep-then-detect ticks", () => {
@@ -86,18 +182,21 @@ describe("closeApprovedLanded", () => {
       `INSERT INTO sessions (id, engine, source, source_ref, status, work_item_id, created_at, last_activity)
        VALUES (?, 'claude', 'cron', ?, 'idle', ?, ?, ?)`,
     ).run(sessionId, `cron:${sessionId}`, item.id, new Date().toISOString(), new Date().toISOString());
-    const run = runs.openWorkItemRun({ workItemId: item.id, sessionId });
-    runs.closeWorkItemRun(run.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    const attempt = runs.openWorkItemRun({ workItemId: item.id, sessionId });
+    runs.closeWorkItemRun(attempt.id, { outcome: "completed", endedAt: new Date().toISOString() });
+    const run = createWorkflowRun(item.id, "completed");
     approvals.requestApproval(item.id, {
-      request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
+      request: "Land?", ref: `workflow:${run.workflowId}:${run.runId}:gate`, target: "operator",
     });
     approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
-    expect(recovery.closeApprovedLanded(item.id)).toBe(false);
+    expect(recovery.closeApprovedLanded(item.id, workflowRepository)).toBe(false);
     expect(store.getWorkItem(item.id)!.status).toBe("in_review");
 
     const tick = (): void => {
       controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });
-      detect.detectTodoAnomalies({ persist: true, closeApprovedLanded: recovery.closeApprovedLanded });
+      detect.detectTodoAnomalies({ persist: true,
+        approvedLandingComplete: (todoId) => recovery.approvedLandingComplete(todoId, workflowRepository),
+        closeApprovedLanded: (todoId) => recovery.closeApprovedLanded(todoId, workflowRepository) });
     };
     tick();
     tick();

--- a/packages/jinn/src/gateway/__tests__/work-items-route-attention-lanes.test.ts
+++ b/packages/jinn/src/gateway/__tests__/work-items-route-attention-lanes.test.ts
@@ -91,7 +91,6 @@ describe("GET /api/work-items?needsAttentionFor=me attention lanes", () => {
     const runs = await import("../../work-items/runs.js");
     const approvals = await import("../../work-items/approvals.js");
     const transitions = await import("../../work-items/transitions.js");
-    const recovery = await import("../todo-recovery.js");
     const rows = await import("../../work-items/recovery-rows.js");
     const db = dbModule.initDb();
 
@@ -113,9 +112,11 @@ describe("GET /api/work-items?needsAttentionFor=me attention lanes", () => {
       request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
     });
     approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
-    expect(recovery.closeApprovedLanded(item.id)).toBe(false);
+    expect(store.getWorkItem(item.id)!.status).toBe("in_review");
 
-    detect.detectTodoAnomalies({ persist: true, closeApprovedLanded: recovery.closeApprovedLanded });
+    detect.detectTodoAnomalies({ persist: true,
+      approvedLandingComplete: (todoId) => todoId === item.id,
+      closeApprovedLanded: () => false });
     expect(rows.getWorkItemRecovery(item.id)?.lane).toBe("manager");
 
     controller.sweepTodoRecovery({ mode: "classify-only", rearm: () => ({ status: "assigned" }) });

--- a/packages/jinn/src/gateway/todo-recovery.ts
+++ b/packages/jinn/src/gateway/todo-recovery.ts
@@ -3,8 +3,8 @@ import { loadConfig } from "../shared/config.js";
 import { sweepTodoRecovery, todoRecoveryMode } from "../work-items/recovery-controller.js";
 import { detectTodoAnomalies } from "../work-items/anomaly-detect.js";
 import { currentApproval } from "../work-items/approvals.js";
-import { listWorkItemRuns } from "../work-items/runs.js";
 import { getWorkItem } from "../work-items/store.js";
+import { reachedSuccessEnd } from "../workflows/run-closure.js";
 import { parseTodoApprovalRef } from "../workflows/todo-approval-ref.js";
 import { availabilityRearm } from "./availability-resume.js";
 import { workflowTodoLifecycle } from "./workflow-todo-surface.js";
@@ -12,18 +12,54 @@ import type { WorkflowRepository } from "../workflows/repository.js";
 
 const DEFAULT_INTERVAL_MS = 5 * 60_000;
 
+function approvedDecision(todoId: string) {
+  const approval = currentApproval(todoId);
+  if (approval?.state !== "approved") return null;
+  if (!approval.decidedBy || !approval.decidedAt) return null;
+  return { ...approval, decidedBy: approval.decidedBy, decidedAt: approval.decidedAt };
+}
+
+function completedExactRun(todoId: string, run: ReturnType<WorkflowRepository["getRun"]>): boolean {
+  if (!run || run.trigger.todoId !== todoId) return false;
+  return run.status === "completed" && Boolean(run.endedAt) && reachedSuccessEnd(run);
+}
+
+function exactGateApproved(run: NonNullable<ReturnType<WorkflowRepository["getRun"]>>, nodeId: string): boolean {
+  const authored = run.definition.nodes.find((node) => node.id === nodeId);
+  if (authored?.type !== "approval") return false;
+  const runtime = run.nodeRuns.find((node) => node.nodeId === nodeId);
+  if (runtime?.status !== "completed") return false;
+  const gate = run.approvals.find((candidate) => candidate.nodeId === nodeId);
+  return gate?.status === "approved" && Boolean(gate.decidedBy && gate.decidedAt);
+}
+
+function referencedRun(repository: WorkflowRepository, workflowId: string, runId: string) {
+  try {
+    return repository.getRun(workflowId, runId);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Classify (and, if enabled, apply) bounded Todo recovery. Default mode is
  * classify-only so production observes lanes without auto-rearming until the
  * reviewed gate flips `gateway.todoRecovery.mode` to `auto`.
  */
-export function closeApprovedLanded(todoId: string): boolean {
-  const approval = currentApproval(todoId);
-  if (approval?.state !== "approved" || !approval.decidedBy || !approval.decidedAt) return false;
+export function approvedLandingComplete(todoId: string, repository: WorkflowRepository): boolean {
+  const approval = approvedDecision(todoId);
+  if (!approval) return false;
   const origin = parseTodoApprovalRef(approval.ref);
   if (!origin) return false;
-  const landed = listWorkItemRuns(todoId).some((run) => run.outcome === "completed" && run.endedAt !== null);
-  if (!landed) return false;
+  const run = referencedRun(repository, origin.workflowId, origin.runId);
+  if (!run || !completedExactRun(todoId, run)) return false;
+  return exactGateApproved(run, origin.nodeId);
+}
+
+export function closeApprovedLanded(todoId: string, repository: WorkflowRepository): boolean {
+  if (!approvedLandingComplete(todoId, repository)) return false;
+  const approval = approvedDecision(todoId)!;
+  const origin = parseTodoApprovalRef(approval.ref)!;
   workflowTodoLifecycle.complete({
     todoId, workflowId: origin.workflowId, runId: origin.runId, nodeId: origin.nodeId,
     approvedBy: approval.decidedBy, approvedAt: approval.decidedAt,
@@ -40,7 +76,11 @@ export function startTodoRecovery(repository: WorkflowRepository, intervalMs = D
         mode,
         rearm: (todoId) => availabilityRearm(todoId, repository),
       });
-      const anomalies = detectTodoAnomalies({ persist: true, closeApprovedLanded });
+      const anomalies = detectTodoAnomalies({
+        persist: true,
+        approvedLandingComplete: (todoId) => approvedLandingComplete(todoId, repository),
+        closeApprovedLanded: (todoId) => closeApprovedLanded(todoId, repository),
+      });
       if (result.classified > 0 || result.applied > 0 || anomalies.length > 0) {
         logger.info(
           `Todo recovery: classified ${result.classified}, applied ${result.applied}, anomalies ${anomalies.length} (mode ${mode})`,

--- a/packages/jinn/src/shared/config-types.ts
+++ b/packages/jinn/src/shared/config-types.ts
@@ -149,6 +149,12 @@ export interface JinnConfig {
     channel?: string;    // Discord channel ID for admin notifications
   };
   workflows?: {
+    /** Canonical Git ref a code Workflow must prove delivery to before its Todo
+     * may close. Defaults to `origin/main`. */
+    delivery?: {
+      remote?: string;
+      branch?: string;
+    };
     /**
      * Employees whose OWN move of a Todo to `assigned` may satisfy a
      * `todo-status` trigger's `actor: operator` filter, so an autonomous

--- a/packages/jinn/src/work-items/__tests__/anomaly-detect.test.ts
+++ b/packages/jinn/src/work-items/__tests__/anomaly-detect.test.ts
@@ -80,6 +80,7 @@ describe("detectTodoAnomalies", () => {
     const closed: string[] = [];
     const found = detect.detectTodoAnomalies({
       persist: true,
+      approvedLandingComplete: (todoId) => todoId === item.id,
       closeApprovedLanded: (todoId) => {
         closed.push(todoId);
         return todoId === item.id;
@@ -105,7 +106,9 @@ describe("detectTodoAnomalies", () => {
       request: "Land?", ref: `workflow:pipeline:${run.id}:gate`, target: "operator",
     });
     approvals.decideWorkItemApprovalSync({ id: item.id, decision: "approve", decidedBy: "operator" });
-    detect.detectTodoAnomalies({ persist: true, closeApprovedLanded: () => false });
+    detect.detectTodoAnomalies({ persist: true,
+      approvedLandingComplete: (todoId) => todoId === item.id,
+      closeApprovedLanded: () => false });
     const hits = store.listWorkItems({ needsAttentionFor: "operator" }).map((row) => row.id);
     expect(hits).toContain(item.id);
   });

--- a/packages/jinn/src/work-items/anomaly-detect.ts
+++ b/packages/jinn/src/work-items/anomaly-detect.ts
@@ -82,11 +82,10 @@ function executionTimeout(item: WorkItem, now: Date): TodoAnomaly | undefined {
   return { workItemId: item.id, kind: "execution-timeout", lane: "manager", reason: "execution has outlived the 4h timeout without an in-flight session to speak for it" };
 }
 
-function reviewAnomaly(item: WorkItem): TodoAnomaly | undefined {
+function reviewAnomaly(item: WorkItem, approvedLandingComplete?: (todoId: string) => boolean): TodoAnomaly | undefined {
   if (item.status !== "in_review") return undefined;
   const approval = currentApproval(item.id);
-  const last = [...listWorkItemRuns(item.id)].reverse().find((run) => run.endedAt !== null);
-  if (approval?.state === "approved" && last?.outcome === "completed") {
+  if (approval?.state === "approved" && approvedLandingComplete?.(item.id)) {
     return { workItemId: item.id, kind: "approved-landed-open", lane: "manager", reason: "approved landing is still open" };
   }
   if (approval?.state !== "pending" && !item.assignee) {
@@ -102,13 +101,17 @@ function blockedWithoutRecovery(item: WorkItem): TodoAnomaly | undefined {
   return { workItemId: item.id, kind: "blocked-without-recovery", lane: verdict.lane, reason: "blocked with no recovery row" };
 }
 
-function inspect(item: WorkItem, now: Date): TodoAnomaly | undefined {
-  return assignedWithoutRun(item, now) ?? executionTimeout(item, now) ?? reviewAnomaly(item) ?? blockedWithoutRecovery(item);
+function inspect(item: WorkItem, now: Date,
+  approvedLandingComplete?: (todoId: string) => boolean): TodoAnomaly | undefined {
+  return assignedWithoutRun(item, now) ?? executionTimeout(item, now)
+    ?? reviewAnomaly(item, approvedLandingComplete) ?? blockedWithoutRecovery(item);
 }
 
 export interface DetectTodoAnomaliesInput {
   now?: Date;
   persist?: boolean;
+  /** Exact Workflow-run proof that the approved landing completed. */
+  approvedLandingComplete?: (todoId: string) => boolean;
   /** Close an approved-landed leftover through the existing complete() path.
    *  Return true when the Todo is done so it is not parked on Manager attention. */
   closeApprovedLanded?: (todoId: string) => boolean;
@@ -124,7 +127,7 @@ export function detectTodoAnomalies(input: DetectTodoAnomaliesInput = {}): TodoA
   const found: TodoAnomaly[] = [];
   for (const status of ["assigned", "executing", "in_review", "blocked"] as const) {
     for (const item of listWorkItems({ status })) {
-      const anomaly = inspect(item, now);
+      const anomaly = inspect(item, now, input.approvedLandingComplete);
       if (!anomaly) continue;
       if (anomaly.kind === "approved-landed-open" && input.closeApprovedLanded?.(item.id)) {
         found.push(anomaly);

--- a/packages/jinn/src/workflows/__tests__/git-landing-evidence.test.ts
+++ b/packages/jinn/src/workflows/__tests__/git-landing-evidence.test.ts
@@ -1,0 +1,45 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createGitLandingEvidence } from "../git-landing-evidence.js";
+
+const roots: string[] = [];
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", cwd, ...args], {
+    encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("canonical git landing evidence", () => {
+  it("refuses a local-main-only commit until it reaches the fetched canonical remote branch", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-canonical-landing-"));
+    roots.push(root);
+    const remote = path.join(root, "origin.git");
+    const checkout = path.join(root, "checkout");
+    execFileSync("git", ["init", "--bare", "--initial-branch=main", remote], { stdio: "ignore" });
+    execFileSync("git", ["clone", remote, checkout], { stdio: "ignore" });
+    git(checkout, "config", "user.email", "test@example.invalid");
+    git(checkout, "config", "user.name", "Jinn Test");
+    fs.writeFileSync(path.join(checkout, "proof.txt"), "base\n");
+    git(checkout, "add", "proof.txt");
+    git(checkout, "commit", "-m", "base");
+    git(checkout, "push", "-u", "origin", "main");
+
+    fs.appendFileSync(path.join(checkout, "proof.txt"), "local only\n");
+    git(checkout, "commit", "-am", "local only");
+    const commit = git(checkout, "rev-parse", "HEAD");
+    const evidence = createGitLandingEvidence({ remote: "origin", branch: "main" });
+
+    await expect(evidence.mergedIntoMain({ commit, checkout })).resolves.toBe(false);
+
+    git(checkout, "push", "origin", "main");
+    await expect(evidence.mergedIntoMain({ commit, checkout })).resolves.toBe(true);
+  });
+});

--- a/packages/jinn/src/workflows/__tests__/landing-evidence.test.ts
+++ b/packages/jinn/src/workflows/__tests__/landing-evidence.test.ts
@@ -86,7 +86,7 @@ let executor: FakeExecutor;
 let lifecycle: RecordingLifecycle;
 let service: WorkflowService;
 let asked: Array<{ commit: string; checkout: string }>;
-let onMain: boolean;
+let onMain: boolean | Error;
 const now = new Date("2026-08-22T19:59:00.000Z");
 
 function edge(id: string, from: string, port: string, to: string) {
@@ -150,7 +150,11 @@ beforeEach(() => {
     repository, executor: executor as unknown as WorkflowSessionExecutor,
     employees: () => new Map([[employee.name, employee]]), models: () => models, now: () => now.toISOString(),
     todoLifecycle: lifecycle,
-    landingEvidence: { mergedIntoMain: async (input) => { asked.push(input); return onMain; } },
+    landingEvidence: { mergedIntoMain: async (input) => {
+      asked.push(input);
+      if (onMain instanceof Error) throw onMain;
+      return onMain;
+    } },
   });
 });
 
@@ -192,6 +196,16 @@ describe("a success End that demands landing evidence", () => {
     expect(lifecycle.reflections.at(-1)).toEqual({ status: "blocked", nodeId: "done" });
     expect(lifecycle.failures.at(-1)!.message).toContain(PHANTOM);
     expect(asked).toEqual([{ commit: PHANTOM, checkout: "/checkouts/pla-180" }]);
+  });
+
+  it("blocks the Todo when canonical delivery cannot be checked", async () => {
+    onMain = new Error("origin is unavailable");
+    const { definition, runId } = await approvedLanding("landing-unreadable");
+    await executor.succeed("land", { mergeCommit: PHANTOM });
+
+    expect(service.getRun(definition.id, runId)!.status).toBe("failed");
+    expect(lifecycle.completions).toEqual([]);
+    expect(lifecycle.failures.at(-1)!.message).toContain("could not be verified on the canonical branch");
   });
 
   it("completes the Todo when the reported commit is on main", async () => {

--- a/packages/jinn/src/workflows/git-landing-evidence.ts
+++ b/packages/jinn/src/workflows/git-landing-evidence.ts
@@ -1,24 +1,52 @@
 import { execFile } from "node:child_process";
+import { loadConfig } from "../shared/config.js";
 import type { WorkflowLandingVerifier } from "./run-closure.js";
 
+export interface CanonicalGitTarget {
+  remote: string;
+  branch: string;
+}
+
+function git(checkout: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile("git", ["-C", checkout, ...args],
+      { timeout: 30_000, windowsHide: true }, (error) => error ? reject(error) : resolve());
+  });
+}
+
+function canonicalTarget(): CanonicalGitTarget {
+  const delivery = loadConfig().workflows?.delivery;
+  return { remote: delivery?.remote ?? "origin", branch: delivery?.branch ?? "main" };
+}
+
 /**
- * The default proof that a commit reached `main`: git's own ancestry check, run
- * in the checkout the Workflow itself named.
+ * Proof that a commit reached the freshly fetched canonical remote branch.
  *
  * An argument vector, never a shell string — both values come out of a phase's
  * submitted output, so both are input. Exit 1 is git's answer, and everything
  * else (no repository there any more, an object it never heard of) throws, so
  * the caller can tell "no" apart from "could not ask".
  */
+export function createGitLandingEvidence(target: CanonicalGitTarget): WorkflowLandingVerifier {
+  const trackingRef = `refs/remotes/${target.remote}/${target.branch}`;
+  return {
+    async mergedIntoMain({ commit, checkout }) {
+      await git(checkout, ["fetch", "--quiet", target.remote,
+        `+refs/heads/${target.branch}:${trackingRef}`]);
+      return new Promise((resolve, reject) => {
+        execFile("git", ["-C", checkout, "merge-base", "--is-ancestor", commit, trackingRef],
+          { timeout: 10_000, windowsHide: true }, (error) => {
+            if (!error) resolve(true);
+            else if (error.code === 1) resolve(false);
+            else reject(error);
+          });
+      });
+    },
+  };
+}
+
 export const gitLandingEvidence: WorkflowLandingVerifier = {
-  mergedIntoMain({ commit, checkout }) {
-    return new Promise((resolve, reject) => {
-      execFile("git", ["-C", checkout, "merge-base", "--is-ancestor", commit, "main"],
-        { timeout: 10_000, windowsHide: true }, (error) => {
-          if (!error) resolve(true);
-          else if (error.code === 1) resolve(false);
-          else reject(error);
-        });
-    });
+  mergedIntoMain(input) {
+    return createGitLandingEvidence(canonicalTarget()).mergedIntoMain(input);
   },
 };

--- a/packages/jinn/src/workflows/run-closure.ts
+++ b/packages/jinn/src/workflows/run-closure.ts
@@ -19,7 +19,7 @@ import type { WorkflowTodoLifecycle } from "./todo-ports.js";
  * and a demand they cannot meet would close nothing at all.
  */
 
-/** Proof that a commit a run reported really reached `main`. A port so the rule
+/** Proof that a commit a run reported really reached the canonical branch. A port so the rule
  *  can be judged without a repository; the default shells git. */
 export interface WorkflowLandingVerifier {
   mergedIntoMain(input: { commit: string; checkout: string }): Promise<boolean>;
@@ -56,13 +56,13 @@ function quoted(value: string): string {
   return value.length > MAX_QUOTED ? `${value.slice(0, MAX_QUOTED)}…` : value;
 }
 
-/** `undefined` when the question could not be put: a checkout git can no longer
- *  read leaves a commit unproven, which is not the same as disproven. */
+/** `undefined` when the question could not be put. Unproven delivery must block
+ *  closure just as firmly as disproven delivery. */
 async function onMain(verifier: WorkflowLandingVerifier, commit: string, checkout: string): Promise<boolean | undefined> {
   try {
     return await verifier.mergedIntoMain({ commit, checkout });
   } catch (error) {
-    logger.warn(`Workflow could not check whether ${commit} is on main in ${checkout}: `
+    logger.warn(`Workflow could not check whether ${commit} is on the canonical branch in ${checkout}: `
       + `${error instanceof Error ? error.message : String(error)}`);
     return undefined;
   }
@@ -74,10 +74,8 @@ async function onMain(verifier: WorkflowLandingVerifier, commit: string, checkou
  *
  * A missing field, a blank one and a value that is not a SHA are the same
  * failure in different clothes: the phase landed nothing and said so in the
- * only place it had. Only the last check needs the world, and it is the one
- * that degrades — an End that named no checkout, or a checkout that has been
- * cleaned up, gets the shape check alone rather than a landing declared blocked
- * because git could not be asked.
+ * only place it had. A declared checkout makes canonical delivery mandatory;
+ * an unavailable repository or remote is failed proof, never permission to close.
  */
 export async function landingShortfall(run: WorkflowRunDetail,
   verifier: WorkflowLandingVerifier = gitLandingEvidence): Promise<WorkflowLandingShortfall | undefined> {
@@ -93,8 +91,16 @@ export async function landingShortfall(run: WorkflowRunDetail,
         reason: `Step ${requires.nodeId} reported ${requires.field} "${quoted(commit)}", which is not a commit SHA.` };
     }
     const checkout = requires.commitIn ? reported(run, requires.commitIn.nodeId, requires.commitIn.field) : "";
-    if (checkout !== "" && await onMain(verifier, commit, checkout) === false) {
-      return { nodeId: end.id, reason: `Commit ${commit} reported by step ${requires.nodeId} is not on main.` };
+    if (checkout !== "") {
+      const delivered = await onMain(verifier, commit, checkout);
+      if (delivered === false) {
+        return { nodeId: end.id,
+          reason: `Commit ${commit} reported by step ${requires.nodeId} is not on the canonical branch.` };
+      }
+      if (delivered === undefined) {
+        return { nodeId: end.id,
+          reason: `Commit ${commit} reported by step ${requires.nodeId} could not be verified on the canonical branch.` };
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
## What this fixes

- Workflow LAND proof now fetches and verifies the configured canonical remote branch (default `origin/main`)
- Unavailable delivery proof blocks closure instead of degrading open
- Todo recovery correlates the exact approved Workflow `run_*`, gate, and successful End
- Generic Todo `wir_*` attempts and failed Workflow review claims can no longer stand in for landing

## Evidence

- Regression: local-main-only commit rejected until pushed and fetched
- Regression: pending/failed Workflow plus unrelated completed Todo attempt stays open
- Focused: 38 tests green
- Build, typecheck, lint, ratchet, footguns green
- Full web suite: 3,370 tests green