### PR TITLE
fix: preserve chat final answers and native agent lifecycle

### DIFF
--- a/packages/jinn/src/engines/__tests__/codex-native-agents.test.ts
+++ b/packages/jinn/src/engines/__tests__/codex-native-agents.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+vi.mock("node:child_process", () => ({ spawn: vi.fn((bin: string, args: string[], opts: unknown) => recordSpawn(bin, args, opts)) }));
+import { CodexEngine } from "../codex.js";
+import type { StreamDelta } from "../../shared/types.js";
+import { agentMessage, flush, recordSpawn, resetSpawnCalls, sleep, spawnCalls, threadStarted, turnCompleted, turnFailed } from "./helpers/codex-run.js";
+beforeEach(resetSpawnCalls);
+
+function nativeActivity(kind: string, thread = "native-thread"): string {
+  return JSON.stringify({ type: "event_msg", payload: {
+    type: "item_completed", thread_id: thread, item: {
+      type: "SubAgentActivity", kind, agent_thread_id: "native-worker", agent_path: "/root/research",
+    },
+  } }) + "\n";
+}
+
+describe("Codex native agent lifecycle", () => {
+  it("surfaces native agents from rollout evidence omitted by the JSON stream", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-native-"));
+    const file = path.join(root, "rollout-native-thread.jsonl");
+    const engine = new CodexEngine({ codexSessionsDir: root });
+    const deltas: StreamDelta[] = [];
+    const promise = engine.run({ prompt: "Research", cwd: root, sessionId: "native-chat", onStream: (delta) => deltas.push(delta) });
+    await flush();
+    fs.writeFileSync(file, nativeActivity("started") + nativeActivity("completed") + nativeActivity("interacted"));
+    const proc = spawnCalls.at(-1)!.proc;
+    proc.emitStdout(threadStarted("native-thread") + "\n" + agentMessage("Research complete.") + "\n" + turnCompleted({}) + "\n");
+    proc.close(0);
+    await promise;
+    expect(deltas.filter((delta) => delta.type === "block").at(-1)?.block).toMatchObject({
+      block: { title: "Native Codex agents", status: "completed", payload: { items: [
+        { text: "research: Completed", status: "completed" },
+      ] } },
+    });
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each(["completed", "exit"])("keeps a terminal parent pending until native work has %s evidence", async (end) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-native-pending-"));
+    const file = path.join(root, "rollout-native-thread.jsonl");
+    const engine = new CodexEngine({ codexSessionsDir: root });
+    const deltas: StreamDelta[] = [];
+    let settled = false;
+    const promise = engine.run({ prompt: "Research", cwd: root, sessionId: "native-chat", onStream: (delta) => deltas.push(delta) }).then((result) => { settled = true; return result; });
+    await flush();
+    fs.writeFileSync(file, nativeActivity("started"));
+    const proc = spawnCalls.at(-1)!.proc;
+    proc.emitStdout(threadStarted("native-thread") + "\n" + agentMessage("Parent answer.") + "\n" + turnCompleted({}) + "\n");
+    await sleep(10);
+    expect(settled).toBe(false);
+    expect(deltas).toContainEqual({ type: "status", content: "Waiting for 1 native Codex agent(s)" });
+    if (end === "completed") fs.appendFileSync(file, nativeActivity("completed"));
+    else proc._handlers.exit?.(0);
+    const result = await promise;
+    expect(result.result).toBe("Parent answer.");
+    expect(result.error).toBe(end === "exit" ? "Native agent work stopped before completion" : undefined);
+    expect(deltas.filter((delta) => delta.type === "block").at(-1)?.block?.block.status).toBe(end === "exit" ? "error" : "completed");
+    expect(engine.isAlive("native-chat")).toBe(false);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("does not replay native activity from a resumed turn or a different thread", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-native-resume-"));
+    const file = path.join(root, "rollout-native-thread.jsonl");
+    fs.writeFileSync(file, nativeActivity("started"));
+    const engine = new CodexEngine({ codexSessionsDir: root });
+    const deltas: StreamDelta[] = [];
+    const promise = engine.run({ prompt: "Continue", cwd: root, resumeSessionId: "native-thread", onStream: (delta) => deltas.push(delta) });
+    await flush();
+    fs.appendFileSync(file, nativeActivity("started", "other-thread"));
+    const proc = spawnCalls.at(-1)!.proc;
+    proc.emitStdout(threadStarted("native-thread") + "\n" + agentMessage("Done.") + "\n" + turnCompleted({}) + "\n");
+    await promise;
+    expect(deltas.filter((delta) => delta.type === "block")).toEqual([]);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each(["failed", "cancelled"])("settles a %s native wait without waiting for inherited pipes to close", async (end) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-native-stop-"));
+    const file = path.join(root, "rollout-native-thread.jsonl");
+    const engine = new CodexEngine({ codexSessionsDir: root });
+    const promise = engine.run({ prompt: "Research", cwd: root, sessionId: "native-stop" });
+    await flush();
+    fs.writeFileSync(file, nativeActivity("started"));
+    const proc = spawnCalls.at(-1)!.proc;
+    proc.emitStdout(threadStarted("native-thread") + "\n" + (end === "failed" ? turnFailed("Native turn failed") : turnCompleted({})) + "\n");
+    await sleep(10);
+    if (end === "cancelled") {
+      const kill = vi.spyOn(process, "kill").mockReturnValue(true);
+      engine.kill("native-stop", "Interrupted by user");
+      kill.mockRestore();
+    }
+    fs.appendFileSync(file, nativeActivity("completed"));
+    proc.exitCode = 0;
+    proc._handlers.exit?.(0);
+    expect((await promise).error).toBe(end === "failed" ? "Native turn failed" : "Interrupted by user");
+    expect(engine.isAlive("native-stop")).toBe(false);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/packages/jinn/src/engines/codex-native-agents.ts
+++ b/packages/jinn/src/engines/codex-native-agents.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import { StringDecoder } from "node:string_decoder";
+import type { StreamDelta } from "../shared/types.js";
+import { findCodexSessionFile } from "./codex-rollout.js";
+
+type Agent = { name: string; status: "running" | "completed" | "error"; detail: string };
+
+function nativeItem(line: string, threadId: string) {
+  let record;
+  try { record = JSON.parse(line); } catch { return undefined; }
+  if (record?.type !== "event_msg") return undefined;
+  const payload = record.payload;
+  if (payload?.type !== "item_completed" || payload.thread_id !== threadId) return undefined;
+  const item = payload.item;
+  if (item?.type !== "SubAgentActivity" || typeof item.agent_thread_id !== "string") return undefined;
+  return item as { agent_thread_id: string; agent_path?: string; kind: string };
+}
+
+/** Codex's SubAgentActivity rollout items are omitted from some exec JSON
+ * streams. Read only newly appended records from this exact parent thread;
+ * inherited transcript history and agent prose cannot declare live work. */
+export class CodexNativeAgents {
+  private threadId = "";
+  private file: string | null = null;
+  private offset = 0;
+  private pending = "";
+  private decoder = new StringDecoder("utf8");
+  private agents = new Map<string, Agent>();
+  private version = 0;
+
+  constructor(private root: string, resumeId?: string) {
+    if (!resumeId) return;
+    this.threadId = resumeId;
+    this.file = findCodexSessionFile(root, resumeId);
+    if (this.file) this.offset = fs.statSync(this.file).size;
+  }
+
+  get active(): number {
+    return [...this.agents.values()].filter((agent) => agent.status === "running").length;
+  }
+
+  bind(threadId: string): void {
+    if (this.threadId === threadId) return;
+    this.threadId = threadId;
+    this.file = null;
+    this.offset = 0;
+    this.pending = "";
+    this.decoder = new StringDecoder("utf8");
+  }
+
+  read(): StreamDelta | undefined {
+    if (!this.threadId) return;
+    this.file ??= findCodexSessionFile(this.root, this.threadId);
+    if (!this.file) return;
+    return this.readFile(this.file);
+  }
+
+  private readFile(file: string): StreamDelta | undefined {
+    let fd: number | undefined;
+    let changed = false;
+    try {
+      fd = fs.openSync(file, "r");
+      const size = fs.fstatSync(fd).size;
+      const buffer = Buffer.alloc(64 * 1024);
+      while (this.offset < size) {
+        const count = fs.readSync(fd, buffer, 0, Math.min(buffer.length, size - this.offset), this.offset);
+        if (!count) break;
+        this.offset += count;
+        this.pending += this.decoder.write(buffer.subarray(0, count));
+        let newline: number;
+        while ((newline = this.pending.indexOf("\n")) >= 0) {
+          const line = this.pending.slice(0, newline);
+          this.pending = this.pending.slice(newline + 1);
+          changed = this.accept(line) || changed;
+        }
+      }
+    } catch { /* A missing or incompletely flushed rollout is not lifecycle evidence. */ }
+    finally { if (fd !== undefined) fs.closeSync(fd); }
+    return changed ? this.delta() : undefined;
+  }
+
+  stop(): StreamDelta | undefined {
+    if (!this.active) return;
+    for (const agent of this.agents.values()) {
+      if (agent.status === "running") {
+        agent.status = "error";
+        agent.detail = "Stopped when the native process exited";
+      }
+    }
+    return this.delta();
+  }
+
+  private accept(line: string): boolean {
+    const item = nativeItem(line, this.threadId);
+    if (!item) return false;
+    const id = item.agent_thread_id;
+    const name = typeof item.agent_path === "string" ? item.agent_path.split("/").filter(Boolean).at(-1) : "Agent";
+    if (item.kind === "started") this.agents.set(id, { name: name || "Agent", status: "running", detail: "Running" });
+    else if (item.kind === "completed") this.agents.set(id, { name: name || "Agent", status: "completed", detail: "Completed" });
+    // Sending a message to a finished agent does not restart it.
+    else return false;
+    return true;
+  }
+
+  private delta(): StreamDelta {
+    return { type: "block", content: "Native Codex agents", block: { op: "put", block: {
+      id: "codex-native-agents",
+      type: "task-list",
+      version: ++this.version,
+      sourceEngine: "codex",
+      title: "Native Codex agents",
+      status: this.active ? "running" : this.agents.size && [...this.agents.values()].some((agent) => agent.status === "error") ? "error" : "completed",
+      payload: { kind: "native-agents", items: [...this.agents].map(([id, agent]) => ({
+        id, text: `${agent.name}: ${agent.detail}`, status: agent.status,
+      })) },
+    } } };
+  }
+}

--- a/packages/jinn/src/engines/codex-usage.ts
+++ b/packages/jinn/src/engines/codex-usage.ts
@@ -1,0 +1,74 @@
+import type { ModelUsage } from '../shared/model-pricing.js';
+import { CODEX_SESSIONS_DIR, forEachCodexTokenCount } from './codex-transcript.js';
+
+/**
+ * Most-recent-turn input-context size from a codex per-turn usage object.
+ * codex's `cached_input_tokens` is a SUBSET of `input_tokens` (OpenAI semantics),
+ * so the window fill is `input_tokens` alone — summing would double-count.
+ * Best-effort: returns undefined on any shape mismatch.
+ */
+export function extractCodexContextTokens(usage: unknown): number | undefined {
+  if (!usage || typeof usage !== "object") return undefined;
+  const last = (usage as Record<string, unknown>).last_token_usage;
+  if (last && typeof last === "object") {
+    return positiveTokens((last as Record<string, unknown>).input_tokens);
+  }
+  const n = Number((usage as Record<string, unknown>).input_tokens ?? 0);
+  // Some Codex CLI builds report cumulative/billed input tokens here, not the
+  // active context window. A value above any supported Codex window is unusable
+  // for the UI context meter, so omit it instead of showing impossible values
+  // like 9282k/272k.
+  if (n > 1_000_000) return undefined;
+  return positiveTokens(n);
+}
+
+function positiveTokens(value: unknown): number | undefined {
+  const tokens = Number(value ?? 0);
+  return Number.isFinite(tokens) && tokens > 0 ? tokens : undefined;
+}
+
+export interface CodexTokenUsage {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+}
+
+export function extractCodexTokenUsage(usage: unknown): CodexTokenUsage | undefined {
+  if (!usage || typeof usage !== "object") return undefined;
+  const record = usage as Record<string, unknown>;
+  const inputTokens = Number(record.input_tokens ?? 0);
+  const cachedInputTokens = Number(record.cached_input_tokens ?? 0);
+  const outputTokens = Number(record.output_tokens ?? 0);
+  if (![inputTokens, cachedInputTokens, outputTokens].every(Number.isFinite)) return undefined;
+  return {
+    inputTokens: Math.max(0, inputTokens),
+    cachedInputTokens: Math.max(0, cachedInputTokens),
+    outputTokens: Math.max(0, outputTokens),
+  };
+}
+
+export function codexUsageDelta(start: CodexTokenUsage, end: CodexTokenUsage): ModelUsage {
+  const inputTokens = Math.max(0, end.inputTokens - start.inputTokens);
+  const cachedInputTokens = Math.min(
+    inputTokens,
+    Math.max(0, end.cachedInputTokens - start.cachedInputTokens),
+  );
+  return {
+    inputTokens: inputTokens - cachedInputTokens,
+    cachedInputTokens,
+    outputTokens: Math.max(0, end.outputTokens - start.outputTokens),
+  };
+}
+
+
+
+
+
+export function lastCodexTranscriptContextTokens(sessionId: string, root = CODEX_SESSIONS_DIR): number | undefined {
+  let last: number | undefined;
+  forEachCodexTokenCount(sessionId, root, (payload) => {
+    const ctx = extractCodexContextTokens(payload.info?.last_token_usage);
+    if (ctx) last = ctx;
+  });
+  return last;
+}

--- a/packages/jinn/src/engines/codex.ts
+++ b/packages/jinn/src/engines/codex.ts
@@ -1,3 +1,5 @@
+import { extractCodexContextTokens, extractCodexTokenUsage, codexUsageDelta, lastCodexTranscriptContextTokens, type CodexTokenUsage } from './codex-usage.js';
+export { extractCodexContextTokens, extractCodexTokenUsage, codexUsageDelta, lastCodexTranscriptContextTokens, type CodexTokenUsage } from './codex-usage.js';
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,12 +9,12 @@ import { logger } from "../shared/logger.js";
 import { resolveBin } from "../shared/resolve-bin.js";
 import { CODEX_HOMES_DIR } from "../shared/paths.js";
 import { buildEngineChildEnv } from "../shared/child-env.js";
-import { costOfUsage, type ModelUsage } from "../shared/model-pricing.js";
+import { costOfUsage } from "../shared/model-pricing.js";
 import { buildPromptWithPlatformContext } from "./platform-context.js";
+import { CodexNativeAgents } from "./codex-native-agents.js";
 import {
   CODEX_SESSIONS_DIR,
   codexRateLimitFor,
-  forEachCodexTokenCount,
 } from "./codex-transcript.js";
 
 
@@ -471,74 +473,6 @@ export function codexChildEnv(
 }
 
 
-/**
- * Most-recent-turn input-context size from a codex per-turn usage object.
- * codex's `cached_input_tokens` is a SUBSET of `input_tokens` (OpenAI semantics),
- * so the window fill is `input_tokens` alone — summing would double-count.
- * Best-effort: returns undefined on any shape mismatch.
- */
-export function extractCodexContextTokens(usage: unknown): number | undefined {
-  if (!usage || typeof usage !== "object") return undefined;
-  const last = (usage as Record<string, unknown>).last_token_usage;
-  if (last && typeof last === "object") {
-    const n = Number((last as Record<string, unknown>).input_tokens ?? 0);
-    return Number.isFinite(n) && n > 0 ? n : undefined;
-  }
-  const n = Number((usage as Record<string, unknown>).input_tokens ?? 0);
-  // Some Codex CLI builds report cumulative/billed input tokens here, not the
-  // active context window. A value above any supported Codex window is unusable
-  // for the UI context meter, so omit it instead of showing impossible values
-  // like 9282k/272k.
-  if (n > 1_000_000) return undefined;
-  return Number.isFinite(n) && n > 0 ? n : undefined;
-}
-
-export interface CodexTokenUsage {
-  inputTokens: number;
-  cachedInputTokens: number;
-  outputTokens: number;
-}
-
-export function extractCodexTokenUsage(usage: unknown): CodexTokenUsage | undefined {
-  if (!usage || typeof usage !== "object") return undefined;
-  const record = usage as Record<string, unknown>;
-  const inputTokens = Number(record.input_tokens ?? 0);
-  const cachedInputTokens = Number(record.cached_input_tokens ?? 0);
-  const outputTokens = Number(record.output_tokens ?? 0);
-  if (![inputTokens, cachedInputTokens, outputTokens].every(Number.isFinite)) return undefined;
-  return {
-    inputTokens: Math.max(0, inputTokens),
-    cachedInputTokens: Math.max(0, cachedInputTokens),
-    outputTokens: Math.max(0, outputTokens),
-  };
-}
-
-export function codexUsageDelta(start: CodexTokenUsage, end: CodexTokenUsage): ModelUsage {
-  const inputTokens = Math.max(0, end.inputTokens - start.inputTokens);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.max(0, end.cachedInputTokens - start.cachedInputTokens),
-  );
-  return {
-    inputTokens: inputTokens - cachedInputTokens,
-    cachedInputTokens,
-    outputTokens: Math.max(0, end.outputTokens - start.outputTokens),
-  };
-}
-
-
-
-
-
-export function lastCodexTranscriptContextTokens(sessionId: string, root = CODEX_SESSIONS_DIR): number | undefined {
-  let last: number | undefined;
-  forEachCodexTokenCount(sessionId, root, (payload) => {
-    const ctx = extractCodexContextTokens(payload.info?.last_token_usage);
-    if (ctx) last = ctx;
-  });
-  return last;
-}
-
 export class CodexEngine implements InterruptibleEngine {
   name = "codex" as const;
   private liveProcesses = new Map<string, LiveProcess>();
@@ -604,6 +538,7 @@ export class CodexEngine implements InterruptibleEngine {
     );
 
     const cleanEnv = this.buildCleanEnv(sessionId, sessionHome?.home);
+    const nativeAgents = new CodexNativeAgents(transcriptSessionsDir, opts.resumeSessionId);
 
     return new Promise((resolve, reject) => {
       const proc = spawn(bin, args, {
@@ -623,6 +558,7 @@ export class CodexEngine implements InterruptibleEngine {
       let threadId = "";
       let resultText = "";
       let numTurns = 0;
+      let terminalSeen = false;
       let turnError: string | null = null;
       let lastContextTokens: number | undefined;
       const usageAtTurnStart = this.totalUsage.get(sessionId)
@@ -631,6 +567,8 @@ export class CodexEngine implements InterruptibleEngine {
       let lineBuf = "";
       let hardTimeout: NodeJS.Timeout | undefined;
       let terminalSettleTimer: NodeJS.Timeout | undefined;
+      let nativeAgentTimer: NodeJS.Timeout | undefined;
+      let nativeInterrupted = false;
       const onStream = opts.onStream || null;
       let lastStreamedTextBlock: string | null = null;
       const STDERR_MAX = 10 * 1024; // 10KB rolling window for error reporting
@@ -638,6 +576,7 @@ export class CodexEngine implements InterruptibleEngine {
       const clearTimers = () => {
         if (hardTimeout) { clearTimeout(hardTimeout); hardTimeout = undefined; }
         if (terminalSettleTimer) { clearTimeout(terminalSettleTimer); terminalSettleTimer = undefined; }
+        if (nativeAgentTimer) { clearInterval(nativeAgentTimer); nativeAgentTimer = undefined; }
       };
       const resetTextBlockRun = () => { lastStreamedTextBlock = null; };
       const turnCost = (): number | undefined => {
@@ -663,8 +602,14 @@ export class CodexEngine implements InterruptibleEngine {
       // fixed for grok in 94a50cc). Mirrors GrokEngine.settleOnTerminal / PiEngine.
       const settleOnTerminal = () => {
         if (settled) return;
+        flushNativeAgents();
+        if (nativeAgents.active) {
+          onStream?.({ type: "status", content: `Waiting for ${nativeAgents.active} native Codex agent(s)` });
+          return;
+        }
         settled = true;
         clearTimers();
+        const terminationReason = this.liveProcesses.get(sessionId)?.terminationReason;
         this.liveProcesses.delete(sessionId);
         // Detached child has signalled turn end and will exit; don't let its (or a
         // lingering grandchild's) open stdout pipe keep the event loop busy.
@@ -681,7 +626,7 @@ export class CodexEngine implements InterruptibleEngine {
 
         logger.info(`Codex turn settled on terminal event (thread: ${threadId || "none"}, turns: ${numTurns})`);
         const cost = turnCost();
-        const settledError = resultText.trim() ? undefined : (turnError ?? undefined);
+        const settledError = terminationReason || (nativeInterrupted ? "Native agent work stopped before completion" : resultText.trim() ? undefined : (turnError ?? undefined));
         resolve({
           sessionId: resolvedThreadId,
           result: resultText,
@@ -699,9 +644,24 @@ export class CodexEngine implements InterruptibleEngine {
       // the turn when `close` never comes (held-pipe hang).
       const scheduleTerminalSettle = () => {
         if (settled || terminalSettleTimer) return;
-        terminalSettleTimer = setTimeout(settleOnTerminal, 0);
+        terminalSettleTimer = setTimeout(() => { terminalSettleTimer = undefined; settleOnTerminal(); }, 0);
         terminalSettleTimer.unref?.();
       };
+
+      const flushNativeAgents = () => {
+        const delta = nativeAgents.read();
+        if (delta) onStream?.(delta);
+      };
+      const stopNativeAgents = () => {
+        flushNativeAgents();
+        const delta = nativeAgents.stop();
+        if (delta) { nativeInterrupted = true; onStream?.(delta); }
+      };
+      nativeAgentTimer = setInterval(() => {
+        flushNativeAgents();
+        if (terminalSeen && !nativeAgents.active) scheduleTerminalSettle();
+      }, 500);
+      nativeAgentTimer.unref?.();
 
       hardTimeout = setTimeout(() => {
         if (settled) return;
@@ -728,6 +688,8 @@ export class CodexEngine implements InterruptibleEngine {
           switch (parsed.type) {
             case "thread_id":
               threadId = parsed.threadId;
+              nativeAgents.bind(threadId);
+              flushNativeAgents();
               logger.info(`Codex session got thread ID: ${threadId}`);
               break;
             case "tool_start":
@@ -753,6 +715,7 @@ export class CodexEngine implements InterruptibleEngine {
               if (onStream) onStream({ type: "error", content: parsed.message });
               break;
             case "usage":
+              terminalSeen = true;
               resetTextBlockRun();
               numTurns++;
               if (parsed.contextTokens) lastContextTokens = parsed.contextTokens;
@@ -760,6 +723,7 @@ export class CodexEngine implements InterruptibleEngine {
               scheduleTerminalSettle(); // turn.completed = end of turn
               break;
             case "turn_failed":
+              terminalSeen = true;
               resetTextBlockRun();
               turnError = parsed.message;
               if (onStream) onStream({ type: "error", content: parsed.message });
@@ -783,8 +747,17 @@ export class CodexEngine implements InterruptibleEngine {
 
       proc.stdin.end();
 
+      // exit does not wait for inherited stdout pipes. It is also the end of
+      // the native runtime, even if an agent never produced a completion item.
+      proc.on("exit", () => {
+        if (settled) return;
+        stopNativeAgents();
+        if (terminalSeen) scheduleTerminalSettle();
+      });
+
       proc.on("close", (code) => {
         if (settled) return;
+        stopNativeAgents();
         settled = true;
         clearTimers();
 
@@ -843,7 +816,7 @@ export class CodexEngine implements InterruptibleEngine {
           // surface a transient/benign error item (e.g. the `web_search_request`
           // deprecation notice that codex emits before the answer) as a failure.
           const cost = turnCost();
-          const settledError = resultText.trim() ? undefined : (turnError ?? undefined);
+          const settledError = nativeInterrupted ? "Native agent work stopped before completion" : resultText.trim() ? undefined : (turnError ?? undefined);
           resolve({
             sessionId: resolvedThreadId,
             result: resultText,

--- a/packages/jinn/src/gateway/streamed-blocks.ts
+++ b/packages/jinn/src/gateway/streamed-blocks.ts
@@ -4,7 +4,7 @@ export interface StreamedBlockForPersistence {
   content: string;
   toolCall?: string;
   media?: unknown[];
-  blocks?: Array<{ type: string }>;
+  blocks?: Array<{ type: string; payload?: { kind?: unknown } }>;
 }
 
 export function shouldPreserveStreamedBlocks(args: {
@@ -34,7 +34,7 @@ export function completedStreamedBlockIds(args: {
   return new Set(args.streamedBlocks.flatMap((message) => {
     if (!message.id) return [];
     const durableBlock = message.blocks?.some((block) =>
-      block.type === "delegation" || block.type === "dispatch",
+      block.type === "delegation" || block.type === "dispatch" || block.payload?.kind === "native-agents",
     );
     const plainInterimProse =
       (message.role === undefined || message.role === "assistant")

--- a/packages/jinn/src/sessions/__tests__/message-phases.test.ts
+++ b/packages/jinn/src/sessions/__tests__/message-phases.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+process.env.JINN_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "jinn-message-phases-"));
+const dbModule = await import("../../shared/db.js");
+const reg = await import("../registry.js");
+function newSession(id: string): void {
+  dbModule.initDb().prepare("INSERT INTO sessions (id, engine, source, source_ref, status, created_at, last_activity) VALUES (?, 'codex', 'web', ?, 'idle', 't', 't')").run(id, `web:${id}`);
+}
+describe("legacy assistant message phases", () => {
+  it("recovers final versus commentary evidence from legacy rows across pagination", () => {
+    newSession("phase-history");
+    reg.insertMessage("phase-history", "user", "Research the design.");
+    reg.insertPartialMessage("phase-history", "assistant", "Checking the implementation.", 0);
+    reg.finalizePartialMessages("phase-history");
+    const finalId = reg.insertMessage("phase-history", "assistant", "The complete conclusion.");
+    reg.insertMessage("phase-history", "assistant", "Callback acknowledged.");
+    const rows = reg.getMessages("phase-history");
+    expect(rows[1].meta?.assistantPhase).toBe("commentary");
+    expect(rows[2].meta?.assistantPhase).toBe("final");
+    expect(rows[3].meta?.assistantPhase).toBe("final");
+    expect(reg.getMessagePage("phase-history", { before: finalId, limit: 1 }).messages[0].meta?.assistantPhase).toBe("commentary");
+  });
+});

--- a/packages/jinn/src/sessions/message-row.ts
+++ b/packages/jinn/src/sessions/message-row.ts
@@ -1,0 +1,119 @@
+import type { ChatBlock, JsonObject } from '../shared/types.js';
+import { validateBlockEnvelope } from '../shared/blocks.js';
+
+/** Attachment descriptor stored alongside a message and rendered by the web UI. */
+export interface MessageMedia {
+  type: 'image' | 'audio' | 'video' | 'file';
+  url: string;
+  name?: string;
+  mimeType?: string;
+  size?: number;
+  /** Displayed pixel size of an image, so the client can reserve its box before
+   * the bytes arrive. Absent when nothing measured it. */
+  width?: number;
+  height?: number;
+}
+
+export interface SessionMessage {
+  id: string;
+  role: string;
+  content: string;
+  timestamp: number;
+  /** Parsed from the `media` JSON column; undefined when the message has no attachments. */
+  media?: MessageMedia[];
+  /** True for a live mid-turn block. Most engines replace these at turn end. */
+  partial?: boolean;
+  /** Tool name when this block is a tool call — lets a reloaded block render as a tool card. */
+  toolCall?: string;
+  /** Native engine call id used to correlate interleaved tool results. */
+  toolId?: string;
+  /** Structured Chat Mode blocks rendered by the web UI. */
+  blocks?: ChatBlock[];
+  /** Safe structured UI metadata, used for reload-stable callback attribution. */
+  meta?: JsonObject;
+}
+
+export interface MessageRow {
+  rowid: number;
+  id: string;
+  role: string;
+  content: string;
+  timestamp: number;
+  media: string | null;
+  partial: number | null;
+  seq: number | null;
+  tool_call: string | null;
+  tool_id: string | null;
+  blocks: string | null;
+  meta: string | null;
+}
+
+export interface MessagePage {
+  messages: SessionMessage[];
+  hasOlder: boolean;
+}
+
+export interface MessagePageOptions {
+  /** Fetch messages strictly older than this message id. Omit for the newest tail. */
+  before?: string;
+  /** Number of messages to return. Clamped to a bounded positive page size. */
+  limit?: number;
+}
+
+function parseMediaColumn(value: unknown): MessageMedia[] | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.length > 0 ? (parsed as MessageMedia[]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseBlocksColumn(value: unknown): ChatBlock[] | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return undefined;
+    const blocks = parsed.flatMap((block) => {
+      const result = validateBlockEnvelope({ op: "put", block });
+      return result.ok ? [result.envelope.block] : [];
+    });
+    return blocks.length > 0 ? blocks : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseMetaColumn(value: unknown): JsonObject | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as JsonObject : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function rowToMessage(r: MessageRow): SessionMessage {
+  const msg: SessionMessage = { id: r.id, role: r.role, content: r.content, timestamp: r.timestamp };
+  const media = parseMediaColumn(r.media);
+  const blocks = parseBlocksColumn(r.blocks);
+  const meta = parseMetaColumn(r.meta);
+  if (media) msg.media = media;
+  if (blocks) msg.blocks = blocks;
+  const phase = messagePhase(r, msg);
+  if (phase) msg.meta = { assistantPhase: phase, ...meta };
+  else if (meta) msg.meta = meta;
+  if (r.partial) msg.partial = true;
+  if (r.tool_call) msg.toolCall = r.tool_call;
+  if (r.tool_id) msg.toolId = r.tool_id;
+  return msg;
+}
+
+function messagePhase(row: MessageRow, message: SessionMessage): string | undefined {
+  if (row.role !== 'assistant' || row.tool_call || message.blocks?.length || message.media?.length || !row.content.trim()) return;
+  // Stream rows retain seq after settlement. Legacy histories distinguish
+  // progress from canonical replies without guessing at callback arrival times.
+  return row.seq === null && !row.partial ? 'final' : 'commentary';
+}

--- a/packages/jinn/src/sessions/registry.ts
+++ b/packages/jinn/src/sessions/registry.ts
@@ -1,3 +1,5 @@
+import { parseBlocksColumn, parseMetaColumn, rowToMessage, type MessageRow, type MessageMedia, type SessionMessage, type MessagePage, type MessagePageOptions } from './message-row.js';
+export type { MessageMedia, SessionMessage, MessagePage, MessagePageOptions } from './message-row.js';
 import { CALLBACK_DELIVERY_SELECT } from "./callback-delivery-query.js";
 import { pendingCompletionBatch } from "./completion-batching.js";
 export { coalescePendingParentCompletionQueueItems } from "./completion-batching.js";
@@ -1751,114 +1753,6 @@ export function deleteSessions(ids: string[]): number {
   return result.changes;
 }
 
-/** Attachment descriptor stored alongside a message and rendered by the web UI. */
-export interface MessageMedia {
-  type: 'image' | 'audio' | 'video' | 'file';
-  url: string;
-  name?: string;
-  mimeType?: string;
-  size?: number;
-  /** Displayed pixel size of an image, so the client can reserve its box before
-   * the bytes arrive. Absent when nothing measured it. */
-  width?: number;
-  height?: number;
-}
-
-export interface SessionMessage {
-  id: string;
-  role: string;
-  content: string;
-  timestamp: number;
-  /** Parsed from the `media` JSON column; undefined when the message has no attachments. */
-  media?: MessageMedia[];
-  /** True for a live mid-turn block. Most engines replace these at turn end. */
-  partial?: boolean;
-  /** Tool name when this block is a tool call — lets a reloaded block render as a tool card. */
-  toolCall?: string;
-  /** Native engine call id used to correlate interleaved tool results. */
-  toolId?: string;
-  /** Structured Chat Mode blocks rendered by the web UI. */
-  blocks?: ChatBlock[];
-  /** Safe structured UI metadata, used for reload-stable callback attribution. */
-  meta?: JsonObject;
-}
-
-interface MessageRow {
-  rowid: number;
-  id: string;
-  role: string;
-  content: string;
-  timestamp: number;
-  media: string | null;
-  partial: number | null;
-  seq: number | null;
-  tool_call: string | null;
-  tool_id: string | null;
-  blocks: string | null;
-  meta: string | null;
-}
-
-export interface MessagePage {
-  messages: SessionMessage[];
-  hasOlder: boolean;
-}
-
-export interface MessagePageOptions {
-  /** Fetch messages strictly older than this message id. Omit for the newest tail. */
-  before?: string;
-  /** Number of messages to return. Clamped to a bounded positive page size. */
-  limit?: number;
-}
-
-function parseMediaColumn(value: unknown): MessageMedia[] | undefined {
-  if (typeof value !== 'string' || !value.trim()) return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) && parsed.length > 0 ? (parsed as MessageMedia[]) : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function parseBlocksColumn(value: unknown): ChatBlock[] | undefined {
-  if (typeof value !== 'string' || !value.trim()) return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    if (!Array.isArray(parsed)) return undefined;
-    const blocks = parsed.flatMap((block) => {
-      const result = validateBlockEnvelope({ op: "put", block });
-      return result.ok ? [result.envelope.block] : [];
-    });
-    return blocks.length > 0 ? blocks : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function parseMetaColumn(value: unknown): JsonObject | undefined {
-  if (typeof value !== 'string' || !value.trim()) return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as JsonObject : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function rowToMessage(r: MessageRow): SessionMessage {
-  const msg: SessionMessage = { id: r.id, role: r.role, content: r.content, timestamp: r.timestamp };
-  const media = parseMediaColumn(r.media);
-  const blocks = parseBlocksColumn(r.blocks);
-  const meta = parseMetaColumn(r.meta);
-  if (media) msg.media = media;
-  if (blocks) msg.blocks = blocks;
-  if (meta) msg.meta = meta;
-  if (r.partial) msg.partial = true;
-  if (r.tool_call) msg.toolCall = r.tool_call;
-  if (r.tool_id) msg.toolId = r.tool_id;
-  return msg;
-}
-
 function normalizeMessagePageLimit(limit: number | undefined): number {
   if (!Number.isFinite(limit) || !limit || limit < 1) return 100;
   return Math.min(500, Math.max(1, Math.floor(limit)));
@@ -1920,14 +1814,15 @@ export function insertMessageAfter(
   afterTimestamp: number,
   media?: MessageMedia[],
   blocks?: ChatBlock[],
+  meta?: JsonObject,
 ): string {
   const db = initDb();
   const id = uuidv4();
   const mediaJson = media && media.length > 0 ? JSON.stringify(media) : null;
   const blocksJson = blocks && blocks.length > 0 ? JSON.stringify(blocks) : null;
   const timestamp = Math.max(Date.now(), Math.floor(afterTimestamp) + 1);
-  db.prepare('INSERT INTO messages (id, session_id, role, content, timestamp, media, blocks) VALUES (?, ?, ?, ?, ?, ?, ?)').run(
-    id, sessionId, role, content, timestamp, mediaJson, blocksJson,
+  db.prepare('INSERT INTO messages (id, session_id, role, content, timestamp, media, blocks, meta) VALUES (?, ?, ?, ?, ?, ?, ?, ?)').run(
+    id, sessionId, role, content, timestamp, mediaJson, blocksJson, meta ? JSON.stringify(meta) : null,
   );
   return id;
 }

--- a/packages/jinn/src/sessions/turn/settle.ts
+++ b/packages/jinn/src/sessions/turn/settle.ts
@@ -65,7 +65,7 @@ export async function settleAnsweredTurn(
 
   const displayText = quietPreempted ? "" : turnDisplayText(result.result, result.error);
   if (shouldPersistFinalAssistantMessage({ resultText: result.result, quietPreempted }) || displayText) {
-    insertMessageAfter(sessionId, "assistant", displayText, verdict.streamedThrough);
+    insertMessageAfter(sessionId, "assistant", displayText, verdict.streamedThrough, undefined, undefined, answeredMessageMeta(run, attempt));
   }
 
   const settled = await settleTurn({
@@ -83,6 +83,14 @@ export async function settleAnsweredTurn(
     (result.durationMs ? ` in ${result.durationMs}ms` : "") +
     (result.cost ? ` ($${result.cost.toFixed(4)})` : ""),
   );
+}
+
+function answeredMessageMeta(run: TurnRun, attempt: EngineAttempt) {
+  return {
+    assistantPhase: "final",
+    turnStartedAt: run.turnStartedAt,
+    turnOutcome: attempt.result.error ? "error" : "complete",
+  };
 }
 
 /**

--- a/packages/jinn/src/shared/__tests__/privacy-guard.test.ts
+++ b/packages/jinn/src/shared/__tests__/privacy-guard.test.ts
@@ -111,7 +111,7 @@ describe("privacy guard", () => {
       const findings = findBlockedTerms(listTrackedTextFiles(repo, ["docs"]), repo);
       expect(findings).not.toEqual([]);
       expect(findings).toEqual(
-        expect.arrayContaining([expect.stringContaining("docs/scratch.md:1 contains")]),
+        expect.arrayContaining([expect.stringContaining(`${join("docs", "scratch.md")}:1 contains`)]),
       );
     } finally {
       rmSync(repo, { recursive: true, force: true });

--- a/packages/web/src/components/chat/__tests__/final-answers.test.tsx
+++ b/packages/web/src/components/chat/__tests__/final-answers.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChatMessages, finalAnswerIndices, groupMessages, partitionForFold } from '../chat-messages'
+import type { Message } from '@/lib/conversations'
+vi.mock('@/lib/api', () => ({ api: { getSession: vi.fn().mockResolvedValue({ messages: [] }) } }))
+const T0 = 1_780_000_000_000
+
+describe('completed answers with a callback queued during work', () => {
+  const messages: Message[] = [
+    { id: 'ask', role: 'user', content: 'Research the design.', timestamp: T0 },
+    { id: 'progress', role: 'assistant', content: 'Checking the implementation.', timestamp: T0 + 1_000, meta: { assistantPhase: 'commentary' } },
+    { id: 'relay', role: 'notification', content: '📨 From coordinator: acknowledged.', timestamp: T0 + 2_000 },
+    { id: 'more-work', role: 'assistant', content: 'Comparing the results.', timestamp: T0 + 3_000, meta: { assistantPhase: 'commentary' } },
+    { id: 'attachment', role: 'assistant', content: 'Detailed evidence.', timestamp: T0 + 4_000, media: [{ type: 'file', url: '/api/files/report', name: 'report.md' }] },
+    { id: 'answer', role: 'assistant', content: 'The complete research conclusion.', timestamp: T0 + 5_000, meta: { assistantPhase: 'final' } },
+    { id: 'ack', role: 'assistant', content: 'The coordinator update is acknowledged.', timestamp: T0 + 6_000, meta: { assistantPhase: 'final' } },
+  ]
+
+  it.each([0, 3, 5])('keeps both final answers outside collapsed work after history page offset %s', (offset) => {
+    const history = messages.slice(offset)
+    const groups = partitionForFold(groupMessages(history), history, new Set(), null, new Set())
+    const visible = groups.flatMap((group) => group.kind === 'plain' && group.item.kind === 'message' ? [group.item.msg.id] : [])
+    expect(visible).toContain('answer')
+    expect(visible).toContain('ack')
+    if (offset === 0) expect(finalAnswerIndices(history)[1]).toBe(5)
+  })
+
+  it('keeps the completed answer identified while a later callback turn streams', () => {
+    const history = messages.slice(0, -1)
+    const { rerender } = render(<ChatMessages messages={history} loading={false} />)
+    expect(screen.getByText('The complete research conclusion.').closest('[data-fold-region]')).toBeNull()
+    rerender(<ChatMessages messages={history} loading streamingText="Checking the coordinator update." />)
+    expect(screen.getByText('The complete research conclusion.').closest('[data-message-id]')?.getAttribute('data-final-answer')).toBe('true')
+    rerender(<ChatMessages messages={messages} loading={false} />)
+    expect(screen.getByText('The complete research conclusion.').closest('[data-fold-region]')).toBeNull()
+    expect(screen.getByText('The coordinator update is acknowledged.').closest('[data-fold-region]')).toBeNull()
+  })
+
+  it('identifies an illustrated final answer while preserving progress as work', () => {
+    const history: Message[] = [messages[0], messages[1], {
+      ...messages[5], content: 'Research conclusion with ![evidence](https://example.test/chart.png)',
+    }]
+    render(<ChatMessages messages={history} loading={false} />)
+    expect(screen.getByText('Final answer')).toBeTruthy()
+    expect(finalAnswerIndices(history)).toEqual([-1, 2, 2])
+  })
+
+  it('counts native agents separately from Jinn teammates in completed work', () => {
+    const native: Message = { id: 'native', role: 'assistant', content: 'Native Codex agents', timestamp: T0 + 4_500, blocks: [{
+      id: 'native-block', type: 'task-list', version: 2, status: 'completed', payload: {
+        kind: 'native-agents', items: [{ id: 'research', text: 'research: Completed', status: 'completed' }],
+      },
+    }] }
+    const history = [messages[0], messages[2], native, messages[5]]
+    render(<ChatMessages messages={history} loading={false} />)
+    expect(screen.getByRole('button', { name: /1 teammate, 1 native agent/ })).toBeTruthy()
+  })
+})

--- a/packages/web/src/components/chat/armed-send.ts
+++ b/packages/web/src/components/chat/armed-send.ts
@@ -1,3 +1,21 @@
+/** Hold threshold (ms) that separates a quick tap from a tap-and-hold. */
+export const MIC_HOLD_THRESHOLD_MS = 250
+
+export type MicGesture = 'hold' | 'tap'
+
+/**
+ * Pure classifier for the mic button gesture. A press held for at least
+ * `threshold` ms is a push-to-talk hold; anything shorter is a quick tap.
+ * Exported for unit testing.
+ */
+export function classifyMicGesture(
+  downAt: number,
+  upAt: number,
+  threshold: number = MIC_HOLD_THRESHOLD_MS,
+): MicGesture {
+  return upAt - downAt >= threshold ? 'hold' : 'tap'
+}
+
 export interface SendTapContext {
   isStop: boolean
   armed: boolean

--- a/packages/web/src/components/chat/chat-input.tsx
+++ b/packages/web/src/components/chat/chat-input.tsx
@@ -10,27 +10,10 @@ import { EmployeeAvatar } from '@/components/ui/employee-avatar'
 import { useChatComposerControl } from './chat-composer-control'
 import { composerCardPresentation } from './chat-composer-presentation'
 import { useChatDraft } from './use-chat-draft'
-import { resolveSendTap, resolveTranscriptLanding } from './armed-send'
+import { classifyMicGesture, MIC_HOLD_THRESHOLD_MS, resolveSendTap, resolveTranscriptLanding } from './armed-send'
 
-export { resolveSendTap, resolveTranscriptLanding } from './armed-send'
-
-/** Hold threshold (ms) that separates a quick tap from a tap-and-hold. */
-export const MIC_HOLD_THRESHOLD_MS = 250
-
-export type MicGesture = 'hold' | 'tap'
-
-/**
- * Pure classifier for the mic button gesture. A press held for at least
- * `threshold` ms is a push-to-talk hold; anything shorter is a quick tap.
- * Exported for unit testing.
- */
-export function classifyMicGesture(
-  downAt: number,
-  upAt: number,
-  threshold: number = MIC_HOLD_THRESHOLD_MS,
-): MicGesture {
-  return upAt - downAt >= threshold ? 'hold' : 'tap'
-}
+export { classifyMicGesture, MIC_HOLD_THRESHOLD_MS, resolveSendTap, resolveTranscriptLanding } from './armed-send'
+export type { MicGesture } from './armed-send'
 
 interface Employee {
   name: string

--- a/packages/web/src/components/chat/chat-messages.tsx
+++ b/packages/web/src/components/chat/chat-messages.tsx
@@ -1,5 +1,7 @@
+import { isAnswerMessage, messageMedia, finalAnswerIndices, settledDurationMs } from './final-answers'
+export { finalAnswerIndices } from './final-answers'
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { parseMedia, stripAttachedFilesBlock, type MediaAttachment, type Message } from '@/lib/conversations'
+import { stripAttachedFilesBlock, type MediaAttachment, type Message } from '@/lib/conversations'
 import { copyText } from '@/platform'
 import { MessageMedia } from './message-media'
 import { useStickToBottom } from '@/hooks/use-stick-to-bottom'
@@ -37,7 +39,7 @@ import {
 import { OlderPageRow } from './older-page-row'
 import { useVirtualBlockOffset } from './virtual-block-offset'
 import { captureVisibleAnchor, OLDER_LOAD_THRESHOLD_PX, type ScrollAnchor } from '@/lib/scroll-anchor'
-import { formatTimestamp, shouldShowTimestamp, TimestampDivider, validTimestamp } from './message-timestamps'
+import { formatTimestamp, shouldShowTimestamp, TimestampDivider } from './message-timestamps'
 
 export { formatMessage, isFilePath, parseFenceLang } from './message-markdown'
 export { TimestampDivider } from './message-timestamps'
@@ -246,25 +248,11 @@ export function groupMessages(messages: Message[]): MessageItem[] {
 
 /* ── The post-turn fold — partitioning ──────────────────── */
 
-/** The turn's final answer: an assistant prose message. Tool calls are not
- *  answers, and neither is any block-carrying message — blocks render as
- *  cards/objects (handoffs, dispatches, task lists), not the turn's prose.
- *  Conservative on purpose: when in doubt the evidence stays visible. */
-function isAnswerMessage(msg: Message): boolean {
-  if (msg.role !== 'assistant' || msg.toolCall) return false
-  if (msg.blocks?.length) return false
-  return Boolean((msg.content || '').trim())
-}
-
 /** A centered bell banner: a notification that is neither a callback nor a
  *  relay. Banners stay OUTSIDE the fold (they're addressed to the user, not
  *  part of the model's work) — a mid-turn banner splits the region. */
 function isSystemBanner(msg: Message): boolean {
   return msg.role === 'notification' && !parseTeammateReply(msg) && !parseAgentRelay(msg)
-}
-
-function messageMedia(msg: Message) {
-  return msg.media?.length ? msg.media : parseMedia(msg.content)
 }
 
 function itemHasAssistantMedia(item: MessageItem): boolean {
@@ -274,63 +262,6 @@ function itemHasAssistantMedia(item: MessageItem): boolean {
       ? item.entries.map((entry) => entry.msg)
       : [item.msg]
   return messages.some((message) => message.role === 'assistant' && messageMedia(message).length > 0)
-}
-
-/** A child callback ("dev replied") or an agent relay ("From dev [hop N]"): an
- *  injected notification that RE-INVOKES the model, starting a fresh engine turn
- *  inside the same logical (user) turn. It closes the previous segment so the
- *  earlier reply stays visible, and folds into the engine turn it triggers. */
-function isReinvocationBoundary(msg: Message): boolean {
-  return msg.role === 'notification' && Boolean(parseTeammateReply(msg) || parseAgentRelay(msg))
-}
-
-/**
- * For each raw message index, the index of the answer that closes ITS engine-turn
- * segment — the last non-partial assistant prose message in the run of work that
- * ends at the next user message OR the next child re-invocation (callback/relay).
- * -1 while that segment has produced no answer yet.
- *
- * One logical (user) turn can hold several engine turns: the model replies and
- * stops, a child callback re-invokes it, it replies again. Each engine turn keeps
- * its OWN closing answer, so the fold before it is scoped to just that segment's
- * work — the earlier reply and its "Worked for" fold are preserved rather than
- * swallowed by one region reaching the turn's very last block. Interim prose
- * WITHIN one engine turn still folds; only the segment's last answer is a boundary.
- * Exported for tests.
- */
-export function finalAnswerIndices(messages: Message[]): number[] {
-  const out = new Array<number>(messages.length).fill(-1)
-  let nextReply = -1
-  // After a re-invocation boundary the NEXT prose above it closes a fresh
-  // segment — a preserved reply. But a segment that produced NO prose (pure tool
-  // work before a callback) must keep folding toward the downstream reply, so we
-  // only re-point `nextReply` when that armed prose actually appears; tools-only
-  // work therefore stays in one fold instead of orphaning as bare rows.
-  let armed = false
-  for (let j = messages.length - 1; j >= 0; j--) {
-    if (messages[j].role === 'user') {
-      nextReply = -1
-      armed = false
-      out[j] = -1
-      continue
-    }
-    if (isReinvocationBoundary(messages[j])) {
-      // The trigger folds into the engine turn it started (the segment below),
-      // and arms the next prose above it as that turn's preserved reply.
-      out[j] = nextReply
-      armed = true
-      continue
-    }
-    // A restored `partial` prose row is still middle evidence. The first
-    // non-partial prose after a boundary (or the turn's first) is a preserved
-    // reply; later prose in the same engine turn is interim and folds toward it.
-    if (!messages[j].partial && isAnswerMessage(messages[j]) && (nextReply === -1 || armed)) {
-      nextReply = j
-      armed = false
-    }
-    out[j] = nextReply
-  }
-  return out
 }
 
 function itemFirstMsg(item: MessageItem): Message {
@@ -358,81 +289,15 @@ function itemHasActiveDelegation(item: MessageItem): boolean {
       ? item.entries.map((entry) => entry.msg)
       : [item.msg]
   return rows.some((message) => message.blocks?.some((block) =>
-    block.type === 'delegation' && isActiveDelegationStatus(block.status),
+    (block.type === 'delegation' || block.payload.kind === 'native-agents') && isActiveDelegationStatus(block.status),
   ))
-}
-
-/** Locate the durable start of the engine segment closed by `answerIndex`.
- * The initiating user starts the first segment. After a completed reply, a
- * callback/relay starts the next one; callbacks that arrive before any reply
- * remain evidence inside the still-open initial segment. */
-function settledSegmentStartIndex(messages: Message[], answerIndex: number): number {
-  let userIndex = -1
-  for (let index = answerIndex - 1; index >= 0; index--) {
-    if (messages[index].role === 'user') {
-      userIndex = index
-      break
-    }
-  }
-
-  let startIndex = userIndex
-  let completedReply = false
-  for (let index = userIndex + 1; index < answerIndex; index++) {
-    const message = messages[index]
-    if (isReinvocationBoundary(message)) {
-      if (completedReply) {
-        startIndex = index
-        completedReply = false
-      }
-      continue
-    }
-    if (!message.partial && isAnswerMessage(message)) completedReply = true
-  }
-  return startIndex
-}
-
-/** A settled fold measures one durable engine segment: initiating user or
- * callback/relay boundary → canonical final assistant row. Legacy rows may lack
- * one boundary; in that case, recover only from timestamped evidence inside
- * the same segment. A single evidence row cannot establish an interval. */
-function settledDurationMs(messages: Message[], answerIndex: number): number | null {
-  if (answerIndex < 0 || answerIndex >= messages.length) return null
-
-  const segmentStartIndex = settledSegmentStartIndex(messages, answerIndex)
-  let startIndex = segmentStartIndex
-  let start = segmentStartIndex >= 0 ? validTimestamp(messages[segmentStartIndex].timestamp) : null
-  if (start === null) {
-    startIndex = -1
-    for (let index = segmentStartIndex + 1; index < answerIndex; index++) {
-      const timestamp = validTimestamp(messages[index].timestamp)
-      if (timestamp === null) continue
-      start = timestamp
-      startIndex = index
-      break
-    }
-  }
-
-  let endIndex = answerIndex
-  let end = validTimestamp(messages[answerIndex].timestamp)
-  if (end === null) {
-    endIndex = -1
-    for (let index = answerIndex - 1; index > segmentStartIndex; index--) {
-      const timestamp = validTimestamp(messages[index].timestamp)
-      if (timestamp === null) continue
-      end = timestamp
-      endIndex = index
-      break
-    }
-  }
-
-  if (start === null || end === null || startIndex === endIndex || end < start) return null
-  return end - start
 }
 
 export function buildFoldSummary(run: MessageItem[], messages: Message[], answerIndex: number): FoldSummaryData {
   let tools = 0
   let updates = 0
   const teammates = new Set<string>()
+  const nativeAgents = new Set<string>()
   for (const item of run) {
     if (item.kind === 'tool-group') {
       tools += item.msgs.length
@@ -465,13 +330,18 @@ export function buildFoldSummary(run: MessageItem[], messages: Message[], answer
     // Interim prose the model wrote on the way to the answer.
     if (isAnswerMessage(msg) && messageMedia(msg).length === 0) updates += 1
     for (const block of msg.blocks || []) {
+      if (block.payload.kind === 'native-agents' && Array.isArray(block.payload.items)) {
+        for (const agent of block.payload.items) {
+          if (agent && typeof agent === 'object' && !Array.isArray(agent) && typeof agent.id === 'string') nativeAgents.add(agent.id)
+        }
+      }
       const employee = block.payload?.employee
       if (typeof employee === 'string' && employee) {
         teammates.add(employee)
       }
     }
   }
-  return { durationMs: settledDurationMs(messages, answerIndex), tools, teammates: teammates.size, updates }
+  return { durationMs: settledDurationMs(messages, answerIndex), tools, teammates: teammates.size, updates, ...(nativeAgents.size ? { nativeAgents: nativeAgents.size } : {}) }
 }
 
 export type RenderGroup =
@@ -700,7 +570,8 @@ export function buildRowMeta(messages: Message[], pendingTurnId: string | null):
       showTimestamp: shouldShowTimestamp(messages, i),
       prevRole: i > 0 ? messages[i - 1].role : null,
       prevUserText: lastUserText,
-      isFinalAnswer: answers[i] === i && turnIds[i] !== pendingTurnId && !openTurns.has(turnIds[i]),
+      isFinalAnswer: answers[i] === i && (msg.meta?.assistantPhase === 'final'
+        || (turnIds[i] !== pendingTurnId && !openTurns.has(turnIds[i]))),
     }
     if (msg.role === 'user' && msg.content.trim()) lastUserText = msg.content
     return meta
@@ -772,7 +643,7 @@ const MessageRow = React.memo(function MessageRow({ msg, index: i, showTimestamp
   const formattedTimestamp = useMemo(() => formatTimestamp(msg.timestamp), [msg.timestamp])
 
   return (
-    <div key={msg.id || i} data-message-id={msg.id || `idx-${i}`}>
+    <div key={msg.id || i} data-message-id={msg.id || `idx-${i}`} data-final-answer={isFinalAnswer || undefined}>
       {/* Timestamp divider */}
       {showTimestamp && <TimestampDivider label={formattedTimestamp} />}
 
@@ -858,12 +729,15 @@ const MessageRow = React.memo(function MessageRow({ msg, index: i, showTimestamp
               away reserves no band for one it never shows. A turn still
               running has no answer yet, so none of its rows carries it. */}
           {textContent && isFinalAnswer && (
-            <MessageActions
+            <div>
+              <div className="mt-2 text-[length:var(--text-caption1)] text-[var(--text-secondary)]">{msg.meta?.turnOutcome === 'error' ? 'Turn failed' : 'Final answer'}</div>
+              <MessageActions
               id={msg.id || `idx-${i}`}
               text={textContent}
               onRetry={onRetry && prevUserText ? () => onRetry(prevUserText) : undefined}
               retryDisabled={loading}
-            />
+              />
+            </div>
           )}
         </AssistantRowShell>
       )}

--- a/packages/web/src/components/chat/final-answers.ts
+++ b/packages/web/src/components/chat/final-answers.ts
@@ -1,0 +1,149 @@
+import { parseMedia, type Message } from '@/lib/conversations'
+import { parseTeammateReply } from './teammate-reply'
+import { parseAgentRelay } from './agent-relay'
+import { validTimestamp } from './message-timestamps'
+
+/** The turn's final answer: an assistant prose message. Tool calls are not
+ *  answers, and neither is any block-carrying message — blocks render as
+ *  cards/objects (handoffs, dispatches, task lists), not the turn's prose.
+ *  Conservative on purpose: when in doubt the evidence stays visible. */
+export function isAnswerMessage(msg: Message): boolean {
+  if (msg.role !== 'assistant' || msg.toolCall) return false
+  if (msg.blocks?.length) return false
+  if (msg.meta?.assistantPhase !== 'final' && messageMedia(msg).length) return false
+  return Boolean((msg.content || '').trim())
+}
+
+export function messageMedia(msg: Message) {
+  return msg.media?.length ? msg.media : parseMedia(msg.content)
+}
+
+/** A child callback ("dev replied") or an agent relay ("From dev [hop N]"): an
+ *  injected notification that RE-INVOKES the model, starting a fresh engine turn
+ *  inside the same logical (user) turn. It closes the previous segment so the
+ *  earlier reply stays visible, and folds into the engine turn it triggers. */
+export function isReinvocationBoundary(msg: Message): boolean {
+  return msg.role === 'notification' && Boolean(parseTeammateReply(msg) || parseAgentRelay(msg))
+}
+
+/**
+ * For each raw message index, the answer that closes its engine-turn segment.
+ * Canonical final metadata is authoritative even when callbacks arrived while
+ * that turn was still running. Legacy clients without metadata retain the
+ * last-prose/boundary fallback. -1 means no closing answer is available.
+ *
+ * One logical (user) turn can hold several engine turns: the model replies and
+ * stops, a child callback re-invokes it, it replies again. Each engine turn keeps
+ * its OWN closing answer, so the fold before it is scoped to just that segment's
+ * work — the earlier reply and its "Worked for" fold are preserved rather than
+ * swallowed by one region reaching the turn's very last block. Interim prose
+ * WITHIN one engine turn still folds; each canonical final is a boundary.
+ * Exported for tests.
+ */
+export function finalAnswerIndices(messages: Message[]): number[] {
+  const out = new Array<number>(messages.length).fill(-1)
+  let nextReply = -1
+  // After a re-invocation boundary the NEXT prose above it closes a fresh
+  // segment — a preserved reply. But a segment that produced NO prose (pure tool
+  // work before a callback) must keep folding toward the downstream reply, so we
+  // only re-point `nextReply` when that armed prose actually appears; tools-only
+  // work therefore stays in one fold instead of orphaning as bare rows.
+  let armed = false
+  for (let j = messages.length - 1; j >= 0; j--) {
+    if (messages[j].role === 'user') {
+      nextReply = -1
+      armed = false
+      out[j] = -1
+      continue
+    }
+    if (isReinvocationBoundary(messages[j])) {
+      // The trigger folds into the engine turn it started (the segment below),
+      // and arms the next prose above it as that turn's preserved reply.
+      out[j] = nextReply
+      armed = true
+      continue
+    }
+    // A restored `partial` prose row is still middle evidence. The first
+    // non-partial prose after a boundary (or the turn's first) is a preserved
+    // reply; later prose in the same engine turn is interim and folds toward it.
+    if (isCompletedAnswer(messages[j])
+      && (messages[j].meta?.assistantPhase === 'final' || nextReply === -1 || armed)) {
+      nextReply = j
+      armed = false
+    }
+    out[j] = nextReply
+  }
+  return out
+}
+
+function isCompletedAnswer(message: Message): boolean {
+  return !message.partial && message.meta?.assistantPhase !== 'commentary' && isAnswerMessage(message)
+}
+
+/** Locate the durable start of the engine segment closed by `answerIndex`.
+ * The initiating user starts the first segment. After a completed reply, a
+ * callback/relay starts the next one; callbacks that arrive before any reply
+ * remain evidence inside the still-open initial segment. */
+function settledSegmentStartIndex(messages: Message[], answerIndex: number): number {
+  let userIndex = -1
+  for (let index = answerIndex - 1; index >= 0; index--) {
+    if (messages[index].role === 'user') {
+      userIndex = index
+      break
+    }
+  }
+
+  let startIndex = userIndex
+  let completedReply = false
+  for (let index = userIndex + 1; index < answerIndex; index++) {
+    const message = messages[index]
+    if (isReinvocationBoundary(message)) {
+      if (completedReply) {
+        startIndex = index
+        completedReply = false
+      }
+      continue
+    }
+    if (isCompletedAnswer(message)) completedReply = true
+  }
+  return startIndex
+}
+
+/** A settled fold measures one durable engine segment: initiating user or
+ * callback/relay boundary → canonical final assistant row. Legacy rows may lack
+ * one boundary; in that case, recover only from timestamped evidence inside
+ * the same segment. A single evidence row cannot establish an interval. */
+export function settledDurationMs(messages: Message[], answerIndex: number): number | null {
+  if (answerIndex < 0 || answerIndex >= messages.length) return null
+
+  const recorded = recordedDuration(messages, answerIndex)
+  if (recorded !== undefined) return recorded
+  const segmentStart = settledSegmentStartIndex(messages, answerIndex)
+  const start = firstTimestamp(messages, Math.max(0, segmentStart), answerIndex, 1)
+  const end = firstTimestamp(messages, answerIndex, segmentStart, -1)
+  if (!start || !end || start.index === end.index || end.time < start.time) return null
+  return end.time - start.time
+}
+
+function firstTimestamp(messages: Message[], from: number, until: number, step: 1 | -1) {
+  for (let index = from; index !== until; index += step) {
+    const time = validTimestamp(messages[index].timestamp)
+    if (time !== null) return { index, time }
+  }
+  return null
+}
+
+function recordedDuration(messages: Message[], answerIndex: number): number | null | undefined {
+  const answer = messages[answerIndex]
+  const meta = answer.meta ?? {}
+  const recordedStart = typeof meta.turnStartedAt === 'number' ? validTimestamp(meta.turnStartedAt) : null
+  if (recordedStart !== null) return Math.max(0, answer.timestamp - recordedStart)
+  // A queued callback's arrival is not its execution start. Legacy consecutive
+  // canonical answers have no exact start evidence for the later turn.
+  if (meta.assistantPhase !== 'final') return undefined
+  for (let index = answerIndex - 1; index >= 0; index--) {
+    if (messages[index].role === 'user' || isReinvocationBoundary(messages[index])) break
+    if (messages[index].meta?.assistantPhase === 'final') return null
+  }
+  return undefined
+}

--- a/packages/web/src/components/chat/fold-summary.tsx
+++ b/packages/web/src/components/chat/fold-summary.tsx
@@ -15,6 +15,7 @@ export interface FoldSummaryData {
   durationMs: number | null
   tools: number
   teammates: number
+  nativeAgents?: number
   /** Interim prose messages the model wrote on the way to the answer. */
   updates: number
 }
@@ -35,8 +36,13 @@ export function foldSummaryWords(summary: FoldSummaryData): string[] {
   const words = duration ? [`Worked for ${duration}`] : []
   if (summary.tools > 0) words.push(`${summary.tools} tool${summary.tools === 1 ? '' : 's'}`)
   if (summary.teammates > 0) words.push(`${summary.teammates} teammate${summary.teammates === 1 ? '' : 's'}`)
+  if (summary.nativeAgents) words.push(nativeAgentCount(summary.nativeAgents))
   if (summary.updates > 0) words.push(`${summary.updates} update${summary.updates === 1 ? '' : 's'}`)
   return words
+}
+
+function nativeAgentCount(count: number): string {
+  return `${count} native agent${count === 1 ? '' : 's'}`
 }
 
 interface FoldSummaryLineProps {
@@ -70,7 +76,7 @@ export function FoldSummaryLine({ summary, closed, arriving, onToggle }: FoldSum
           className="-ml-1.5 flex min-h-8 w-full cursor-pointer items-center gap-[var(--space-2)] rounded-[8px] border-none bg-transparent py-[3px] pl-1.5 pr-2 text-left font-[inherit] text-[length:var(--text-caption1)] font-[var(--weight-medium)] text-[var(--text-tertiary)] transition-colors duration-150 ease-[var(--ease-smooth)] hover:bg-[var(--fill-quaternary)] hover:text-[var(--text-secondary)]"
         >
           <Settings size={13} strokeWidth={2} aria-hidden="true" className="shrink-0 text-[var(--text-quaternary)]" />
-          <span className="flex min-w-0 items-center gap-[7px]">
+          <span className="flex min-w-0 flex-wrap items-center gap-[7px]">
             {words.map((word, index) => (
               <Fragment key={index}>
                 {index > 0 && (

--- a/packages/web/src/hooks/__tests__/completed-turn-messages.test.ts
+++ b/packages/web/src/hooks/__tests__/completed-turn-messages.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import type { Message } from '@/lib/conversations'
+import { reconcileCompletedTurnMessages } from '../completed-turn-messages'
+
+describe("reconcileCompletedTurnMessages", () => {
+  it("classifies success and error evidence identically except for canonical success dedup", () => {
+    const olderUser: Message = { id: "older-user", role: "user", content: "older request", timestamp: 1 }
+    const olderFinal: Message = { id: "older-final", role: "assistant", content: "older answer", timestamp: 2 }
+    const currentEvidence: Message[] = [
+      { id: "current-user", role: "user", content: "current request", timestamp: 3 },
+      { id: "interim", role: "assistant", content: "Interim prose", timestamp: 4 },
+      { id: "tool", role: "assistant", content: "Using Read", timestamp: 5, toolCall: "Read" },
+      { id: "notification", role: "notification", content: "Callback received", timestamp: 6 },
+      {
+        id: "media",
+        role: "assistant",
+        content: "Screenshot",
+        timestamp: 7,
+        media: [{ type: "image", url: "https://example.test/evidence.png" }],
+      },
+      {
+        id: "delegation",
+        role: "assistant",
+        content: "Delegated",
+        timestamp: 8,
+        blocks: [{ id: "delegation", type: "delegation", version: 1, payload: {} }],
+      },
+      {
+        id: "dispatch",
+        role: "assistant",
+        content: "Followed up",
+        timestamp: 9,
+        blocks: [{ id: "dispatch", type: "dispatch", version: 1, payload: {} }],
+      },
+      {
+        id: "task-list",
+        role: "assistant",
+        content: "Temporary plan",
+        timestamp: 10,
+        blocks: [{ id: "plan", type: "task-list", version: 1, payload: {} }],
+      },
+      {
+        id: "native-agents",
+        role: "assistant",
+        content: "Native Codex agents",
+        timestamp: 10,
+        blocks: [{ id: "native", type: "task-list", version: 2, status: 'completed', payload: { kind: 'native-agents', items: [] } }],
+      },
+      { id: "empty", role: "assistant", content: "  ", timestamp: 11 },
+      { id: "streamed-result", role: "assistant", content: "Canonical result", timestamp: 12 },
+    ]
+    const messages = [olderUser, olderFinal, ...currentEvidence]
+    const successFinal: Message = {
+      id: "success-final",
+      role: "assistant",
+      content: "Canonical result",
+      timestamp: 20,
+    }
+    const errorFinal: Message = {
+      id: "error-final",
+      role: "assistant",
+      content: "Error: engine failed",
+      timestamp: 21,
+    }
+
+    const success = reconcileCompletedTurnMessages({
+      messages,
+      turnStart: 2,
+      finalMessage: successFinal,
+      exactResult: successFinal.content,
+    })
+    const error = reconcileCompletedTurnMessages({
+      messages,
+      turnStart: 2,
+      finalMessage: errorFinal,
+    })
+
+    expect(success[0]).toBe(olderUser)
+    expect(success[1]).toBe(olderFinal)
+    expect(error[0]).toBe(olderUser)
+    expect(error[1]).toBe(olderFinal)
+    expect(success.slice(2, -1)).toEqual(error.slice(2, -1).filter((message) => message.id !== "streamed-result"))
+    expect(success.some((message) => message.id === "streamed-result")).toBe(false)
+    expect(error.some((message) => message.id === "streamed-result")).toBe(true)
+    expect(success.some((message) => message.id === "task-list" || message.id === "empty")).toBe(false)
+    expect(error.some((message) => message.id === "task-list" || message.id === "empty")).toBe(false)
+    expect(success.some((message) => message.id === 'native-agents')).toBe(true)
+    expect(error.some((message) => message.id === 'native-agents')).toBe(true)
+    expect(success.find((message) => message.id === "tool")?.content).toBe("Used Read")
+    expect(error.find((message) => message.id === "tool")?.content).toBe("Used Read")
+    expect(success.at(-1)).toEqual({ ...successFinal, meta: { assistantPhase: 'final' } })
+    expect(error.at(-1)).toEqual({ ...errorFinal, meta: { assistantPhase: 'final' } })
+    expect(success.find((message) => message.id === 'interim')?.meta?.assistantPhase).toBe('commentary')
+  })
+})

--- a/packages/web/src/hooks/__tests__/use-live-session.test.ts
+++ b/packages/web/src/hooks/__tests__/use-live-session.test.ts
@@ -25,7 +25,6 @@ import {
   isRestingSnapshot,
   prefetchLiveSessionSnapshot,
   readPrefetchedLiveSessionSnapshot,
-  reconcileCompletedTurnMessages,
   SESSION_SNAPSHOT_REVISIT_TTL_MS,
   useLiveSession,
 } from "../use-live-session"
@@ -88,87 +87,6 @@ describe("live session prefetch handoff", () => {
   })
 })
 
-describe("reconcileCompletedTurnMessages", () => {
-  it("classifies success and error evidence identically except for canonical success dedup", () => {
-    const olderUser: Message = { id: "older-user", role: "user", content: "older request", timestamp: 1 }
-    const olderFinal: Message = { id: "older-final", role: "assistant", content: "older answer", timestamp: 2 }
-    const currentEvidence: Message[] = [
-      { id: "current-user", role: "user", content: "current request", timestamp: 3 },
-      { id: "interim", role: "assistant", content: "Interim prose", timestamp: 4 },
-      { id: "tool", role: "assistant", content: "Using Read", timestamp: 5, toolCall: "Read" },
-      { id: "notification", role: "notification", content: "Callback received", timestamp: 6 },
-      {
-        id: "media",
-        role: "assistant",
-        content: "Screenshot",
-        timestamp: 7,
-        media: [{ type: "image", url: "https://example.test/evidence.png" }],
-      },
-      {
-        id: "delegation",
-        role: "assistant",
-        content: "Delegated",
-        timestamp: 8,
-        blocks: [{ id: "delegation", type: "delegation", version: 1, payload: {} }],
-      },
-      {
-        id: "dispatch",
-        role: "assistant",
-        content: "Followed up",
-        timestamp: 9,
-        blocks: [{ id: "dispatch", type: "dispatch", version: 1, payload: {} }],
-      },
-      {
-        id: "task-list",
-        role: "assistant",
-        content: "Temporary plan",
-        timestamp: 10,
-        blocks: [{ id: "plan", type: "task-list", version: 1, payload: {} }],
-      },
-      { id: "empty", role: "assistant", content: "  ", timestamp: 11 },
-      { id: "streamed-result", role: "assistant", content: "Canonical result", timestamp: 12 },
-    ]
-    const messages = [olderUser, olderFinal, ...currentEvidence]
-    const successFinal: Message = {
-      id: "success-final",
-      role: "assistant",
-      content: "Canonical result",
-      timestamp: 20,
-    }
-    const errorFinal: Message = {
-      id: "error-final",
-      role: "assistant",
-      content: "Error: engine failed",
-      timestamp: 21,
-    }
-
-    const success = reconcileCompletedTurnMessages({
-      messages,
-      turnStart: 2,
-      finalMessage: successFinal,
-      exactResult: successFinal.content,
-    })
-    const error = reconcileCompletedTurnMessages({
-      messages,
-      turnStart: 2,
-      finalMessage: errorFinal,
-    })
-
-    expect(success[0]).toBe(olderUser)
-    expect(success[1]).toBe(olderFinal)
-    expect(error[0]).toBe(olderUser)
-    expect(error[1]).toBe(olderFinal)
-    expect(success.slice(2, -1)).toEqual(error.slice(2, -1).filter((message) => message.id !== "streamed-result"))
-    expect(success.some((message) => message.id === "streamed-result")).toBe(false)
-    expect(error.some((message) => message.id === "streamed-result")).toBe(true)
-    expect(success.some((message) => message.id === "task-list" || message.id === "empty")).toBe(false)
-    expect(error.some((message) => message.id === "task-list" || message.id === "empty")).toBe(false)
-    expect(success.find((message) => message.id === "tool")?.content).toBe("Used Read")
-    expect(error.find((message) => message.id === "tool")?.content).toBe("Used Read")
-    expect(success.at(-1)).toBe(successFinal)
-    expect(error.at(-1)).toBe(errorFinal)
-  })
-})
 
 describe("useLiveSession (read-only)", () => {
   it("loads only the session tail on initial hydration and tracks older availability", async () => {

--- a/packages/web/src/hooks/completed-turn-messages.ts
+++ b/packages/web/src/hooks/completed-turn-messages.ts
@@ -1,0 +1,43 @@
+import type { Message } from '@/lib/conversations'
+
+export function reconcileCompletedTurnMessages(args: {
+  messages: Message[]
+  turnStart: number
+  finalMessage: Message
+  exactResult?: string
+}): Message[] {
+  const turnStart = args.turnStart >= 0
+    ? Math.min(args.turnStart, args.messages.length)
+    : args.messages.length
+  const exactResult = args.exactResult?.trim() ?? ''
+  const preserved = args.messages.slice(turnStart)
+    .filter((message) =>
+      message.role === 'user'
+      || Boolean(message.media?.length)
+      || Boolean(message.toolCall)
+      || message.role === 'notification'
+      || hasDurableBlocks(message)
+      || hasInterimProse(message, exactResult))
+    .map((message) => {
+      if (message.toolCall && !message.content.startsWith('Used ')) return { ...message, content: `Used ${message.toolCall}` }
+      if (message.role === 'assistant' && !message.toolCall && !message.blocks?.length && !message.media?.length) {
+        return { ...message, partial: undefined, meta: { assistantPhase: 'commentary', ...message.meta } }
+      }
+      return message
+    })
+
+  return [
+    ...args.messages.slice(0, turnStart),
+    ...preserved,
+    { ...args.finalMessage, meta: { ...args.finalMessage.meta, assistantPhase: 'final' } },
+  ]
+}
+
+function hasDurableBlocks(message: Message): boolean {
+  return Boolean(message.blocks?.some((block) => block.type === 'delegation' || block.type === 'dispatch' || block.payload.kind === 'native-agents'))
+}
+
+function hasInterimProse(message: Message, exactResult: string): boolean {
+  return message.role === 'assistant' && !message.blocks?.length
+    && Boolean(message.content.trim()) && (!exactResult || message.content.trim() !== exactResult)
+}

--- a/packages/web/src/hooks/use-live-session.ts
+++ b/packages/web/src/hooks/use-live-session.ts
@@ -1,3 +1,5 @@
+import { reconcileCompletedTurnMessages } from './completed-turn-messages'
+export { reconcileCompletedTurnMessages } from './completed-turn-messages'
 /**
  * useLiveSession — the live read pipeline for one gateway session.
  *
@@ -329,6 +331,7 @@ function hasFinalAssistantAfterLastUser(messages: Message[]): boolean {
   return messages.slice(userIndex + 1).some((message) =>
     message.role === 'assistant'
     && !message.partial
+    && message.meta?.assistantPhase !== 'commentary'
     && !message.toolCall
     && !message.blocks?.length
     && Boolean(message.content.trim()),
@@ -337,37 +340,6 @@ function hasFinalAssistantAfterLastUser(messages: Message[]): boolean {
 
 function formatTerminalAssistantError(error: unknown): string {
   return `Error: ${String(error)}`
-}
-
-export function reconcileCompletedTurnMessages(args: {
-  messages: Message[]
-  turnStart: number
-  finalMessage: Message
-  exactResult?: string
-}): Message[] {
-  const turnStart = args.turnStart >= 0
-    ? Math.min(args.turnStart, args.messages.length)
-    : args.messages.length
-  const exactResult = args.exactResult?.trim() ?? ''
-  const preserved = args.messages.slice(turnStart)
-    .filter((message) =>
-      message.role === 'user'
-      || Boolean(message.media?.length)
-      || Boolean(message.toolCall)
-      || message.role === 'notification'
-      || Boolean(message.blocks?.some((block) => block.type === 'delegation' || block.type === 'dispatch'))
-      || (message.role === 'assistant' && !message.blocks?.length
-        && Boolean(message.content.trim())
-        && (!exactResult || message.content.trim() !== exactResult)))
-    .map((message) => message.toolCall && !message.content.startsWith('Used ')
-      ? { ...message, content: `Used ${message.toolCall}` }
-      : message)
-
-  return [
-    ...args.messages.slice(0, turnStart),
-    ...preserved,
-    args.finalMessage,
-  ]
 }
 
 function isPersistedTerminalAssistantError(message: Message | undefined, error: unknown): boolean {
@@ -949,6 +921,7 @@ export function useLiveSession(
               role: 'assistant' as const,
               content: resultStr,
               timestamp: Date.now(),
+              meta: { turnOutcome: p.error ? 'error' : 'complete', ...(typeof p.durationMs === 'number' ? { turnStartedAt: Date.now() - p.durationMs } : {}) },
             },
           }))
         }
@@ -964,6 +937,7 @@ export function useLiveSession(
               role: 'assistant' as const,
               content: formatTerminalAssistantError(p.error),
               timestamp: Date.now(),
+              meta: { turnOutcome: 'error' },
             },
           }))
         }

--- a/packages/web/src/routes/settings/page.tsx
+++ b/packages/web/src/routes/settings/page.tsx
@@ -29,6 +29,7 @@ import { SttSettingsSection } from "./stt-section"
 import { VoiceSection } from "./voice-section"
 import { PairingSection } from "./pairing-section"
 import { ShortcutsSection } from "./shortcuts-section"
+import { ResetSection } from "./reset-section"
 import { useConfigCommit } from "./use-config-commit"
 import { useVoiceCapability } from "./use-voice-capability"
 import {
@@ -1386,41 +1387,7 @@ export default function SettingsPage() {
           )}
 
           <PluginsEntry />
-          {/* -- Section 7: Reset — quiet pills; destructive reads as a red wash,
-                not a solid alarm block. */}
-          <Section title="Reset">
-            <div
-              className="flex flex-wrap items-center gap-[var(--space-3)]"
-            >
-              <button
-                onClick={() => {
-                  localStorage.removeItem("jinn-onboarded")
-                  window.location.reload()
-                }}
-                className="inline-flex h-[38px] cursor-pointer items-center gap-1.5 rounded-full border-none bg-[var(--fill-tertiary)] px-4 text-[length:var(--text-subheadline)] font-[var(--weight-medium)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--fill-secondary)] hover:text-[var(--text-primary)]"
-              >
-                <RotateCcw size={15} />
-                Re-run Onboarding
-              </button>
-              <button
-                onClick={() => {
-                  if (
-                    window.confirm("Reset all settings to defaults?")
-                  ) {
-                    localStorage.removeItem("jinn-settings")
-                    localStorage.removeItem("jinn-theme")
-                    resetAll()
-                    window.location.reload()
-                  }
-                }}
-                className="inline-flex h-[38px] cursor-pointer items-center gap-1.5 rounded-full border-none px-4 text-[length:var(--text-subheadline)] font-semibold text-[var(--system-red)] transition-transform hover:scale-[0.98]"
-                style={{ background: "color-mix(in srgb, var(--system-red) 8%, transparent)" }}
-              >
-                <Trash2 size={15} />
-                Reset All Settings
-              </button>
-            </div>
-          </Section>
+          <ResetSection resetAll={resetAll} />
         </div>
       </PageScaffold>
     </PageLayout>

--- a/packages/web/src/routes/settings/reset-section.tsx
+++ b/packages/web/src/routes/settings/reset-section.tsx
@@ -1,0 +1,41 @@
+import { RotateCcw, Trash2 } from "lucide-react"
+import { Section } from "./shared"
+
+export function ResetSection({ resetAll }: { resetAll: () => void }) {
+  // Destructive actions use a quiet red wash rather than a solid alarm block.
+  return (
+    <Section title="Reset">
+      <div
+        className="flex flex-wrap items-center gap-[var(--space-3)]"
+      >
+        <button
+          onClick={() => {
+            localStorage.removeItem("jinn-onboarded")
+            window.location.reload()
+          }}
+          className="inline-flex h-[38px] cursor-pointer items-center gap-1.5 rounded-full border-none bg-[var(--fill-tertiary)] px-4 text-[length:var(--text-subheadline)] font-[var(--weight-medium)] text-[var(--text-secondary)] transition-colors hover:bg-[var(--fill-secondary)] hover:text-[var(--text-primary)]"
+        >
+          <RotateCcw size={15} />
+          Re-run Onboarding
+        </button>
+        <button
+          onClick={() => {
+            if (
+              window.confirm("Reset all settings to defaults?")
+            ) {
+              localStorage.removeItem("jinn-settings")
+              localStorage.removeItem("jinn-theme")
+              resetAll()
+              window.location.reload()
+            }
+          }}
+          className="inline-flex h-[38px] cursor-pointer items-center gap-1.5 rounded-full border-none px-4 text-[length:var(--text-subheadline)] font-semibold text-[var(--system-red)] transition-transform hover:scale-[0.98]"
+          style={{ background: "color-mix(in srgb, var(--system-red) 8%, transparent)" }}
+        >
+          <Trash2 size={15} />
+          Reset All Settings
+        </button>
+      </div>
+    </Section>
+  )
+}

--- a/scripts/__tests__/upgrade-verify-cleanup.test.mjs
+++ b/scripts/__tests__/upgrade-verify-cleanup.test.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import test from "node:test"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 import { createDisposableRoot, NONCE_FILE, removeDisposableRoot, stopGateway } from "../upgrade-verify-lib.mjs"
 
 const library = new URL("../upgrade-verify-lib.mjs", import.meta.url).href
@@ -178,7 +178,7 @@ function runCliWithLeak(t, assertionFailure) {
   `)
   const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("JINN_")))
   if (assertionFailure) env.UPGRADE_TEST_ASSERTION_FAILURE = String(assertionFailure)
-  const child = spawnSync(process.execPath, ["--import", preload, fileURLToPath(entrypoint), "--candidate-tarball", tarball], {
+  const child = spawnSync(process.execPath, ["--import", pathToFileURL(preload).href, fileURLToPath(entrypoint), "--candidate-tarball", tarball], {
     env, encoding: "utf8", timeout: 30_000,
   })
   const leaked = /disposable root ([^;\n]+)/.exec(child.stderr)?.[1] ?? /'(.*jinn-upgrade-verify-[^']*)'/.exec(child.stderr)?.[1]

--- a/size-baseline.json
+++ b/size-baseline.json
@@ -174,7 +174,7 @@
       ]
     },
     "packages/jinn/src/engines/codex.ts": {
-      "lines": 1065,
+      "lines": 1038,
       "exempt": [
         "complexity",
         "max-depth",
@@ -690,7 +690,7 @@
       ]
     },
     "packages/jinn/src/sessions/registry.ts": {
-      "lines": 2625,
+      "lines": 2520,
       "exempt": [
         "complexity",
         "max-depth",
@@ -1093,7 +1093,7 @@
       ]
     },
     "packages/web/src/components/chat/chat-messages.tsx": {
-      "lines": 1334,
+      "lines": 1208,
       "exempt": [
         "complexity",
         "max-depth",
@@ -1365,7 +1365,7 @@
       ]
     },
     "packages/web/src/hooks/__tests__/use-live-session.test.ts": {
-      "lines": 2103
+      "lines": 2021
     },
     "packages/web/src/hooks/use-chat-tabs.ts": {
       "lines": 337,
@@ -1385,7 +1385,7 @@
       ]
     },
     "packages/web/src/hooks/use-live-session.ts": {
-      "lines": 1428,
+      "lines": 1402,
       "exempt": [
         "@typescript-eslint/no-floating-promises",
         "complexity",

--- a/size-baseline.json
+++ b/size-baseline.json
@@ -1085,7 +1085,7 @@
       ]
     },
     "packages/web/src/components/chat/chat-input.tsx": {
-      "lines": 1046,
+      "lines": 1039,
       "exempt": [
         "@typescript-eslint/no-floating-promises",
         "complexity",
@@ -1568,7 +1568,7 @@
       ]
     },
     "packages/web/src/routes/settings/page.tsx": {
-      "lines": 1427,
+      "lines": 1395,
       "exempt": [
         "complexity",
         "max-lines-per-function"


### PR DESCRIPTION
A callback notification can arrive while a research turn is still running. Chat previously guessed turn endings from notification arrival and later prose, folding the original final answer under a later acknowledgement. This change preserves canonical final metadata during persistence and live reconciliation, recovers it for legacy history, and renders every final answer outside the work fold with an explicit label.

Native Codex agent lifecycle records omitted from exec JSON are read incrementally from the parent rollout. Native agents appear separately from employee teammates. A terminal parent stays pending while observed native work runs; process exit and interruption cannot leave running ghosts.

To clear existing CI failures, this also extracts the unchanged mic-gesture helper and Settings reset section so both oversized modules fit reduced size baselines, makes the privacy-guard test's expected path use native separators, and supplies a file URL to the upgrade test fixture's Node --import preload on Windows. No privacy rule or size limit is relaxed.

Validation: red regressions before the Chat fix; independent review accepted the implementation and component extractions; isolated desktop/mobile rendering in both themes checked final answers, callbacks, attachments, reload, older-history pagination, native waiting/completion, cancellation and resume. Local typecheck, lint, full tests, build and ratchet passed the integrated local-main version. All four required local gates pass on exact head 8a176304c9b6a6bdf8571655282128dc4a48219b. CI run https://github.com/hristo2612/jinn/actions/runs/34054266642 passed every job, including Linux and Windows tests, coverage, typecheck, lint, build, Docker, ratchet, footguns and all-checks-pass.
