### PR TITLE
Recover verified ICI-1410 and ICI-1411 onto origin/main

### DIFF
--- a/packages/jinn/src/cron/__tests__/runner-run-log-status.test.ts
+++ b/packages/jinn/src/cron/__tests__/runner-run-log-status.test.ts
@@ -91,6 +91,15 @@ describe("runCronJob — what the run log says about a settled session", () => {
     },
   );
 
+  it("keeps an empty error string as the reason it was recorded", async () => {
+    vi.mocked(getSession).mockReturnValue(makeSession({ attemptOutcome: "failed", lastError: "" }));
+
+    const entry = await runOnce();
+
+    expect(entry["status"]).toBe("error");
+    expect(entry["error"]).toBe("");
+  });
+
   it("records a failure for a session left in error, whatever its attempt receipt says", async () => {
     vi.mocked(getSession).mockReturnValue(makeSession({ status: "error", lastError: "engine crashed" }));
 

--- a/packages/jinn/src/cron/__tests__/runner-run-log-status.test.ts
+++ b/packages/jinn/src/cron/__tests__/runner-run-log-status.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runCronJob } from "../runner.js";
+import { appendRunLog } from "../jobs.js";
+import { getSession, getSessionBySessionKey } from "../../sessions/registry.js";
+import { logger } from "../../shared/logger.js";
+import type { CronJob, Connector, JinnConfig, Session } from "../../shared/types.js";
+
+/**
+ * ICI-1410 — the run log used to record `success` the moment `route()` resolved,
+ * whatever the turn actually did. An expired auth chain, a rate limit, or an engine
+ * crash was logged green and the configured alert connector never fired, while the
+ * same pass reconciled the linked Todo to `blocked` from the real session state.
+ *
+ * The settled session is the receipt. The run log has to read it.
+ */
+
+vi.mock("../jobs.js", () => ({ appendRunLog: vi.fn() }));
+vi.mock("../../sessions/registry.js", () => ({ getSession: vi.fn(), getSessionBySessionKey: vi.fn() }));
+vi.mock("../../gateway/org-registry.js", () => ({ orgRegistry: vi.fn(() => new Map()) }));
+vi.mock("../../work-items/store.js", () => ({ createWorkItem: vi.fn(() => ({ id: "wi_test" })), linkSession: vi.fn() }));
+vi.mock("../../work-items/reconcile.js", () => ({ reconcileWorkItem: vi.fn() }));
+vi.mock("../../shared/logger.js", () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+const job: CronJob = { id: "test-job", name: "Test Job", enabled: true, schedule: "0 * * * *", prompt: "do something" };
+
+/** A config whose failure alerts have somewhere to go, as a real one does. */
+function makeConfig(): JinnConfig {
+  return {
+    engines: { default: "codex", codex: {} },
+    logging: { file: false, stdout: false, level: "info" },
+    cron: { alertConnector: "chat", alertChannel: "ops" },
+  } as unknown as JinnConfig;
+}
+
+function makeSession(overrides: Partial<Session>): Session {
+  return { id: "sess-123", status: "idle", attemptOutcome: null, lastError: null, ...overrides } as Session;
+}
+
+const sendMessage = vi.fn().mockResolvedValue(undefined);
+const emit = vi.fn();
+
+/** Runs one fire and hands back the run-log entry it wrote. */
+async function runOnce(): Promise<Record<string, unknown>> {
+  const sessionManager = { route: vi.fn().mockResolvedValue({ sessionId: "sess-123" }) } as never;
+  const connectors = new Map<string, Connector>([["chat", { sendMessage } as unknown as Connector]]);
+  await runCronJob(job, sessionManager, makeConfig(), connectors, { emit });
+  return vi.mocked(appendRunLog).mock.calls[0]![1] as unknown as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getSession).mockReturnValue(undefined);
+  vi.mocked(getSessionBySessionKey).mockReturnValue(undefined);
+});
+
+describe("runCronJob — what the run log says about a settled session", () => {
+  it("records the failure and its reason when the session's attempt failed", async () => {
+    vi.mocked(getSession).mockReturnValue(
+      makeSession({ attemptOutcome: "failed", lastError: "OAuth token expired" }),
+    );
+
+    const entry = await runOnce();
+
+    expect(entry["status"]).toBe("error");
+    expect(entry["error"]).toBe("OAuth token expired");
+  });
+
+  it("alerts on that failure exactly as a thrown error already does", async () => {
+    vi.mocked(getSession).mockReturnValue(
+      makeSession({ attemptOutcome: "failed", lastError: "OAuth token expired" }),
+    );
+
+    await runOnce();
+
+    expect(emit).toHaveBeenCalledWith("cron:run-finished", { jobId: "test-job", status: "error" });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]![1]).toContain("OAuth token expired");
+  });
+
+  it.each(["failed", "interrupted"] as const)(
+    "names the outcome when a %s attempt left no error behind",
+    async (attemptOutcome) => {
+      vi.mocked(getSession).mockReturnValue(makeSession({ attemptOutcome }));
+
+      const entry = await runOnce();
+
+      expect(entry["status"]).toBe("error");
+      expect(entry["error"]).toBe(`session ${attemptOutcome}`);
+    },
+  );
+
+  it("records a failure for a session left in error, whatever its attempt receipt says", async () => {
+    vi.mocked(getSession).mockReturnValue(makeSession({ status: "error", lastError: "engine crashed" }));
+
+    const entry = await runOnce();
+
+    expect(entry["status"]).toBe("error");
+    expect(entry["error"]).toBe("engine crashed");
+  });
+
+  it("leaves a succeeded attempt green and silent", async () => {
+    vi.mocked(getSession).mockReturnValue(makeSession({ attemptOutcome: "succeeded" }));
+
+    const entry = await runOnce();
+
+    expect(entry["status"]).toBe("success");
+    expect(entry["error"]).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("stays green when no session row can be found for the fire", async () => {
+    const entry = await runOnce();
+
+    expect(getSessionBySessionKey).toHaveBeenCalled();
+    expect(entry["status"]).toBe("success");
+    expect(entry["error"]).toBeNull();
+  });
+
+  it("stays green and warns once when the registry read fails", async () => {
+    vi.mocked(getSession).mockImplementation(() => {
+      throw new Error("database is locked");
+    });
+
+    const entry = await runOnce();
+
+    expect(entry["status"]).toBe("success");
+    expect(entry["error"]).toBeNull();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/jinn/src/cron/runner.ts
+++ b/packages/jinn/src/cron/runner.ts
@@ -1,9 +1,10 @@
-import type { CronJob, Connector, JinnConfig } from "../shared/types.js";
+import type { CronJob, Connector, JinnConfig, Session } from "../shared/types.js";
 import { logger } from "../shared/logger.js";
 import { appendRunLog } from "./jobs.js";
 import { orgRegistry } from "../gateway/org-registry.js";
 import { CronConnector } from "../connectors/cron/index.js";
 import type { SessionManager } from "../sessions/manager.js";
+import { getSession, getSessionBySessionKey } from "../sessions/registry.js";
 import { createWorkItem, linkSession, type WorkItem } from "../work-items/store.js";
 import { reconcileWorkItem } from "../work-items/reconcile.js";
 import { notifyTodoChanged } from "../work-items/live-events.js";
@@ -24,6 +25,18 @@ export interface RunCronJobOptions {
   fireIso?: string;
   /** Gateway broadcast seam. Absent in CLI/unit contexts without a live server. */
   emit?: GatewayEmit;
+}
+
+/**
+ * How a settled session failed, or null if it did not. `attemptOutcome` is the
+ * durable receipt for the attempt; `status === "error"` catches a session that was
+ * left broken without ever getting one.
+ */
+function sessionFailure(session: Session): "failed" | "interrupted" | "error" | null {
+  if (session.attemptOutcome === "failed" || session.attemptOutcome === "interrupted") {
+    return session.attemptOutcome;
+  }
+  return session.status === "error" ? "error" : null;
 }
 
 export async function runCronJob(
@@ -94,6 +107,20 @@ export async function runCronJob(
       `Cron job "${job.name}" work-item mint skipped: ${wiErr instanceof Error ? wiErr.message : wiErr}`,
     );
   }
+
+  const sendFailureAlert = async (message: string): Promise<void> => {
+    const alertConnector = config.cron?.alertConnector;
+    const alertChannel = config.cron?.alertChannel;
+    if (!alertConnector || !alertChannel) return;
+    const alertTarget = connectors.get(alertConnector);
+    if (!alertTarget) return;
+    await alertTarget.sendMessage(
+      { channel: alertChannel },
+      `⚠️ Cron job "${job.name}" failed:\n${message.slice(0, 500)}`,
+    ).catch((alertErr) => {
+      logger.error(`Failed to send cron alert: ${alertErr instanceof Error ? alertErr.message : alertErr}`);
+    });
+  };
 
   try {
     // Org scanning lives inside the try: org/ hot-reloads, and a malformed YAML
@@ -171,6 +198,39 @@ export async function runCronJob(
     }
 
     const durationMs = Date.now() - startTime;
+
+    // ICI-1410 — `route()` resolving is not the same as the turn succeeding. A dead
+    // auth chain, a rate limit, or an engine crash settles the session as failed and
+    // still returns here, so the run log has to read the session's own receipt. A
+    // registry hiccup must not fail a run that otherwise worked: it falls through to
+    // `success`, which keeps this guard able only to turn a FALSE green red.
+    let settled: Session | undefined;
+    try {
+      settled = (routeResult?.sessionId ? getSession(routeResult.sessionId) : undefined)
+        ?? getSessionBySessionKey(sessionKey);
+    } catch (lookupErr) {
+      logger.warn(
+        `Cron job "${job.name}" could not read its settled session: ${lookupErr instanceof Error ? lookupErr.message : lookupErr}`,
+      );
+    }
+
+    const failure = settled ? sessionFailure(settled) : null;
+    if (settled && failure) {
+      const message = settled.lastError || `session ${failure}`;
+      appendRunLog(job.id, {
+        timestamp: startedAt,
+        sessionKey,
+        sessionId: routeResult?.sessionId ?? null,
+        status: "error",
+        durationMs,
+        error: message,
+      });
+      opts?.emit?.("cron:run-finished", { jobId: job.id, status: "error" });
+      logger.error(`Cron job "${job.name}" failed after ${durationMs}ms: ${message}`);
+      await sendFailureAlert(message);
+      return;
+    }
+
     appendRunLog(job.id, {
       timestamp: startedAt,
       sessionKey,
@@ -213,19 +273,6 @@ export async function runCronJob(
     opts?.emit?.("cron:run-finished", { jobId: job.id, status: "error" });
     logger.error(`Cron job "${job.name}" failed: ${message}`);
 
-    // Send alert if configured
-    const alertConnector = config.cron?.alertConnector;
-    const alertChannel = config.cron?.alertChannel;
-    if (alertConnector && alertChannel) {
-      const alertTarget = connectors.get(alertConnector);
-      if (alertTarget) {
-        await alertTarget.sendMessage(
-          { channel: alertChannel },
-          `⚠️ Cron job "${job.name}" failed:\n${message.slice(0, 500)}`,
-        ).catch((alertErr) => {
-          logger.error(`Failed to send cron alert: ${alertErr instanceof Error ? alertErr.message : alertErr}`);
-        });
-      }
-    }
+    await sendFailureAlert(message);
   }
 }

--- a/packages/jinn/src/cron/runner.ts
+++ b/packages/jinn/src/cron/runner.ts
@@ -216,7 +216,7 @@ export async function runCronJob(
 
     const failure = settled ? sessionFailure(settled) : null;
     if (settled && failure) {
-      const message = settled.lastError || `session ${failure}`;
+      const message = settled.lastError ?? `session ${failure}`;
       appendRunLog(job.id, {
         timestamp: startedAt,
         sessionKey,

--- a/packages/web/src/components/chat/chat-pane-session-menu.tsx
+++ b/packages/web/src/components/chat/chat-pane-session-menu.tsx
@@ -1,10 +1,12 @@
-import { Ellipsis, PanelRightOpen, Share2 } from 'lucide-react'
+import { Ellipsis, ExternalLink, PanelRightOpen, Share2 } from 'lucide-react'
 import { useState } from 'react'
+import { sessionUrl } from '@/components/chat/chat-route-helpers'
 import { SessionRowMenu, SESSION_MENU_CONTENT_CLASS, SESSION_MENU_ITEM_CLASS, SESSION_MENU_SEPARATOR_CLASS } from '@/components/chat/session-row-menu'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import type { Session } from '@/components/chat/session-signals'
 import type { PaneSessionActions } from '@/components/chat/pane-session-actions'
 import { cn } from '@/lib/utils'
+import { openExternal } from '@/platform'
 import type { ViewMode } from '@/lib/view-mode'
 
 async function renamePane(title: string, sessionId: string, actions: PaneSessionActions, onRenamed: (title: string) => void): Promise<void> {
@@ -42,7 +44,7 @@ function PaneMenuTrigger({ title }: Pick<ChatPaneSessionMenuProps, 'title'>) {
   )
 }
 
-function PaneViewControls({ actions, viewMode, cliModeAvailable, viewSwitchLocked, cliTitle, onChange }: Pick<ChatPaneSessionMenuProps, 'actions' | 'viewMode' | 'cliModeAvailable' | 'viewSwitchLocked' | 'cliTitle'> & { onChange: (mode: ViewMode) => void }) {
+function PaneViewControls({ session, actions, viewMode, cliModeAvailable, viewSwitchLocked, cliTitle, onChange }: Pick<ChatPaneSessionMenuProps, 'session' | 'actions' | 'viewMode' | 'cliModeAvailable' | 'viewSwitchLocked' | 'cliTitle'> & { onChange: (mode: ViewMode) => void }) {
   if (!actions.openBeside) return null
   return (
     <>
@@ -70,12 +72,17 @@ function PaneViewControls({ actions, viewMode, cliModeAvailable, viewSwitchLocke
           )}
         >CLI</button>
       </div>
-      {/* Same label and same slot as the header's More menu: the view toggle, then Open
-          beside, then everything else. The pane title bar is the multi-pane home of an
-          action the header owns in single-pane, so the two have to read alike. */}
+      {/* Same labels and same slots as the header's More menu: the view toggle, then Open
+          beside, then Open in new tab, then everything else. The pane title bar is the
+          multi-pane home of actions the header owns in single-pane, so the two have to read
+          alike. */}
       <DropdownMenuItem className={SESSION_MENU_ITEM_CLASS} onClick={actions.openBeside}>
         <PanelRightOpen aria-hidden />
         Open beside
+      </DropdownMenuItem>
+      <DropdownMenuItem className={SESSION_MENU_ITEM_CLASS} onClick={() => { void openExternal(sessionUrl(session.id)) }}>
+        <ExternalLink aria-hidden />
+        Open in new tab
       </DropdownMenuItem>
       <DropdownMenuSeparator className={SESSION_MENU_SEPARATOR_CLASS} />
     </>

--- a/packages/web/src/components/chat/chat-route-helpers.ts
+++ b/packages/web/src/components/chat/chat-route-helpers.ts
@@ -73,6 +73,11 @@ export function sessionPath(id: string): string {
   return `/?session=${encodeURIComponent(id)}`
 }
 
+/** `sessionPath` made absolute, for handing to a new browser tab or the shell. */
+export function sessionUrl(id: string): string {
+  return new URL(sessionPath(id), window.location.href).toString()
+}
+
 /**
  * The mobile pane a chat load should open on: a URL-selected session (refresh,
  * deep link, direct open) lands in the THREAD; bare `/` lands on the LIST —

--- a/packages/web/src/platform/index.ts
+++ b/packages/web/src/platform/index.ts
@@ -1,5 +1,5 @@
 export { selectionFeedback } from "./feedback"
 export { getPlatform, installPlatform } from "./platform"
-export { copyText, share } from "./sharing"
+export { copyText, openExternal, share } from "./sharing"
 export { startKeyboardInset } from "./viewport"
 export type { Capability, OperationResult, Platform, Runtime } from "./contracts"

--- a/packages/web/src/platform/sharing.ts
+++ b/packages/web/src/platform/sharing.ts
@@ -8,3 +8,7 @@ export function share(content: { title?: string; text?: string; url?: string }):
 export function copyText(text: string): Promise<OperationResult> {
   return getPlatform().perform({ kind: "clipboard.copy", text })
 }
+
+export function openExternal(url: string): Promise<OperationResult> {
+  return getPlatform().perform({ kind: "navigation.open-external", url })
+}

--- a/packages/web/src/routes/chat/__tests__/chat-header-menu.test.tsx
+++ b/packages/web/src/routes/chat/__tests__/chat-header-menu.test.tsx
@@ -1,6 +1,9 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ChatHeaderMenu } from '../chat-header-menu'
+import { installPlatform } from '@/platform'
+import { createPlatform, type Runtime } from '@/platform/contracts'
+import { createTestAdapter, type TestAdapter } from '@/platform/adapters/test'
 
 const pinState = vi.hoisted(() => ({
   keys: new Set<string>(),
@@ -13,6 +16,18 @@ vi.mock('@/hooks/use-pins', () => ({
 }))
 
 const SESSION_ID = 'session-1'
+
+const runtime: Runtime = {
+  container: 'browser',
+  os: 'unknown',
+  engine: 'unknown',
+  secureContext: true,
+  appVersion: 'test',
+  userAgent: 'chat-header-menu-test',
+}
+
+let platform: TestAdapter
+let restorePlatform: () => void
 
 function renderMenu(overrides: Partial<Parameters<typeof ChatHeaderMenu>[0]> = {}) {
   return render(
@@ -48,6 +63,12 @@ function itemLabels() {
 beforeEach(() => {
   pinState.keys = new Set<string>()
   pinState.mutate = vi.fn()
+  platform = createTestAdapter({ results: { 'navigation.open-external': { status: 'performed' } } })
+  restorePlatform = installPlatform(createPlatform({ runtime, adapters: [platform] }))
+})
+
+afterEach(() => {
+  restorePlatform()
 })
 
 describe('ChatHeaderMenu', () => {
@@ -80,6 +101,7 @@ describe('ChatHeaderMenu', () => {
     expect(screen.queryByText('Unpin')).toBeNull()
     expect(screen.queryByText('Duplicate...')).toBeNull()
     expect(screen.queryByText('Archive chat')).toBeNull()
+    expect(screen.queryByText('Open in new tab')).toBeNull()
   })
 
   it('opens a picker pane beside the current chat and closes the menu', () => {
@@ -89,10 +111,28 @@ describe('ChatHeaderMenu', () => {
 
     const labels = itemLabels()
     expect(labels.indexOf('Open beside')).toBe(labels.indexOf('CLI') + 1)
-    expect(labels.indexOf('Open beside')).toBe(labels.indexOf('Pin') - 1)
+    expect(labels.indexOf('Open beside')).toBe(labels.indexOf('Open in new tab') - 1)
     fireEvent.click(screen.getByRole('button', { name: 'Open beside' }))
 
     expect(onOpenChatBeside).toHaveBeenCalledOnce()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('opens the selected chat in its own tab through the platform and closes the menu', async () => {
+    const onOpenChange = vi.fn()
+    renderMenu({ onOpenChange })
+
+    const labels = itemLabels()
+    expect(labels.indexOf('Open in new tab')).toBe(labels.indexOf('Open beside') + 1)
+    expect(labels.indexOf('Open in new tab')).toBe(labels.indexOf('Pin') - 1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open in new tab' }))
+
+    await waitFor(() => expect(platform.calls).toHaveLength(1))
+    const [intent] = platform.calls
+    expect(intent.kind).toBe('navigation.open-external')
+    const target = new URL((intent as Extract<typeof intent, { kind: 'navigation.open-external' }>).url)
+    expect(`${target.pathname}${target.search}`).toBe(`/?session=${encodeURIComponent(SESSION_ID)}`)
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 })

--- a/packages/web/src/routes/chat/__tests__/pane-focus-page.test.tsx
+++ b/packages/web/src/routes/chat/__tests__/pane-focus-page.test.tsx
@@ -115,6 +115,7 @@ describe('desktop pane focus', () => {
     fireEvent.pointerDown(within(paneB).getByRole('button', { name: 'Actions for Title b' }), { button: 0, ctrlKey: false })
     let menu = await screen.findByRole('menu')
     expect(within(menu).getByRole('menuitem', { name: 'Open beside' })).toBeTruthy()
+    expect(within(menu).getByRole('menuitem', { name: 'Open in new tab' })).toBeTruthy()
     expect(within(menu).getByRole('button', { name: 'Chat' })).toBeTruthy()
     expect(within(menu).getByRole('button', { name: 'CLI' })).toBeTruthy()
     // The pane title bar is the multi-pane home of the header's Open beside, so it has to
@@ -123,6 +124,7 @@ describe('desktop pane focus', () => {
     const paneMenuOrder = Array.from(menu.querySelectorAll('[role="menuitem"], button'))
       .map((element) => element.textContent?.trim() ?? '')
     expect(paneMenuOrder.indexOf('Open beside')).toBe(paneMenuOrder.indexOf('CLI') + 1)
+    expect(paneMenuOrder.indexOf('Open in new tab')).toBe(paneMenuOrder.indexOf('Open beside') + 1)
     expect(paneMenuOrder.indexOf('Open beside')).toBeLessThan(paneMenuOrder.indexOf('Rename'))
     expect(within(menu).getByRole('menuitem', { name: 'Copy CLI Resume Command' })).toBeTruthy()
     expect(within(menu).getByRole('menuitem', { name: 'Share debug log' })).toBeTruthy()

--- a/packages/web/src/routes/chat/chat-header-menu.tsx
+++ b/packages/web/src/routes/chat/chat-header-menu.tsx
@@ -1,5 +1,7 @@
-import { Archive, ArchiveRestore, Copy, MoreHorizontal, PanelRightOpen, Pin, PinOff, Search, Share2, Trash2 } from 'lucide-react'
+import { Archive, ArchiveRestore, Copy, ExternalLink, MoreHorizontal, PanelRightOpen, Pin, PinOff, Search, Share2, Trash2 } from 'lucide-react'
+import { sessionUrl } from '@/components/chat/chat-route-helpers'
 import { usePins, useTogglePin } from '@/hooks/use-pins'
+import { openExternal } from '@/platform'
 import { cn } from '@/lib/utils'
 import type { ViewMode } from '@/lib/view-mode'
 
@@ -33,7 +35,8 @@ type SelectedChatProps = Omit<ChatHeaderMenuProps, 'selectedId'> & { selectedId:
 // More (…) menu — rendered as the last control inside the right header pill.
 // D7: ALWAYS rendered (even on a new chat, where it carries Search, the view
 // toggle, and Open beside) so the right pill is consistent. When a session is
-// selected the items are grouped: primary (Search · view toggle · Open beside · Pin · Duplicate) → Developer
+// selected the items are grouped: primary (Search · view toggle · Open beside · Open in new
+// tab · Pin · Duplicate) → Developer
 // cluster → destructive Delete, each separated.
 //
 // Open state lives in the route, not here: the outside-click handler there
@@ -54,8 +57,8 @@ export function ChatHeaderMenu(props: ChatHeaderMenuProps) {
 
       {open && (
         <div className="absolute right-0 top-full z-[200] mt-2 min-w-[220px] overflow-hidden rounded-[var(--radius-md)] border border-border bg-[var(--material-thick)] shadow-[var(--shadow-overlay)] backdrop-blur-xl">
-          {/* PRIMARY group — Search (⌘K), the Chat/CLI view toggle, Open beside, then Pin and
-              Duplicate (only when a session is selected). */}
+          {/* PRIMARY group — Search (⌘K), the Chat/CLI view toggle, Open beside, then Open in
+              new tab, Pin and Duplicate (only when a session is selected). */}
           {/* D4: Search lives at the very top — the only visible ⌘K entry point on desktop. */}
           <button
             onClick={props.openGlobalSearch}
@@ -120,6 +123,13 @@ function SelectedChatItems(props: SelectedChatProps) {
 
   return (
     <>
+      <button
+        onClick={() => { void openExternal(sessionUrl(selectedId)); onOpenChange(false) }}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-subheadline text-foreground transition-colors hover:bg-accent"
+      >
+        <ExternalLink className="size-3.5" />
+        <span className="flex-1">Open in new tab</span>
+      </button>
       <PinItem selectedId={selectedId} onOpenChange={onOpenChange} />
       <button
         onClick={() => props.onDuplicate(selectedId)}


### PR DESCRIPTION
## Summary
- recover the independently verified cron settled-session logging fix from ICI-1410
- recover the independently verified chat open-in-new-tab action from ICI-1411
- publish both onto canonical origin/main after the former local-only landing workflow left them stranded

## Verification
- focused cron runner tests: 9 passed
- focused chat header/pane tests: 10 passed
- pnpm typecheck
- pnpm ratchet --check
- git diff --check

This PR deliberately contains only the three ticket commits; it does not merge the divergent local main.