### PR TITLE
Fix same-named media attachment identity (PLA-393)

### DIFF
--- a/packages/web/src/components/chat/__tests__/chat-pane-fixture.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-pane-fixture.tsx
@@ -1,0 +1,154 @@
+import { beforeEach, vi, type Mock } from 'vitest'
+import { render, type RenderResult } from '@testing-library/react'
+import type React from 'react'
+import type { MediaAttachment } from '@/lib/conversations'
+import { ChatPane } from '../chat-pane'
+
+let featuresState = {
+  notesEnabled: false,
+  staleChat: { enabled: true, tokenThreshold: 300_000, staleAfterMinutes: 60 },
+}
+
+const mocks = vi.hoisted(() => ({
+  uploadFile: vi.fn(),
+  createSession: vi.fn(),
+  updateSession: vi.fn(() => Promise.resolve({})),
+  sendMessage: vi.fn<(id: string, body: unknown) => Promise<Record<string, unknown>>>(() => Promise.resolve({})),
+}))
+
+vi.mock('@/lib/api', () => ({ api: mocks }))
+
+export const apiMocks: Record<'uploadFile' | 'createSession' | 'updateSession' | 'sendMessage', Mock> = mocks
+
+vi.mock('@/hooks/use-employees', () => {
+  const result = { data: { employees: [{ name: 'platform-lead', displayName: 'Platform Lead' }] } }
+  return { useOrg: () => result }
+})
+
+vi.mock('@/hooks/use-features', () => ({
+  useFeatures: () => ({ data: featuresState, isPending: false }),
+}))
+
+interface LiveSessionMockState {
+  messages: unknown[]
+  streamingText: string
+  loading: boolean
+  hydrating: boolean
+  session: Record<string, unknown> | null
+  error: Error | null
+  liveContextTokens: number | null
+  backgroundActivity: unknown
+  reload: ReturnType<typeof vi.fn>
+  beginSend: ReturnType<typeof vi.fn>
+  updateSendMedia: ReturnType<typeof vi.fn>
+  failSend: ReturnType<typeof vi.fn>
+  appendLocal: ReturnType<typeof vi.fn>
+  reset: ReturnType<typeof vi.fn>
+}
+
+export const liveSessionDefaults: LiveSessionMockState = {
+  messages: [],
+  streamingText: '',
+  loading: false,
+  hydrating: false,
+  session: { id: 's1', status: 'idle', engine: 'claude', model: 'opus' },
+  error: null,
+  liveContextTokens: null,
+  backgroundActivity: null,
+  reload: vi.fn(),
+  beginSend: vi.fn(),
+  updateSendMedia: vi.fn(),
+  failSend: vi.fn(),
+  appendLocal: vi.fn(),
+  reset: vi.fn(),
+}
+
+export const pane = {
+  liveSessionState: { ...liveSessionDefaults },
+  composerOnSend: null as ((message: string, media?: MediaAttachment[]) => Promise<boolean>) | null,
+  messagesOnRetry: null as ((message: string) => void) | null,
+  composerActive: undefined as boolean | undefined,
+}
+
+vi.mock('@/hooks/use-live-session', () => ({
+  useLiveSession: () => pane.liveSessionState,
+}))
+
+vi.mock('@/components/chat/chat-input', () => ({
+  ChatInput: ({ selectorSlot, statusSlot, onSend, isActive }: {
+    selectorSlot?: React.ReactNode
+    statusSlot?: React.ReactNode
+    onSend: (message: string, media?: MediaAttachment[]) => Promise<boolean>
+    isActive?: boolean
+  }) => {
+    pane.composerOnSend = onSend
+    pane.composerActive = isActive
+    return <div data-testid="chat-input" data-active={String(isActive)}>{selectorSlot}{statusSlot}</div>
+  },
+}))
+
+vi.mock('@/components/chat/model-selector-row', () => ({
+  ModelSelectorRow: ({ onChange }: { onChange: (next: { engine?: string; model?: string; effortLevel?: string }) => void }) => (
+    <button
+      type="button"
+      onClick={() => onChange({ engine: 'codex', model: 'gpt-5.5', effortLevel: 'medium' })}
+    >
+      selector switch engine
+    </button>
+  ),
+}))
+
+vi.mock('@/components/chat/chat-messages', () => ({
+  ChatMessages: ({ footer, onRetry }: { footer?: React.ReactNode; onRetry?: (message: string) => void }) => {
+    pane.messagesOnRetry = onRetry ?? null
+    return <div data-testid="messages">{footer}</div>
+  },
+}))
+
+vi.mock('@/components/chat/chat-employee-picker', () => ({
+  ChatEmployeePicker: () => <div data-testid="employee-picker" />,
+}))
+
+
+vi.mock('@/components/chat/background-activity-status', () => ({
+  BackgroundActivityStatus: ({ delegatedActivity, employeeDisplayNames }: {
+    delegatedActivity?: { activeSessions: number; employees: string[] } | null
+    employeeDisplayNames?: Record<string, string>
+  }) => (
+    <div data-testid="background-status">
+      {delegatedActivity?.activeSessions ?? 0}:{employeeDisplayNames?.['platform-lead'] ?? ''}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/chat/cli-keybar', () => ({
+  CliKeybar: () => null,
+}))
+
+export function renderPane(props: Partial<React.ComponentProps<typeof ChatPane>> = {}): RenderResult {
+  return render(
+    <ChatPane
+      sessionId="s1"
+      isActive
+      onFocus={() => {}}
+      subscribe={() => () => {}}
+      events={[]}
+      {...props}
+    />,
+  )
+}
+
+beforeEach(() => {
+  pane.liveSessionState = { ...liveSessionDefaults, beginSend: vi.fn(), updateSendMedia: vi.fn() }
+  featuresState = {
+    notesEnabled: false,
+    staleChat: { enabled: true, tokenThreshold: 300_000, staleAfterMinutes: 60 },
+  }
+  apiMocks.updateSession.mockClear()
+  apiMocks.sendMessage.mockReset()
+  apiMocks.sendMessage.mockResolvedValue({})
+  pane.composerOnSend = null
+  pane.messagesOnRetry = null
+  pane.composerActive = undefined
+  localStorage.clear()
+})

--- a/packages/web/src/components/chat/__tests__/chat-pane-media.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-pane-media.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { act } from '@testing-library/react'
+import { apiMocks, pane, renderPane } from './chat-pane-fixture'
+import { reconcileMessages, type MediaAttachment, type Message } from '@/lib/conversations'
+
+describe('ChatPane media identity', () => {
+  it.each(['s1', null])('associates same-named uploads before dispatch and new-session handoff (%s)', async (sessionId) => {
+    const media: MediaAttachment[] = ['a', 'b'].map((id) => ({
+      type: 'video', url: `blob:${id}`, name: 'capture.mp4',
+      file: new File([id], 'capture.mp4', { type: 'video/mp4' }),
+    }))
+    apiMocks.uploadFile.mockReset().mockResolvedValueOnce({ id: 'a' }).mockResolvedValueOnce({ id: 'b' })
+    const onSessionCreated = vi.fn()
+    let optimistic: Message | undefined
+    pane.liveSessionState.beginSend.mockImplementation((message: Message) => { optimistic = { ...message } })
+    pane.liveSessionState.updateSendMedia.mockImplementation((id: string, uploaded: MediaAttachment[]) => {
+      expect(id).toBe(optimistic?.id)
+      optimistic = { ...optimistic!, media: uploaded }
+    })
+    const persisted = (): Message => ({
+      id: 'server', role: 'user', content: 'compare', timestamp: Date.now(),
+      media: ['a', 'b'].map((id) => ({ type: 'video', name: 'capture.mp4', url: `/api/files/${id}` })),
+    })
+    const dispatch = async () => {
+      const merged = reconcileMessages([optimistic!], [persisted()])
+      expect(merged).toHaveLength(1)
+      expect(merged[0].id).toBe(optimistic?.id)
+      return { id: 'new-session' }
+    }
+    apiMocks.sendMessage.mockImplementation(dispatch)
+    apiMocks.createSession.mockImplementation(dispatch)
+    renderPane({ sessionId, onSessionCreated })
+
+    await act(async () => { expect(await pane.composerOnSend?.('compare', media)).toBe(true) })
+
+    expect(optimistic?.media?.map((item) => item.fileId)).toEqual(['a', 'b'])
+    const call = sessionId ? apiMocks.sendMessage.mock.calls[0]?.[1] : apiMocks.createSession.mock.calls[0]?.[0]
+    expect(call).toMatchObject({ attachments: ['a', 'b'] })
+    if (!sessionId) {
+      expect(onSessionCreated).toHaveBeenCalledWith('new-session', expect.objectContaining({ media: optimistic?.media }))
+    }
+  })
+
+})

--- a/packages/web/src/components/chat/__tests__/chat-pane.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-pane.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import type React from 'react'
+import type { MediaAttachment, Message } from '@/lib/conversations'
+import { reconcileMessages } from '@/lib/conversations'
 import { ChatPane } from '../chat-pane'
 import type { GatewayEvent } from '@jinn/gateway-events'
 import { CHAT_SESSION_DND_MIME } from '@/routes/chat/chat-session-dnd'
@@ -11,15 +13,18 @@ let featuresState = {
 }
 
 const apiMocks = vi.hoisted(() => ({
+  uploadFile: vi.fn(),
+  createSession: vi.fn(),
   updateSession: vi.fn(() => Promise.resolve({})),
-  sendMessage: vi.fn(() => Promise.resolve({})),
+  sendMessage: vi.fn<(id: string, body: unknown) => Promise<Record<string, unknown>>>(() => Promise.resolve({})),
 }))
 
 vi.mock('@/lib/api', () => ({ api: apiMocks }))
 
-vi.mock('@/hooks/use-employees', () => ({
-  useOrg: () => ({ data: { employees: [{ name: 'platform-lead', displayName: 'Platform Lead' }] } }),
-}))
+vi.mock('@/hooks/use-employees', () => {
+  const result = { data: { employees: [{ name: 'platform-lead', displayName: 'Platform Lead' }] } }
+  return { useOrg: () => result }
+})
 
 vi.mock('@/hooks/use-features', () => ({
   useFeatures: () => ({ data: featuresState, isPending: false }),
@@ -36,6 +41,7 @@ interface LiveSessionMockState {
   backgroundActivity: unknown
   reload: ReturnType<typeof vi.fn>
   beginSend: ReturnType<typeof vi.fn>
+  updateSendMedia: ReturnType<typeof vi.fn>
   failSend: ReturnType<typeof vi.fn>
   appendLocal: ReturnType<typeof vi.fn>
   reset: ReturnType<typeof vi.fn>
@@ -52,13 +58,14 @@ const liveSessionDefaults: LiveSessionMockState = {
   backgroundActivity: null,
   reload: vi.fn(),
   beginSend: vi.fn(),
+  updateSendMedia: vi.fn(),
   failSend: vi.fn(),
   appendLocal: vi.fn(),
   reset: vi.fn(),
 }
 
 let liveSessionState: LiveSessionMockState
-let composerOnSend: ((message: string) => Promise<boolean>) | null
+let composerOnSend: ((message: string, media?: MediaAttachment[]) => Promise<boolean>) | null
 let messagesOnRetry: ((message: string) => void) | null
 let composerActive: boolean | undefined
 
@@ -70,7 +77,7 @@ vi.mock('@/components/chat/chat-input', () => ({
   ChatInput: ({ selectorSlot, statusSlot, onSend, isActive }: {
     selectorSlot?: React.ReactNode
     statusSlot?: React.ReactNode
-    onSend: (message: string) => Promise<boolean>
+    onSend: (message: string, media?: MediaAttachment[]) => Promise<boolean>
     isActive?: boolean
   }) => {
     composerOnSend = onSend
@@ -132,7 +139,7 @@ function renderPane(props: Partial<React.ComponentProps<typeof ChatPane>> = {}) 
 
 describe('ChatPane', () => {
   beforeEach(() => {
-    liveSessionState = { ...liveSessionDefaults }
+    liveSessionState = { ...liveSessionDefaults, beginSend: vi.fn(), updateSendMedia: vi.fn() }
     featuresState = {
       notesEnabled: false,
       staleChat: { enabled: true, tokenThreshold: 300_000, staleAfterMinutes: 60 },
@@ -144,6 +151,43 @@ describe('ChatPane', () => {
     messagesOnRetry = null
     composerActive = undefined
     localStorage.clear()
+  })
+
+  it.each(['s1', null])('associates same-named uploads before dispatch and new-session handoff (%s)', async (sessionId) => {
+    const media: MediaAttachment[] = ['a', 'b'].map((id) => ({
+      type: 'video', url: `blob:${id}`, name: 'capture.mp4',
+      file: new File([id], 'capture.mp4', { type: 'video/mp4' }),
+    }))
+    apiMocks.uploadFile.mockReset().mockResolvedValueOnce({ id: 'a' }).mockResolvedValueOnce({ id: 'b' })
+    const onSessionCreated = vi.fn()
+    let optimistic: Message | undefined
+    liveSessionState.beginSend.mockImplementation((message: Message) => { optimistic = { ...message } })
+    liveSessionState.updateSendMedia.mockImplementation((id: string, uploaded: MediaAttachment[]) => {
+      expect(id).toBe(optimistic?.id)
+      optimistic = { ...optimistic!, media: uploaded }
+    })
+    const persisted = (): Message => ({
+      id: 'server', role: 'user', content: 'compare', timestamp: Date.now(),
+      media: ['a', 'b'].map((id) => ({ type: 'video', name: 'capture.mp4', url: `/api/files/${id}` })),
+    })
+    const dispatch = async () => {
+      const merged = reconcileMessages([optimistic!], [persisted()])
+      expect(merged).toHaveLength(1)
+      expect(merged[0].id).toBe(optimistic?.id)
+      return { id: 'new-session' }
+    }
+    apiMocks.sendMessage.mockImplementation(dispatch)
+    apiMocks.createSession.mockImplementation(dispatch)
+    renderPane({ sessionId, onSessionCreated })
+
+    await act(async () => { expect(await composerOnSend?.('compare', media)).toBe(true) })
+
+    expect(optimistic?.media?.map((item) => item.fileId)).toEqual(['a', 'b'])
+    const call = sessionId ? apiMocks.sendMessage.mock.calls[0]?.[1] : apiMocks.createSession.mock.calls[0]?.[0]
+    expect(call).toMatchObject({ attachments: ['a', 'b'] })
+    if (!sessionId) {
+      expect(onSessionCreated).toHaveBeenCalledWith('new-session', expect.objectContaining({ media: optimistic?.media }))
+    }
   })
 
   it('makes focus state real at the pane and composer boundaries', () => {

--- a/packages/web/src/components/chat/__tests__/chat-pane.test.tsx
+++ b/packages/web/src/components/chat/__tests__/chat-pane.test.tsx
@@ -1,201 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen } from '@testing-library/react'
-import type React from 'react'
-import type { MediaAttachment, Message } from '@/lib/conversations'
-import { reconcileMessages } from '@/lib/conversations'
+import { apiMocks, liveSessionDefaults, pane, renderPane } from './chat-pane-fixture'
 import { ChatPane } from '../chat-pane'
 import type { GatewayEvent } from '@jinn/gateway-events'
 import { CHAT_SESSION_DND_MIME } from '@/routes/chat/chat-session-dnd'
 
-let featuresState = {
-  notesEnabled: false,
-  staleChat: { enabled: true, tokenThreshold: 300_000, staleAfterMinutes: 60 },
-}
-
-const apiMocks = vi.hoisted(() => ({
-  uploadFile: vi.fn(),
-  createSession: vi.fn(),
-  updateSession: vi.fn(() => Promise.resolve({})),
-  sendMessage: vi.fn<(id: string, body: unknown) => Promise<Record<string, unknown>>>(() => Promise.resolve({})),
-}))
-
-vi.mock('@/lib/api', () => ({ api: apiMocks }))
-
-vi.mock('@/hooks/use-employees', () => {
-  const result = { data: { employees: [{ name: 'platform-lead', displayName: 'Platform Lead' }] } }
-  return { useOrg: () => result }
-})
-
-vi.mock('@/hooks/use-features', () => ({
-  useFeatures: () => ({ data: featuresState, isPending: false }),
-}))
-
-interface LiveSessionMockState {
-  messages: unknown[]
-  streamingText: string
-  loading: boolean
-  hydrating: boolean
-  session: Record<string, unknown> | null
-  error: Error | null
-  liveContextTokens: number | null
-  backgroundActivity: unknown
-  reload: ReturnType<typeof vi.fn>
-  beginSend: ReturnType<typeof vi.fn>
-  updateSendMedia: ReturnType<typeof vi.fn>
-  failSend: ReturnType<typeof vi.fn>
-  appendLocal: ReturnType<typeof vi.fn>
-  reset: ReturnType<typeof vi.fn>
-}
-
-const liveSessionDefaults: LiveSessionMockState = {
-  messages: [],
-  streamingText: '',
-  loading: false,
-  hydrating: false,
-  session: { id: 's1', status: 'idle', engine: 'claude', model: 'opus' },
-  error: null,
-  liveContextTokens: null,
-  backgroundActivity: null,
-  reload: vi.fn(),
-  beginSend: vi.fn(),
-  updateSendMedia: vi.fn(),
-  failSend: vi.fn(),
-  appendLocal: vi.fn(),
-  reset: vi.fn(),
-}
-
-let liveSessionState: LiveSessionMockState
-let composerOnSend: ((message: string, media?: MediaAttachment[]) => Promise<boolean>) | null
-let messagesOnRetry: ((message: string) => void) | null
-let composerActive: boolean | undefined
-
-vi.mock('@/hooks/use-live-session', () => ({
-  useLiveSession: () => liveSessionState,
-}))
-
-vi.mock('@/components/chat/chat-input', () => ({
-  ChatInput: ({ selectorSlot, statusSlot, onSend, isActive }: {
-    selectorSlot?: React.ReactNode
-    statusSlot?: React.ReactNode
-    onSend: (message: string, media?: MediaAttachment[]) => Promise<boolean>
-    isActive?: boolean
-  }) => {
-    composerOnSend = onSend
-    composerActive = isActive
-    return <div data-testid="chat-input" data-active={String(isActive)}>{selectorSlot}{statusSlot}</div>
-  },
-}))
-
-vi.mock('@/components/chat/model-selector-row', () => ({
-  ModelSelectorRow: ({ onChange }: { onChange: (next: { engine?: string; model?: string; effortLevel?: string }) => void }) => (
-    <button
-      type="button"
-      onClick={() => onChange({ engine: 'codex', model: 'gpt-5.5', effortLevel: 'medium' })}
-    >
-      selector switch engine
-    </button>
-  ),
-}))
-
-vi.mock('@/components/chat/chat-messages', () => ({
-  ChatMessages: ({ footer, onRetry }: { footer?: React.ReactNode; onRetry?: (message: string) => void }) => {
-    messagesOnRetry = onRetry ?? null
-    return <div data-testid="messages">{footer}</div>
-  },
-}))
-
-vi.mock('@/components/chat/chat-employee-picker', () => ({
-  ChatEmployeePicker: () => <div data-testid="employee-picker" />,
-}))
-
-
-vi.mock('@/components/chat/background-activity-status', () => ({
-  BackgroundActivityStatus: ({ delegatedActivity, employeeDisplayNames }: {
-    delegatedActivity?: { activeSessions: number; employees: string[] } | null
-    employeeDisplayNames?: Record<string, string>
-  }) => (
-    <div data-testid="background-status">
-      {delegatedActivity?.activeSessions ?? 0}:{employeeDisplayNames?.['platform-lead'] ?? ''}
-    </div>
-  ),
-}))
-
-vi.mock('@/components/chat/cli-keybar', () => ({
-  CliKeybar: () => null,
-}))
-
-function renderPane(props: Partial<React.ComponentProps<typeof ChatPane>> = {}) {
-  return render(
-    <ChatPane
-      sessionId="s1"
-      isActive
-      onFocus={() => {}}
-      subscribe={() => () => {}}
-      events={[]}
-      {...props}
-    />,
-  )
-}
-
 describe('ChatPane', () => {
-  beforeEach(() => {
-    liveSessionState = { ...liveSessionDefaults, beginSend: vi.fn(), updateSendMedia: vi.fn() }
-    featuresState = {
-      notesEnabled: false,
-      staleChat: { enabled: true, tokenThreshold: 300_000, staleAfterMinutes: 60 },
-    }
-    apiMocks.updateSession.mockClear()
-    apiMocks.sendMessage.mockReset()
-    apiMocks.sendMessage.mockResolvedValue({})
-    composerOnSend = null
-    messagesOnRetry = null
-    composerActive = undefined
-    localStorage.clear()
-  })
-
-  it.each(['s1', null])('associates same-named uploads before dispatch and new-session handoff (%s)', async (sessionId) => {
-    const media: MediaAttachment[] = ['a', 'b'].map((id) => ({
-      type: 'video', url: `blob:${id}`, name: 'capture.mp4',
-      file: new File([id], 'capture.mp4', { type: 'video/mp4' }),
-    }))
-    apiMocks.uploadFile.mockReset().mockResolvedValueOnce({ id: 'a' }).mockResolvedValueOnce({ id: 'b' })
-    const onSessionCreated = vi.fn()
-    let optimistic: Message | undefined
-    liveSessionState.beginSend.mockImplementation((message: Message) => { optimistic = { ...message } })
-    liveSessionState.updateSendMedia.mockImplementation((id: string, uploaded: MediaAttachment[]) => {
-      expect(id).toBe(optimistic?.id)
-      optimistic = { ...optimistic!, media: uploaded }
-    })
-    const persisted = (): Message => ({
-      id: 'server', role: 'user', content: 'compare', timestamp: Date.now(),
-      media: ['a', 'b'].map((id) => ({ type: 'video', name: 'capture.mp4', url: `/api/files/${id}` })),
-    })
-    const dispatch = async () => {
-      const merged = reconcileMessages([optimistic!], [persisted()])
-      expect(merged).toHaveLength(1)
-      expect(merged[0].id).toBe(optimistic?.id)
-      return { id: 'new-session' }
-    }
-    apiMocks.sendMessage.mockImplementation(dispatch)
-    apiMocks.createSession.mockImplementation(dispatch)
-    renderPane({ sessionId, onSessionCreated })
-
-    await act(async () => { expect(await composerOnSend?.('compare', media)).toBe(true) })
-
-    expect(optimistic?.media?.map((item) => item.fileId)).toEqual(['a', 'b'])
-    const call = sessionId ? apiMocks.sendMessage.mock.calls[0]?.[1] : apiMocks.createSession.mock.calls[0]?.[0]
-    expect(call).toMatchObject({ attachments: ['a', 'b'] })
-    if (!sessionId) {
-      expect(onSessionCreated).toHaveBeenCalledWith('new-session', expect.objectContaining({ media: optimistic?.media }))
-    }
-  })
-
   it('makes focus state real at the pane and composer boundaries', () => {
     const onFocus = vi.fn()
     const { container } = renderPane({ isActive: false, onFocus })
 
     expect(container.querySelector('[data-chat-pane-active="false"]')).toBeTruthy()
-    expect(composerActive).toBe(false)
+    expect(pane.composerActive).toBe(false)
     fireEvent.focusIn(screen.getByTestId('chat-input'))
     expect(onFocus).toHaveBeenCalledOnce()
   })
@@ -203,7 +19,7 @@ describe('ChatPane', () => {
   it('renders pane-owned chrome only in a multi-pane layout', () => {
     const onFocus = vi.fn()
     const onClose = vi.fn()
-    liveSessionState = {
+    pane.liveSessionState = {
       ...liveSessionDefaults,
       loading: true,
       session: { id: 's1', title: '#9 - Focus work', employee: 'platform-lead', status: 'running' },
@@ -264,16 +80,16 @@ describe('ChatPane', () => {
   it('returns failed delivery while retaining the optimistic bubble and retry path', async () => {
     apiMocks.sendMessage.mockRejectedValueOnce(new Error('transport aborted')).mockResolvedValueOnce({})
     renderPane()
-    const first = await composerOnSend?.('Retry this message.')
+    const first = await pane.composerOnSend?.('Retry this message.')
     expect(first).toBe(false)
-    expect(liveSessionState.beginSend).toHaveBeenCalledTimes(1)
-    expect(liveSessionState.failSend).toHaveBeenCalledWith('transport aborted')
+    expect(pane.liveSessionState.beginSend).toHaveBeenCalledTimes(1)
+    expect(pane.liveSessionState.failSend).toHaveBeenCalledWith('transport aborted')
 
-    messagesOnRetry?.('Retry this message.')
+    pane.messagesOnRetry?.('Retry this message.')
 
     await vi.waitFor(() => expect(apiMocks.sendMessage).toHaveBeenCalledTimes(2))
-    expect(liveSessionState.beginSend).toHaveBeenCalledTimes(2)
-    expect(liveSessionState.failSend).toHaveBeenCalledTimes(1)
+    expect(pane.liveSessionState.beginSend).toHaveBeenCalledTimes(2)
+    expect(pane.liveSessionState.failSend).toHaveBeenCalledTimes(1)
   })
 
   it('persists existing-chat engine switching on the same session', () => {
@@ -293,7 +109,7 @@ describe('ChatPane', () => {
   it('shows a lightweight loading status instead of an empty new-chat picker while a session hydrates', () => {
     vi.useFakeTimers()
     try {
-      liveSessionState = { ...liveSessionDefaults, hydrating: true, session: null }
+      pane.liveSessionState = { ...liveSessionDefaults, hydrating: true, session: null }
 
       renderPane()
 
@@ -331,9 +147,9 @@ describe('ChatPane', () => {
     expect(onContentReady).toHaveBeenCalledOnce()
     expect(onContentReady).toHaveBeenCalledWith('s1')
 
-    liveSessionState = {
-      ...liveSessionState,
-      session: { ...liveSessionState.session, title: 'Metadata landed before paint' },
+    pane.liveSessionState = {
+      ...pane.liveSessionState,
+      session: { ...pane.liveSessionState.session, title: 'Metadata landed before paint' },
     }
     rerender(<ChatPane {...props} />)
     expect(onContentReady).toHaveBeenCalledOnce()

--- a/packages/web/src/components/chat/__tests__/same-named-media.test.tsx
+++ b/packages/web/src/components/chat/__tests__/same-named-media.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { reconcileMessages, type Message, type MediaAttachment } from '@/lib/conversations'
+import { MessageMedia } from '../message-media'
+
+function attachment(id: string, url: string, type: MediaAttachment['type']): Message {
+  return {
+    id, role: 'assistant', content: '', timestamp: 1000,
+    media: [{ type, url, name: type === 'image' ? 'capture.png' : 'capture.mp4', mimeType: type === 'image' ? 'image/png' : 'video/mp4' }],
+  }
+}
+
+describe.each(['video', 'file', 'image'] as const)('same-named %s sources', (type) => {
+  it('keeps both file references through a history refresh and renders each source', () => {
+    const first = attachment('history-a', '/api/files/a', type)
+    const second = attachment('live-b', '/api/files/b', type)
+    const merged = reconcileMessages([second], [first], 2000)
+    render(<MessageMedia media={merged.flatMap((m) => m.media ?? [])} isUser={false} />)
+
+    if (type === 'image') {
+      const openers = screen.getAllByLabelText('Open capture.png')
+      expect(openers).toHaveLength(2)
+      for (const [index, url] of ['/api/files/a', '/api/files/b'].entries()) {
+        fireEvent.click(openers[index])
+        expect(screen.getByLabelText('Download image').getAttribute('href')).toBe(url)
+        fireEvent.click(screen.getByLabelText('Close'))
+      }
+    } else {
+      const playButtons = screen.getAllByLabelText('Play capture.mp4')
+      expect(playButtons).toHaveLength(2)
+      playButtons.forEach((button) => fireEvent.click(button))
+      const players = screen.getAllByTestId('video-player-element')
+      expect(players.map((player) => player.getAttribute('src'))).toEqual(['/api/files/a?quality=low', '/api/files/b?quality=low'])
+    }
+    expect(merged.map((m) => m.id)).toEqual(['history-a', 'live-b'])
+  })
+
+  it('still groups a live attachment with its identical persisted reference', () => {
+    const live = attachment('local-a', '/api/files/a', type)
+    const persisted = attachment('history-a', '/api/files/a', type)
+    const merged = reconcileMessages([live], [persisted], 2000)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toMatchObject({ id: live.id, media: persisted.media })
+  })
+})

--- a/packages/web/src/components/chat/chat-pane.tsx
+++ b/packages/web/src/components/chat/chat-pane.tsx
@@ -138,6 +138,7 @@ export function ChatPane({
     blockAnnouncement,
     loadOlderMessages,
     beginSend,
+    updateSendMedia,
     failSend,
     appendLocal,
     reset: resetPane,
@@ -312,13 +313,14 @@ export function ChatPane({
         // Upload any attached files to the server in parallel and collect file IDs
         let attachmentIds: string[] | undefined
         if (media && media.length > 0) {
-          const uploadPromises = media
-            .filter((att) => att.file)
-            .map((att) => api.uploadFile(att.file!, sessionIdRef.current || undefined))
-          if (uploadPromises.length > 0) {
-            const uploaded = await Promise.all(uploadPromises)
-            attachmentIds = uploaded.map((u) => u.id)
-          }
+          const uploadedMedia = await Promise.all(media.map(async (att) => {
+            if (!att.file) return att
+            const uploaded = await api.uploadFile(att.file, sessionIdRef.current || undefined)
+            return { ...att, fileId: uploaded.id }
+          }))
+          attachmentIds = uploadedMedia.flatMap((att) => att.fileId ? [att.fileId] : [])
+          userMsg.media = uploadedMedia
+          updateSendMedia(userMsg.id, uploadedMedia)
         }
 
         let sid = sessionId
@@ -355,7 +357,7 @@ export function ChatPane({
       }
     },
     // Keep viewMode and stale-notice handling fresh across chat↔CLI sends.
-    [sessionId, selectedEmployee, onSessionCreated, onRefresh, viewMode, selector, currentSession?.engine, engineRegistry, beginSend, failSend, answerStaleChatBySending, sessionQueue]
+    [sessionId, selectedEmployee, onSessionCreated, onRefresh, viewMode, selector, currentSession?.engine, engineRegistry, beginSend, updateSendMedia, failSend, answerStaleChatBySending, sessionQueue]
   )
 
   const handleStatusRequest = useCallback(async () => {

--- a/packages/web/src/components/chat/chat-pane.tsx
+++ b/packages/web/src/components/chat/chat-pane.tsx
@@ -286,7 +286,6 @@ export function ChatPane({
     }
   }, [selector, currentSession?.engine, currentSession?.engineSessionId])
 
-
   const handleInterrupt = useCallback(async () => {
     if (!sessionId) return
     try {
@@ -310,7 +309,6 @@ export function ChatPane({
       answerStaleChatBySending()
 
       try {
-        // Upload any attached files to the server in parallel and collect file IDs
         let attachmentIds: string[] | undefined
         if (media && media.length > 0) {
           const uploadedMedia = await Promise.all(media.map(async (att) => {

--- a/packages/web/src/hooks/__tests__/use-live-session-send.test.ts
+++ b/packages/web/src/hooks/__tests__/use-live-session-send.test.ts
@@ -51,6 +51,32 @@ describe("useLiveSession send lifecycle", () => {
     expect(result.current.loading).toBe(true)
   })
 
+  it("retains uploaded identities through stale history and matches the persisted twin", async () => {
+    getSession.mockResolvedValue({ status: "idle", messages: [] })
+    const { subscribe } = makeBus()
+    const { result } = renderHook(() => useLiveSession("s1", { subscribe }))
+    await act(async () => { await Promise.resolve() })
+    const timestamp = Date.now()
+    act(() => {
+      result.current.beginSend({ id: "local", role: "user", content: "compare", timestamp,
+        media: [{ type: "video", name: "capture.mp4", url: "blob:preview" }] })
+    })
+    act(() => {
+      result.current.updateSendMedia("local", [{ type: "video", name: "capture.mp4", url: "blob:preview", fileId: "uploaded" }])
+    })
+    await act(async () => { await result.current.reload("s1") })
+    expect(result.current.messages[0].media?.[0].fileId).toBe("uploaded")
+    expect(result.current.messages[0].sendState).toBe("pending")
+
+    getSession.mockResolvedValue({ status: "idle", messages: [{
+      id: "server", role: "user", content: "compare", timestamp,
+      media: [{ type: "video", name: "capture.mp4", url: "/api/files/uploaded" }],
+    }] })
+    await act(async () => { await result.current.reload("s1") })
+    expect(result.current.messages).toHaveLength(1)
+    expect(result.current.messages[0]).toMatchObject({ id: "local", media: [{ url: "/api/files/uploaded" }] })
+  })
+
   it("settles the pending bubble on the first frame of the turn", async () => {
     getSession.mockResolvedValue({ status: "idle", messages: [] })
     const { subscribe, emit } = makeBus()

--- a/packages/web/src/hooks/use-live-session.ts
+++ b/packages/web/src/hooks/use-live-session.ts
@@ -1,23 +1,10 @@
 /**
- * useLiveSession — the live read pipeline for one gateway session.
+ * Live messages, streaming events and history reconciliation for one session.
+ * Shared by ChatPane and the read-only Talk child-session modal.
  *
- * Extracted verbatim from ChatPane so it can be reused read-only by the Talk
- * child-session modal (which previously only refetched on terminal events and
- * thus never showed live streaming or live media). It owns:
- *   - the message list + the optimistic streaming-text bubble
- *   - the full WS event set (session:delta text/tool/context, :notification,
- *     :attachment, :interrupted, :stopped, :completed)
- *   - server load + reconcile (lib/conversations.reconcileMessages)
- *   - reconnect (connectionSeq) backfill + the dropped-completion watchdog
- *
- * ChatPane consumes the SAME hook for its read side and keeps its composer/send
- * on top, driving the optimistic write path through the small write API
- * (beginSend/failSend/appendLocal/reset). The modal passes `readOnly: true`,
- * which seeds `loading` from the session's running state and skips the
- * localStorage intermediate cache (that cache belongs to the editable pane).
- *
- * Behaviour for the editable (ChatPane) path is intended to be byte-for-byte
- * identical to the previous inline implementation.
+ * ChatPane drives optimistic sends through the write API, including uploaded
+ * media identities before dispatch. Read-only consumers seed loading from the
+ * server and skip the editable pane's localStorage intermediate cache.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '@/lib/api'

--- a/packages/web/src/hooks/use-live-session.ts
+++ b/packages/web/src/hooks/use-live-session.ts
@@ -138,6 +138,8 @@ export interface UseLiveSessionResult {
   // --- write API (editable pane only) ---
   /** Optimistically append the user message + arm loading for a send. */
   beginSend: (userMsg: Message) => void
+  /** Associate uploaded file identities with the optimistic row before dispatch. */
+  updateSendMedia: (messageId: string, media: MediaAttachment[]) => void
   /** A send failed: clear loading + mark that user message failed. */
   failSend: (reason: string) => void
   /** Append a local-only message (status replies, etc.). */
@@ -1334,6 +1336,13 @@ export function useLiveSession(
     lastDeltaAtRef.current = Date.now()
   }, [])
 
+  const updateSendMedia = useCallback((messageId: string, media: MediaAttachment[]) => {
+    if (pendingUserMessageRef.current?.id === messageId) {
+      pendingUserMessageRef.current = { ...pendingUserMessageRef.current, media }
+    }
+    setMessages((prev) => prev.map((message) => message.id === messageId ? { ...message, media } : message))
+  }, [])
+
   const failSend = useCallback((reason: string) => {
     const failed = pendingUserMessageRef.current
     pendingUserMessageRef.current = null
@@ -1421,6 +1430,7 @@ export function useLiveSession(
     reload: loadSession,
     loadOlderMessages,
     beginSend,
+    updateSendMedia,
     failSend,
     appendLocal,
     reset,

--- a/packages/web/src/lib/__tests__/reconcile-messages.test.ts
+++ b/packages/web/src/lib/__tests__/reconcile-messages.test.ts
@@ -65,15 +65,15 @@ describe('reconcileMessages — attachment disappear regression', () => {
 
 describe('reconcileMessages — inbound user-message duplicate regression (v0.16.0)', () => {
   // Optimistic user message with image + video, appended with a CLIENT random id
-  // and base64 preview urls.
+  // and base64 preview urls, with IDs returned by the completed uploads.
   const optimisticUserMsg: Message = {
     id: 'client-random-uuid',
     role: 'user',
     content: 'what you see here?',
     timestamp: 5000,
     media: [
-      { type: 'image', url: 'data:image/jpeg;base64,AAAA', name: 'chest-front.jpg' },
-      { type: 'file', url: 'data:video/mp4;base64,BBBB', name: 'clip.mp4' },
+      { type: 'image', url: 'data:image/jpeg;base64,AAAA', fileId: 'img-id', name: 'chest-front.jpg' },
+      { type: 'file', url: 'data:video/mp4;base64,BBBB', fileId: 'vid-id', name: 'clip.mp4' },
     ],
   }
   // Server-persisted twin: DIFFERENT (canonical) id, /api/files urls, same names.
@@ -107,7 +107,7 @@ describe('reconcileMessages — inbound user-message duplicate regression (v0.16
       role: 'user',
       content: 'check the document',
       timestamp: 6000,
-      media: [{ type: 'file', url: 'blob:local-preview', name: filename }],
+      media: [{ type: 'file', url: 'blob:local-preview', fileId: 'file-id', name: filename }],
     }
     const persisted: Message = {
       id: 'server-unicode-id',

--- a/packages/web/src/lib/conversations.ts
+++ b/packages/web/src/lib/conversations.ts
@@ -54,17 +54,15 @@ export interface Message {
 /**
  * Content-identity key for a message, independent of its id. Used to recognise a
  * locally-appended optimistic message and its server-persisted twin as the SAME
- * message even though their ids differ. The media fingerprint keys on the file
- * NAME (stable across the optimistic base64-url copy and the server /api/files
- * copy) falling back to type, so it is robust to the url differing and to any
- * media type (image, audio, video → 'file', etc.).
+ * message even though their ids differ. Upload IDs survive the local preview →
+ * stored URL transition. Other attachments use their full URL: filenames are
+ * display labels and collide across distinct uploads (PLA-393).
  */
 export function messageIdentityKey(m: Message): string {
   const sep = '\u0000'
-  const mediaFp = (m.media || [])
-    .map((x) => x.name || x.type || x.url)
-    .sort()
-    .join('|')
+  const mediaFp = JSON.stringify((m.media || [])
+    .map((x) => x.fileId ? `/api/files/${x.fileId}` : x.url)
+    .sort())
   const blockFp = (m.blocks || [])
     .map((x) => `${x.id}:${x.type}:${x.version}`)
     .sort()

--- a/size-baseline.json
+++ b/size-baseline.json
@@ -1385,7 +1385,7 @@
       ]
     },
     "packages/web/src/hooks/use-live-session.ts": {
-      "lines": 1428,
+      "lines": 1425,
       "exempt": [
         "@typescript-eslint/no-floating-promises",
         "complexity",


### PR DESCRIPTION
Distinct media attachments with the same filename could replace one another during chat history reconciliation. Media identity now uses the uploaded file ID, normalized to its stored file URL, or the full URL for other references. Repeated references to the same file still reconcile to one message.

The composer now carries upload IDs into the optimistic row, pending history state, and new-session handoff before dispatch. This preserves preview URLs and stable message IDs while removing filename-based matching for videos and images.

Validation:
- Reproduced on current main: same-named video, legacy file-typed video, and image cases each rendered only one source before the fix.
- Regression tests cover separate playback/image selection, identical-reference grouping, stale history, and both existing/new-session sends.
- Browser component preview with synthetic files: both videos played; both images opened distinct source URLs.
- Independent review found no production-code defects.
- Local gates passed: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build`, `pnpm ratchet --check`, and `pnpm footguns`.
- After splitting test scaffolding to respect the size ratchet, reran typecheck, lint, build and the full web suite: 401 files / 3,449 tests passed. Production cleanup was comments/whitespace only; gateway/native/root checks from the full run remain applicable.
- Remote CI for the final revision is queued; no merge or deployment performed.
